### PR TITLE
feat: expose audio device support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,3 +5,4 @@
 - Introduced corresponding camera keys (audio_device, audio_codec, audio_bitrate) with default handling.
 - Added Motion option mappings for audio settings across versions.
 - Defined global audio defaults in settings.py.
+- Added audio device enumeration and `has_audio_support` template helper.

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.43.1b5"  # version: 2025-08-25
+VERSION = "0.43.1b6"  # version: 2025-08-25

--- a/motioneye/handlers/main.py
+++ b/motioneye/handlers/main.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# version: 2025-08-25
+
 from motioneye import config, motionctl, settings, update, utils
 from motioneye.handlers.base import BaseHandler
 
@@ -55,6 +57,7 @@ class MainHandler(BaseHandler):
             has_hevc_nvmpi_support=motionctl.has_hevc_nvmpi_support(),
             has_h264_qsv_support=motionctl.has_h264_qsv_support(),
             has_hevc_qsv_support=motionctl.has_hevc_qsv_support(),
+            has_audio_support=motionctl.has_audio_support(),
             has_motion=bool(motionctl.find_motion()[0]),
             mask_width=utils.MASK_WIDTH,
         )

--- a/user_manual.md
+++ b/user_manual.md
@@ -10,3 +10,7 @@ motionEye supports audio options per camera:
 - **Audio Bitrate** – maps to `ffmpeg_audio_bitrate`.
 
 Global defaults reside in `settings.py` (`AUDIO_DEVICE`, `AUDIO_ENABLED`, `AUDIO_CODEC`, `AUDIO_BITRATE`).
+
+## Audio Detection
+Use `list_audio_devices()` to enumerate capture hardware. Templates can check
+`has_audio_support` to determine if audio devices are available.


### PR DESCRIPTION
## Summary
- enumerate audio capture devices and expose availability
- expose audio support info to templates
- document audio device detection and helper

## Testing
- `pytest` *(fails: fixture 'data' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf750935c832ca65a97f67cd7d232