### PR TITLE
Allow audio parameters in handlers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 2025-08-26
 - Added FFMPEG audio codec mapping and optional audio stream inclusion during conversions.
 - Ensured converted files use the proper extension matching video and audio content.
+- Enabled GET/POST handling for `audio_*` parameters in config and preference APIs.
+- Validated and persisted audio configuration values.
 
 2025-08-25
 - Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# version: 2025-08-25
+# version: 2025-08-26
 
 import collections
 import datetime
@@ -866,9 +866,9 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         'rotate': int(ui['rotation']),
         'mask_privacy': '',
         'sound_device': ui['audio_device'],
-        'sound_enabled': ui['audio_enabled'],
+        'sound_enabled': bool(ui['audio_enabled']),
         'ffmpeg_audio_codec': ui['audio_codec'],
-        'ffmpeg_audio_bitrate': ui['audio_bitrate'],
+        'ffmpeg_audio_bitrate': int(ui['audio_bitrate']),
         # file storage
         '@storage_device': ui['storage_device'],
         '@network_server': ui['network_server'],
@@ -1335,9 +1335,11 @@ def motion_camera_dict_to_ui(data):
         'privacy_mask': False,
         'privacy_mask_lines': [],
         'audio_device': data.get('sound_device', ''),
-        'audio_enabled': data.get('sound_enabled', False),
+        'audio_enabled': bool(data.get('sound_enabled', False)),
         'audio_codec': data.get('ffmpeg_audio_codec', settings.AUDIO_CODEC),
-        'audio_bitrate': data.get('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE),
+        'audio_bitrate': int(
+            data.get('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE)
+        ),
         # file storage
         'smb_shares': settings.SMB_SHARES,
         'storage_device': data['@storage_device'],
@@ -2214,9 +2216,9 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('rotate', 0)
     data.setdefault('mask_privacy', '')
     data.setdefault('sound_device', settings.AUDIO_DEVICE)
-    data.setdefault('sound_enabled', settings.AUDIO_ENABLED)
+    data.setdefault('sound_enabled', bool(settings.AUDIO_ENABLED))
     data.setdefault('ffmpeg_audio_codec', settings.AUDIO_CODEC)
-    data.setdefault('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE)
+    data.setdefault('ffmpeg_audio_bitrate', int(settings.AUDIO_BITRATE))
 
     data.setdefault('@storage_device', 'custom-path')
     data.setdefault('@network_server', '')

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# version: 2025-08-26
+
 import datetime
 import json
 import logging
@@ -137,13 +139,7 @@ class ConfigHandler(BaseHandler):
 
     @BaseHandler.auth(admin=True)
     async def set_config(self, camera_id):
-        try:
-            ui_config = json.loads(self.request.body)
-
-        except Exception as e:
-            logging.error(f'could not decode json: {str(e)}')
-
-            raise
+        ui_config = self.get_all_arguments()
 
         camera_ids = config.get_camera_ids()
 

--- a/motioneye/handlers/prefs.py
+++ b/motioneye/handlers/prefs.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
+# version: 2025-08-26
+
 import logging
 
 from motioneye.handlers.base import BaseHandler
@@ -25,15 +26,21 @@ __all__ = ('PrefsHandler',)
 
 class PrefsHandler(BaseHandler):
     def get(self, key=None):
-        self.finish_json(self.get_pref(key))
+        if key:
+            data = self.get_pref(key)
+        else:
+            args = self.get_all_arguments()
+            data = {k: self.get_pref(k) for k in args} if args else self.get_pref(None)
+
+        self.finish_json(data)
 
     def post(self, key=None):
-        try:
-            value = json.loads(self.request.body)
+        data = self.get_all_arguments()
 
-        except Exception as e:
-            logging.error('could not decode json: %s' % e)
+        if key:
+            self.set_pref(key, data.get(key))
+        else:
+            for pref_key, pref_value in data.items():
+                self.set_pref(pref_key, pref_value)
 
-            raise
-
-        self.set_pref(key, value)
+        self.finish_json()

--- a/user_manual.md
+++ b/user_manual.md
@@ -10,6 +10,7 @@ motionEye supports audio options per camera:
 - **Audio Bitrate** – maps to `ffmpeg_audio_bitrate`.
 
 Global defaults reside in `settings.py` (`AUDIO_DEVICE`, `AUDIO_ENABLED`, `AUDIO_CODEC`, `AUDIO_BITRATE`).
+Configuration and preference APIs accept these options via `audio_*` fields in GET or POST requests.
 
 ## Audio Detection
 Use `list_audio_devices()` to enumerate capture hardware. Templates can check


### PR DESCRIPTION
## Summary
- accept `audio_*` params in config and preference handlers
- validate and persist audio settings in config
- document audio parameter support

## Testing
- `pre-commit run --files changelog.md motioneye/config.py motioneye/handlers/config.py motioneye/handlers/prefs.py user_manual.md` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not connect to proxy)*
- `pytest` *(errors: missing fixture 'data')*

------
https://chatgpt.com/codex/tasks/task_e_68acfa3ca00c832ca0f04e17e45eb081