### PR TITLE
Add audio configuration defaults and mappings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+<!-- version: 2025-08-25 -->
+
+2025-08-25
+- Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).
+- Introduced corresponding camera keys (audio_device, audio_codec, audio_bitrate) with default handling.
+- Added Motion option mappings for audio settings across versions.
+- Defined global audio defaults in settings.py.

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.43.1b4"
+VERSION = "0.43.1b5"  # version: 2025-08-25

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# version: 2025-08-25
+
 import collections
 import datetime
 import glob
@@ -109,6 +111,10 @@ _USED_MOTION_OPTIONS = {
     'smart_mask_speed',
     'snapshot_filename',
     'snapshot_interval',
+    'sound_device',
+    'sound_enabled',
+    'ffmpeg_audio_codec',
+    'ffmpeg_audio_bitrate',
     'stream_authentication',
     'stream_auth_method',
     'stream_localhost',
@@ -161,6 +167,10 @@ _MOTION_41_TO_43_OPTIONS_MAPPING = {
     'output_debug_pictures': 'picture_output_motion',
     'quality': 'picture_quality',
     'rtsp_uses_tcp': 'netcam_use_tcp',
+    'snd_device': 'sound_device',
+    'snd_enabled': 'sound_enabled',
+    'ffmpeg_audio_codec': 'ffmpeg_audio_codec',
+    'ffmpeg_audio_bitrate': 'ffmpeg_audio_bitrate',
     'text_double': text_double,
     'webcontrol_html_output': webcontrol_html_output,
 }
@@ -177,6 +187,10 @@ _MOTION_43_TO_41_OPTIONS_MAPPING = {
     'picture_output_motion': 'output_debug_pictures',
     'picture_quality': 'quality',
     'netcam_use_tcp': 'rtsp_uses_tcp',
+    'sound_device': 'snd_device',
+    'sound_enabled': 'snd_enabled',
+    'ffmpeg_audio_codec': 'ffmpeg_audio_codec',
+    'ffmpeg_audio_bitrate': 'ffmpeg_audio_bitrate',
     'text_scale': text_scale,
     'webcontrol_interface': webcontrol_interface,
     # motion pre-v4.1
@@ -851,6 +865,10 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         'framerate': int(ui['framerate']),
         'rotate': int(ui['rotation']),
         'mask_privacy': '',
+        'sound_device': ui['audio_device'],
+        'sound_enabled': ui['audio_enabled'],
+        'ffmpeg_audio_codec': ui['audio_codec'],
+        'ffmpeg_audio_bitrate': ui['audio_bitrate'],
         # file storage
         '@storage_device': ui['storage_device'],
         '@network_server': ui['network_server'],
@@ -1316,6 +1334,10 @@ def motion_camera_dict_to_ui(data):
         'rotation': int(data['rotate']),
         'privacy_mask': False,
         'privacy_mask_lines': [],
+        'audio_device': data.get('sound_device', ''),
+        'audio_enabled': data.get('sound_enabled', False),
+        'audio_codec': data.get('ffmpeg_audio_codec', settings.AUDIO_CODEC),
+        'audio_bitrate': data.get('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE),
         # file storage
         'smb_shares': settings.SMB_SHARES,
         'storage_device': data['@storage_device'],
@@ -2191,6 +2213,10 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('framerate', 2)
     data.setdefault('rotate', 0)
     data.setdefault('mask_privacy', '')
+    data.setdefault('sound_device', settings.AUDIO_DEVICE)
+    data.setdefault('sound_enabled', settings.AUDIO_ENABLED)
+    data.setdefault('ffmpeg_audio_codec', settings.AUDIO_CODEC)
+    data.setdefault('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE)
 
     data.setdefault('@storage_device', 'custom-path')
     data.setdefault('@network_server', '')

--- a/motioneye/settings.py
+++ b/motioneye/settings.py
@@ -3,6 +3,8 @@ import os.path
 import socket
 import sys
 
+# version: 2025-08-25
+
 import motioneye
 
 config_file = None
@@ -61,6 +63,12 @@ PORT = 8765
 
 # path to the motion binary to use (automatically detected by default)
 MOTION_BINARY = None
+
+# audio defaults
+AUDIO_DEVICE = None
+AUDIO_ENABLED = False
+AUDIO_CODEC = 'aac'
+AUDIO_BITRATE = 128
 
 # whether motion HTTP control interface listens on
 # localhost or on all interfaces

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,0 +1,12 @@
+<!-- version: 2025-08-25 -->
+
+# User Manual
+
+## Audio Configuration
+motionEye supports audio options per camera:
+- **Audio Device** – maps to Motion's `sound_device`.
+- **Audio Enabled** – maps to `sound_enabled`.
+- **Audio Codec** – maps to `ffmpeg_audio_codec`.
+- **Audio Bitrate** – maps to `ffmpeg_audio_bitrate`.
+
+Global defaults reside in `settings.py` (`AUDIO_DEVICE`, `AUDIO_ENABLED`, `AUDIO_CODEC`, `AUDIO_BITRATE`).


### PR DESCRIPTION
## Summary
- extend used motion options with sound and ffmpeg audio keys
- add audio fields to camera configuration and defaults
- provide global audio defaults in settings

## Testing
- `pytest` *(fails: fixture 'data' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf5ff4d28832c878136f3738e76c4