### PR TITLE
Ajout de la configuration audio des caméras

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Ensured converted files use the proper extension matching video and audio content.
 - Enabled GET/POST handling for `audio_*` parameters in config and preference APIs.
 - Validated and persisted audio configuration values.
+- Added camera UI fields for enabling audio, selecting devices, codec and bitrate.
 
 2025-08-25
 - Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1340,6 +1340,7 @@ def motion_camera_dict_to_ui(data):
         'audio_bitrate': int(
             data.get('ffmpeg_audio_bitrate', settings.AUDIO_BITRATE)
         ),
+        'audio_devices': motionctl.list_audio_devices(),
         # file storage
         'smb_shares': settings.SMB_SHARES,
         'storage_device': data['@storage_device'],

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1,3 +1,4 @@
+/* version: 2025-08-26 */
 
 var USERNAME_COOKIE = 'meye_username';
 var PASSWORD_COOKIE = 'meye_password_hash';
@@ -743,6 +744,7 @@ function initUI() {
     $('#preserveMoviesSelect').change(updateConfigUI);
     $('#moviePassthroughSwitch').change(updateConfigUI);
     $('#workingScheduleEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
+    $('#audioDeviceEnabledSwitch').change(updateConfigUI);
 
     $('#mondayEnabledSwitch').change(updateConfigUI);
     $('#tuesdayEnabledSwitch').change(updateConfigUI);
@@ -1956,6 +1958,12 @@ function cameraUi2Dict() {
             }
         }).filter(function (e) {return e;}),
 
+        /* audio */
+        'audio_device': $('#audioDeviceSelect').val(),
+        'audio_enabled': $('#audioDeviceEnabledSwitch').length ? $('#audioDeviceEnabledSwitch')[0].checked : false,
+        'audio_codec': $('#audioCodecSelect').val(),
+        'audio_bitrate': $('#audioBitrateEntry').val(),
+
         /* file storage */
         'storage_device': $('#storageDeviceSelect').val(),
         'network_server': $('#networkServerEntry').val(),
@@ -2228,6 +2236,17 @@ function dict2CameraUi(dict) {
     $('#deviceTypeEntry').val(prettyType); markHideIfNull(!prettyType, 'deviceTypeEntry');
     $('#deviceTypeEntry')[0].proto = dict['proto'];
     $('#autoBrightnessSwitch')[0].checked = dict['auto_brightness']; markHideIfNull('auto_brightness', 'autoBrightnessSwitch');
+
+    if ($('#audioDeviceEnabledSwitch').length) {
+        $('#audioDeviceEnabledSwitch')[0].checked = dict['audio_enabled']; markHideIfNull('audio_enabled', 'audioDeviceEnabledSwitch');
+        $('#audioDeviceSelect').html('');
+        (dict['audio_devices'] || []).forEach(function (dev) {
+            $('#audioDeviceSelect').append('<option value="' + dev + '">' + dev + '</option>');
+        });
+        $('#audioDeviceSelect').val(dict['audio_device']); markHideIfNull('audio_devices', 'audioDeviceSelect');
+        $('#audioCodecSelect').val(dict['audio_codec']); markHideIfNull('audio_codec', 'audioCodecSelect');
+        $('#audioBitrateEntry').val(dict['audio_bitrate']); markHideIfNull('audio_bitrate', 'audioBitrateEntry');
+    }
 
     $('#resolutionSelect').html('');
     if (dict['available_resolutions']) {

--- a/motioneye/static/js/motioneye.ar.json
+++ b/motioneye/static/js/motioneye.ar.json
@@ -1,164 +1,176 @@
-{"":{"language":"ar","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "الأحرف الخاصة غير مسموح بها في كلمة المرور"
-,"Ĉi tiu kampo estas deviga": "هذا الحقل مطلوب"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "الأحرف الخاصة غير مسموح بها في اسم الكاميرا"
-,"valoro devas esti multoblo de 8": "يجب أن تكون القيمة مضاعفًا لـ 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "الأحرف الخاصة غير مسموح بها في اسم مسار الجذر"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "لا يمكن إنشاء الملفات مباشرة في جذر النظام الخاص بك"
-,"enigu validan retpoŝtadreson": "أدخل عنوان بريد إلكتروني صالح"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "أدخل قائمة بعناوين بريد إلكتروني صالحة مفصولة بفواصل"
-,"specialaj signoj ne rajtas en dosiernomo": "الأحرف الخاصة غير مسموح بها في اسم الملف"
-,"enigu validan valoron": "أدخل قيمة صالحة"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "سيؤدي هذا بشكل متكرر إلى حذف جميع الملفات الموجودة في المجلد السحابي \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\"، وليس فقط تلك التي تم تحميلها بواسطة motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "سيؤدي هذا بشكل متكرر إلى حذف جميع ملفات الوسائط القديمة الموجودة في المجلد \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\"، وليس فقط تلك التي تم إنشاؤها بواسطة motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "لا يمكن تحرير القناع بدون صورة كاميرا صالحة!"
-,"Propra": "الخاصة"
-,"Propra dosierindiko": "اسم ملف مخصص"
-,"Retan kunlokon": "الاتصال عبر الإنترنت"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "متصفحك لا ينفذ هذه الميزة!"
-,"Apliki": "تطبيق"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "تأكد من أن جميع خيارات التكوين صالحة!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "سيؤدي ذلك إلى إعادة تشغيل النظام. تواصل؟"
-,"Vere fermiti sistemon?": "حقا اغلاق النظام؟"
-,"Malŝaltita": "متوقف"
-,"Ĉu vere restartigi ?": "هل تريد إعادة التشغيل حقًا؟"
-,"La sistemo rekomencis!": "تمت إعادة تشغيل النظام!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "يرجى تطبيق الإعدادات المعدلة أولاً!"
-,"Neniu fotilo por forigi!": "لا توجد كاميرا لإزالتها!"
-,"Ĉu forigi kameraon ": "يمكن إزالة الكاميرا"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "يتم تحديث motionEye (الإصدار الحالي:"
-,"Nova versio havebla: ": "يتوفر إصدار جديد:"
-,". Ĝisdatigi?": ". تحديث؟"
-,"motionEye estis sukcese ĝisdatigita!": "تم تحديث motionEye بنجاح!"
-,"Ĝisdatigo malsukcesis!": "فشل التحديث!"
-,"La ĝisdatiga procezo malsukcesis!": "فشلت عملية الترقية!"
-,"Rezerva dosiero": "ملف النسخ الاحتياطي"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "ملف النسخ الاحتياطي الذي قمت بتنزيله مسبقًا."
-,"Restaŭrigi Agordon": "استعادة التكوين"
-,"Restaŭriganta agordon ...": "جاري استعادة التكوين ..."
-,"La agordo restaŭrigis!": "تمت استعادة التكوين!"
-,"Malsukcesis restaŭri la agordon!": "فشل في استعادة التكوين!"
-,"Aliri la alŝutan servon malsukcesis: ": "فشل الوصول إلى خدمة التحميل:"
-,"Aliri la alŝutan servon sukcesis!": "كان الوصول إلى خدمة التحميل ناجحًا!"
-,"Sciiga retpoŝto fiaskis:": "فشل البريد الإلكتروني الأخبار:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "تأكد من أن جميع خيارات التكوين صالحة!"
-,"Sciiga Telegramo fiaskis:": "فشل برقية الإعلام:"
-,"Sciiga Telegramo sukcesis!": "كان برقية الإعلام ناجحا!"
-,"Aliro al retdividado fiaskis: ": "فشل الوصول إلى الشبكة"
-,"Aliro al retdividado sukcesis!": "كان الوصول إلى التخلف ناجحا!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "هل تريد حقًا حذف هذا الملف؟"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "هل تريد حقًا حذف جميع الصور من \"%(group)s\"؟"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "هل تريد حقًا حذف جميع الأفلام من \"%(group)s\"؟"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "هل تريد حقًا حذف جميع الصور غير المجمعة؟"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "هل تريد حقًا حذف جميع الأفلام غير المجمعة؟"
-,"aldonadi kameraon...": "إضافة كاميرا ..."
-,"Uzantnomo": "اسم المستخدم"
-,"Pasvorto": "كلمة المرور"
-,"Memoru min": "تذكرني"
-,"Ensaluti": "تسجيل الدخول"
-,"Nuligi": "الإلغاء"
-,"Vi abortis la filmeton.": "لقد أجهضت الفيديو."
-,"Reto eraro okazis.": "حدث خطأ في الشبكة."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "خطأ في فك التشفير أو وظيفة غير متوقعة."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "التنسيق غير مدعوم أو يتعذر الوصول إليه / غير مناسب للتشغيل."
-,"Nekonata eraro okazis.": "حدث خطأ غير معروف."
-,"Eraro : ": "خطأ:"
-,"antaŭa bildo": "الصورة السابقة"
-,"ludi": "للعب"
-,"ludi * 5 kaj enĉenigi": "اللعب * 5 وسلسلة"
-,"sekva bildo": "الصورة التالية"
-,"Fermi": "أغلق"
-,"Elŝuti": "تنزيل"
-,"Forigi": "إزالة"
-,"Kamerao tipo": "نوع الكاميرا"
-,"Loka V4L2-kamerao": "كاميرا V4L2 محلية"
-,"Loka MMAL-kamerao": "كاميرا MMAL محلية"
-,"Reta kamerao": "كاميرا ويب"
-,"Fora motionEye kamerao": "كاميرا خارجية"
-,"Simpla MJPEG-kamerao": "كاميرا MJPEG بسيطة"
-,"la speco de kamerao, kiun vi volas aldoni": "نوع الكاميرا التي تريد إضافتها"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / كاميرات / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "عنوان URL للكاميرا (مثل http://example.com:8080/cam/)"
-,"uzantnomo...": "اسم المستخدم ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "اسم المستخدم لعنوان URL ، إذا لزم الأمر (مثل المشرف)"
-,"pasvorto...": "كلمة المرور ..."
-,"la pasvorto por la URL, se bezonata": "كلمة المرور لعنوان URL ، إذا لزم الأمر"
-,"Kamerao": "الكاميرا"
-,"la kameraon, kiun vi volas aldoni": "الكاميرا التي تريد إضافتها"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "كاميرا MotionEye عن بعد هي كاميرا مثبتة خلف خادم MotionEye آخر. ستسمح لك إضافتها هنا بمشاهدتها وإدارتها من مسافة بعيدة."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "كاميرات الشبكة (أو كاميرات IP) هي الأجهزة التي تقوم بدفق مقاطع فيديو RTSP / RTMP أو MJPEG أو صور JPEG البسيطة. راجع دليل جهازك لمعرفة عنوان URL RTSP أو RTMP أو MJPEG أو JPEG الصحيح."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "كاميرات MMAL المحلية هي أجهزة متصلة مباشرة بنظام motionEye الخاص بك. عادة ما تكون هذه الكاميرات خاصة بالبطاقة."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ستؤدي إضافة جهازك ككاميرا MJPEG بسيطة بدلاً من ككاميرا ويب إلى تحسين التصوير الفوتوغرافي ، ولكن لن يتوفر أي كشف عن الحركة أو التقاط الصور أو تسجيل الأفلام. يجب أن تكون الكاميرا متاحة لخادمك ومتصفحك. لا يتطابق هذا النوع من الكاميرا مع Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "كاميرات V4L2 المحلية عبارة عن أجهزة كاميرا متصلة مباشرة بنظام motionEye الخاص بك ، عادةً عبر USB."
-,"Aldonadi kameraon...": "إضافة كاميرا ..."
-,"Grupo": "مجموعة"
-,"Inkluzivi foton prenitan ĉiun": "تضمين صورة تم التقاطها لكل منها"
-,"sekundo": "الثانية"
-,"5 sekundoj": "5 ثواني"
-,"10 sekundoj": "10 ثواني"
-,"30 sekundoj": "30 ثانية"
-,"minuto": "دقيقة"
-,"5 minutoj": "5 دقائق"
-,"10 minutoj": "10 دقائق"
-,"30 minutoj": "30 دقيقة"
-,"horo": "ساعة"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "حدد الفترة الزمنية بين صورتين محددتين."
-,"Filmo framfrekvenco": "معدل إطار الفيلم"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "اختر مدى السرعة التي تريدها لتسريع الفيديو."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "بالنظر إلى العدد الكبير من الصور ، قد يستغرق إنشاء الفيديو بعض الوقت!"
-,"Krei akselita video": "إنشاء فيديو مسرع"
-,"Filmo kreanta en progreso...": "فيلم قيد التقدم ..."
-,"Zipitaj": "انغلق"
-,"Akselita video": "فيديو معجل"
-,"Forigi ĉiujn": "قم بإزالتها جميعًا"
-,"Bildoj prenitaj de ": "الصور الملتقطة"
-,"Filmoj registritaj de ": "الأفلام المسجلة بواسطة"
-,"montru ĉi tiun fotilon plenekranan": "عرض هذه الكاميرا دوام كامل"
-,"montri ĉiujn fotilojn": "عرض كل الكاميرات"
-,"montru nur ĉi tiun fotilon": "عرض فقط هذه الكاميرا"
-,"malfermaj bildoj retumilo": "فتح متصفح الصور"
-,"malferma videoj retumilo": "فتح متصفح الفيديو"
-,"agordi ĉi tiun kameraon": "ضبط هذه الكاميرا"
-,"preni instantaron": "أخذ لقطة"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "لم تقم بعد بتكوين أي كاميرا. انقر هنا لاضافة واحدة ..."
-,"enigu pozitivan nombron": "أدخل رقمًا موجبًا"
-,"enigu pozitivan entjeran nombron": "أدخل عددًا صحيحًا موجبًا"
-,"enigu nombron": "أدخل رقمًا"
-,"enigu entjeran nombron": "أدخل عددًا صحيحًا"
-," inter ": "بينهما"
-," kaj ": "و"
-," pli ol ": "أكثر من"
-," malpli ol ": "أقل من"
-,"enigu validan tempon en la sekva formato: HH:MM": "أدخل وقتًا صالحًا بالتنسيق التالي: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "أدخل عنوان URL صالحًا (مثل http://example.com:8080/cams/)"
-,"fermi": "ليغلق"
-,"Ne": "لا"
-,"Jes": "نعم"
-,"Bone": "حسنًا"
-,"Auto Exposure": "التعرض التلقائي"
-,"Backlight Compensation": "وتعويض الإضاءة الخلفية"
-,"Brightness": "سطوع"
-,"Contrast": "التباين"
-,"Exposure Absolute": "التعرض بالتأكيد"
-,"Exposure Auto": "التعرض التلقائي"
-,"Exposure Auto Priority": "تعرض أولوية السيارات"
-,"Exposure Time Absolute": "وقت التعرض بالتأكيد"
-,"Focus Absolute": "ركز تماما"
-,"Focus Auto": "التركيز التلقائي"
-,"Gain": "ربح"
-,"Gamma": "جاما"
-,"Hue": "مسحة"
-,"Led1 Mode": "وضع LED1"
-,"Led1 Frequency": "تردد LED1"
-,"Pan Absolute": "عموم بالتأكيد"
-,"Power Line Frequency": "تردد خط الطاقة"
-,"Saturation": "التشبع"
-,"Sharpness": "حدة"
-,"Tilt Absolute": "إمالة تماما"
-,"White Balance Temperature": "درجة حرارة التوازن الأبيض"
-,"White Balance Temperature Auto": "وايت توازن درجة حرارة السيارات"
-,"Zoom Absolute": "تكبير بالتأكيد"
+{
+  "": {
+    "language": "ar",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "الأحرف الخاصة غير مسموح بها في كلمة المرور",
+  "Ĉi tiu kampo estas deviga": "هذا الحقل مطلوب",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "الأحرف الخاصة غير مسموح بها في اسم الكاميرا",
+  "valoro devas esti multoblo de 8": "يجب أن تكون القيمة مضاعفًا لـ 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "الأحرف الخاصة غير مسموح بها في اسم مسار الجذر",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "لا يمكن إنشاء الملفات مباشرة في جذر النظام الخاص بك",
+  "enigu validan retpoŝtadreson": "أدخل عنوان بريد إلكتروني صالح",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "أدخل قائمة بعناوين بريد إلكتروني صالحة مفصولة بفواصل",
+  "specialaj signoj ne rajtas en dosiernomo": "الأحرف الخاصة غير مسموح بها في اسم الملف",
+  "enigu validan valoron": "أدخل قيمة صالحة",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "سيؤدي هذا بشكل متكرر إلى حذف جميع الملفات الموجودة في المجلد السحابي \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\"، وليس فقط تلك التي تم تحميلها بواسطة motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "سيؤدي هذا بشكل متكرر إلى حذف جميع ملفات الوسائط القديمة الموجودة في المجلد \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\"، وليس فقط تلك التي تم إنشاؤها بواسطة motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "لا يمكن تحرير القناع بدون صورة كاميرا صالحة!",
+  "Propra": "الخاصة",
+  "Propra dosierindiko": "اسم ملف مخصص",
+  "Retan kunlokon": "الاتصال عبر الإنترنت",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "متصفحك لا ينفذ هذه الميزة!",
+  "Apliki": "تطبيق",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "تأكد من أن جميع خيارات التكوين صالحة!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "سيؤدي ذلك إلى إعادة تشغيل النظام. تواصل؟",
+  "Vere fermiti sistemon?": "حقا اغلاق النظام؟",
+  "Malŝaltita": "متوقف",
+  "Ĉu vere restartigi ?": "هل تريد إعادة التشغيل حقًا؟",
+  "La sistemo rekomencis!": "تمت إعادة تشغيل النظام!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "يرجى تطبيق الإعدادات المعدلة أولاً!",
+  "Neniu fotilo por forigi!": "لا توجد كاميرا لإزالتها!",
+  "Ĉu forigi kameraon ": "يمكن إزالة الكاميرا",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "يتم تحديث motionEye (الإصدار الحالي:",
+  "Nova versio havebla: ": "يتوفر إصدار جديد:",
+  ". Ĝisdatigi?": ". تحديث؟",
+  "motionEye estis sukcese ĝisdatigita!": "تم تحديث motionEye بنجاح!",
+  "Ĝisdatigo malsukcesis!": "فشل التحديث!",
+  "La ĝisdatiga procezo malsukcesis!": "فشلت عملية الترقية!",
+  "Rezerva dosiero": "ملف النسخ الاحتياطي",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "ملف النسخ الاحتياطي الذي قمت بتنزيله مسبقًا.",
+  "Restaŭrigi Agordon": "استعادة التكوين",
+  "Restaŭriganta agordon ...": "جاري استعادة التكوين ...",
+  "La agordo restaŭrigis!": "تمت استعادة التكوين!",
+  "Malsukcesis restaŭri la agordon!": "فشل في استعادة التكوين!",
+  "Aliri la alŝutan servon malsukcesis: ": "فشل الوصول إلى خدمة التحميل:",
+  "Aliri la alŝutan servon sukcesis!": "كان الوصول إلى خدمة التحميل ناجحًا!",
+  "Sciiga retpoŝto fiaskis:": "فشل البريد الإلكتروني الأخبار:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "تأكد من أن جميع خيارات التكوين صالحة!",
+  "Sciiga Telegramo fiaskis:": "فشل برقية الإعلام:",
+  "Sciiga Telegramo sukcesis!": "كان برقية الإعلام ناجحا!",
+  "Aliro al retdividado fiaskis: ": "فشل الوصول إلى الشبكة",
+  "Aliro al retdividado sukcesis!": "كان الوصول إلى التخلف ناجحا!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "هل تريد حقًا حذف هذا الملف؟",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "هل تريد حقًا حذف جميع الصور من \"%(group)s\"؟",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "هل تريد حقًا حذف جميع الأفلام من \"%(group)s\"؟",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "هل تريد حقًا حذف جميع الصور غير المجمعة؟",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "هل تريد حقًا حذف جميع الأفلام غير المجمعة؟",
+  "aldonadi kameraon...": "إضافة كاميرا ...",
+  "Uzantnomo": "اسم المستخدم",
+  "Pasvorto": "كلمة المرور",
+  "Memoru min": "تذكرني",
+  "Ensaluti": "تسجيل الدخول",
+  "Nuligi": "الإلغاء",
+  "Vi abortis la filmeton.": "لقد أجهضت الفيديو.",
+  "Reto eraro okazis.": "حدث خطأ في الشبكة.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "خطأ في فك التشفير أو وظيفة غير متوقعة.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "التنسيق غير مدعوم أو يتعذر الوصول إليه / غير مناسب للتشغيل.",
+  "Nekonata eraro okazis.": "حدث خطأ غير معروف.",
+  "Eraro : ": "خطأ:",
+  "antaŭa bildo": "الصورة السابقة",
+  "ludi": "للعب",
+  "ludi * 5 kaj enĉenigi": "اللعب * 5 وسلسلة",
+  "sekva bildo": "الصورة التالية",
+  "Fermi": "أغلق",
+  "Elŝuti": "تنزيل",
+  "Forigi": "إزالة",
+  "Kamerao tipo": "نوع الكاميرا",
+  "Loka V4L2-kamerao": "كاميرا V4L2 محلية",
+  "Loka MMAL-kamerao": "كاميرا MMAL محلية",
+  "Reta kamerao": "كاميرا ويب",
+  "Fora motionEye kamerao": "كاميرا خارجية",
+  "Simpla MJPEG-kamerao": "كاميرا MJPEG بسيطة",
+  "la speco de kamerao, kiun vi volas aldoni": "نوع الكاميرا التي تريد إضافتها",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / كاميرات / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "عنوان URL للكاميرا (مثل http://example.com:8080/cam/)",
+  "uzantnomo...": "اسم المستخدم ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "اسم المستخدم لعنوان URL ، إذا لزم الأمر (مثل المشرف)",
+  "pasvorto...": "كلمة المرور ...",
+  "la pasvorto por la URL, se bezonata": "كلمة المرور لعنوان URL ، إذا لزم الأمر",
+  "Kamerao": "الكاميرا",
+  "la kameraon, kiun vi volas aldoni": "الكاميرا التي تريد إضافتها",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "كاميرا MotionEye عن بعد هي كاميرا مثبتة خلف خادم MotionEye آخر. ستسمح لك إضافتها هنا بمشاهدتها وإدارتها من مسافة بعيدة.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "كاميرات الشبكة (أو كاميرات IP) هي الأجهزة التي تقوم بدفق مقاطع فيديو RTSP / RTMP أو MJPEG أو صور JPEG البسيطة. راجع دليل جهازك لمعرفة عنوان URL RTSP أو RTMP أو MJPEG أو JPEG الصحيح.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "كاميرات MMAL المحلية هي أجهزة متصلة مباشرة بنظام motionEye الخاص بك. عادة ما تكون هذه الكاميرات خاصة بالبطاقة.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ستؤدي إضافة جهازك ككاميرا MJPEG بسيطة بدلاً من ككاميرا ويب إلى تحسين التصوير الفوتوغرافي ، ولكن لن يتوفر أي كشف عن الحركة أو التقاط الصور أو تسجيل الأفلام. يجب أن تكون الكاميرا متاحة لخادمك ومتصفحك. لا يتطابق هذا النوع من الكاميرا مع Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "كاميرات V4L2 المحلية عبارة عن أجهزة كاميرا متصلة مباشرة بنظام motionEye الخاص بك ، عادةً عبر USB.",
+  "Aldonadi kameraon...": "إضافة كاميرا ...",
+  "Grupo": "مجموعة",
+  "Inkluzivi foton prenitan ĉiun": "تضمين صورة تم التقاطها لكل منها",
+  "sekundo": "الثانية",
+  "5 sekundoj": "5 ثواني",
+  "10 sekundoj": "10 ثواني",
+  "30 sekundoj": "30 ثانية",
+  "minuto": "دقيقة",
+  "5 minutoj": "5 دقائق",
+  "10 minutoj": "10 دقائق",
+  "30 minutoj": "30 دقيقة",
+  "horo": "ساعة",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "حدد الفترة الزمنية بين صورتين محددتين.",
+  "Filmo framfrekvenco": "معدل إطار الفيلم",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "اختر مدى السرعة التي تريدها لتسريع الفيديو.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "بالنظر إلى العدد الكبير من الصور ، قد يستغرق إنشاء الفيديو بعض الوقت!",
+  "Krei akselita video": "إنشاء فيديو مسرع",
+  "Filmo kreanta en progreso...": "فيلم قيد التقدم ...",
+  "Zipitaj": "انغلق",
+  "Akselita video": "فيديو معجل",
+  "Forigi ĉiujn": "قم بإزالتها جميعًا",
+  "Bildoj prenitaj de ": "الصور الملتقطة",
+  "Filmoj registritaj de ": "الأفلام المسجلة بواسطة",
+  "montru ĉi tiun fotilon plenekranan": "عرض هذه الكاميرا دوام كامل",
+  "montri ĉiujn fotilojn": "عرض كل الكاميرات",
+  "montru nur ĉi tiun fotilon": "عرض فقط هذه الكاميرا",
+  "malfermaj bildoj retumilo": "فتح متصفح الصور",
+  "malferma videoj retumilo": "فتح متصفح الفيديو",
+  "agordi ĉi tiun kameraon": "ضبط هذه الكاميرا",
+  "preni instantaron": "أخذ لقطة",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "لم تقم بعد بتكوين أي كاميرا. انقر هنا لاضافة واحدة ...",
+  "enigu pozitivan nombron": "أدخل رقمًا موجبًا",
+  "enigu pozitivan entjeran nombron": "أدخل عددًا صحيحًا موجبًا",
+  "enigu nombron": "أدخل رقمًا",
+  "enigu entjeran nombron": "أدخل عددًا صحيحًا",
+  " inter ": "بينهما",
+  " kaj ": "و",
+  " pli ol ": "أكثر من",
+  " malpli ol ": "أقل من",
+  "enigu validan tempon en la sekva formato: HH:MM": "أدخل وقتًا صالحًا بالتنسيق التالي: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "أدخل عنوان URL صالحًا (مثل http://example.com:8080/cams/)",
+  "fermi": "ليغلق",
+  "Ne": "لا",
+  "Jes": "نعم",
+  "Bone": "حسنًا",
+  "Auto Exposure": "التعرض التلقائي",
+  "Backlight Compensation": "وتعويض الإضاءة الخلفية",
+  "Brightness": "سطوع",
+  "Contrast": "التباين",
+  "Exposure Absolute": "التعرض بالتأكيد",
+  "Exposure Auto": "التعرض التلقائي",
+  "Exposure Auto Priority": "تعرض أولوية السيارات",
+  "Exposure Time Absolute": "وقت التعرض بالتأكيد",
+  "Focus Absolute": "ركز تماما",
+  "Focus Auto": "التركيز التلقائي",
+  "Gain": "ربح",
+  "Gamma": "جاما",
+  "Hue": "مسحة",
+  "Led1 Mode": "وضع LED1",
+  "Led1 Frequency": "تردد LED1",
+  "Pan Absolute": "عموم بالتأكيد",
+  "Power Line Frequency": "تردد خط الطاقة",
+  "Saturation": "التشبع",
+  "Sharpness": "حدة",
+  "Tilt Absolute": "إمالة تماما",
+  "White Balance Temperature": "درجة حرارة التوازن الأبيض",
+  "White Balance Temperature Auto": "وايت توازن درجة حرارة السيارات",
+  "Zoom Absolute": "تكبير بالتأكيد",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.bn.json
+++ b/motioneye/static/js/motioneye.bn.json
@@ -1,164 +1,176 @@
-{"":{"language":"bn","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "পাসওয়ার্ডে বিশেষ অক্ষর অনুমোদিত নয়"
-,"Ĉi tiu kampo estas deviga": "এই ক্ষেত্রটি প্রয়োজনীয়"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "বিশেষ অক্ষর ক্যামেরার নামে অনুমোদিত নয়"
-,"valoro devas esti multoblo de 8": "মানটি 8 এর একাধিক হতে হবে"
-,"specialaj signoj ne rajtas en radika voja nomo": "মূল পাথের নামে বিশেষ অক্ষর অনুমোদিত নয়"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "আপনার সিস্টেমে সরাসরি ফাইলগুলি তৈরি করা যায় না"
-,"enigu validan retpoŝtadreson": "একটি বৈধ ইমেল ঠিকানা লিখুন"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "কমা-বিচ্ছিন্ন বৈধ ইমেল ঠিকানাগুলির একটি তালিকা প্রবেশ করান"
-,"specialaj signoj ne rajtas en dosiernomo": "ফাইলের অক্ষরে বিশেষ অক্ষর অনুমোদিত নয়"
-,"enigu validan valoron": "একটি বৈধ মান লিখুন"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "এটি পুনরাবৃত্তভাবে মেঘ ফোল্ডারের সমস্ত ফাইল মুছে ফেলবে \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", মোশনই দ্বারা আপলোড করা কেবল এটিই নয়!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "এটি পুনরাবৃত্তভাবে ফোল্ডারে থাকা সমস্ত পুরানো মিডিয়া ফাইলগুলি মুছে ফেলবে \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", মোশনই দ্বারা নির্মিত কেবল এটিই নয়!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "কোনও বৈধ ক্যামেরা চিত্র ছাড়া মাস্কটি সম্পাদনা করতে পারবেন না!"
-,"Propra": "প্রথা"
-,"Propra dosierindiko": "কাস্টম ফাইলের নাম"
-,"Retan kunlokon": "অনলাইন যোগাযোগ"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "আপনার ব্রাউজার এই বৈশিষ্ট্য বহন করে না!"
-,"Apliki": "প্রয়োগ করা"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "সমস্ত কনফিগারেশন বিকল্প বৈধ কিনা তা নিশ্চিত করুন!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "এটি সিস্টেম পুনরায় আরম্ভ করবে। চালিয়ে যেতে চান?"
-,"Vere fermiti sistemon?": "সত্যিই কি সিস্টেম বন্ধ?"
-,"Malŝaltita": "অক্ষম"
-,"Ĉu vere restartigi ?": "সত্যিই আবার চালু হবে?"
-,"La sistemo rekomencis!": "সিস্টেমটি আবার চালু!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "প্রথমে পরিবর্তিত সেটিংস প্রয়োগ করুন!"
-,"Neniu fotilo por forigi!": "অপসারণের জন্য ক্যামেরা নেই!"
-,"Ĉu forigi kameraon ": "ক্যামেরা সরাতে পারে"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "মোশনই আপডেট হয়েছে (বর্তমান সংস্করণ:"
-,"Nova versio havebla: ": "নতুন সংস্করণ উপলব্ধ:"
-,". Ĝisdatigi?": "। আপডেট করবেন?"
-,"motionEye estis sukcese ĝisdatigita!": "মোশনই সফলভাবে আপডেট হয়েছে!"
-,"Ĝisdatigo malsukcesis!": "আপডেট ব্যর্থ!"
-,"La ĝisdatiga procezo malsukcesis!": "আপগ্রেড প্রক্রিয়া ব্যর্থ!"
-,"Rezerva dosiero": "ব্যাকআপ ফাইল"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "আপনি আগে ডাউনলোড করেছেন ব্যাকআপ ফাইল।"
-,"Restaŭrigi Agordon": "কনফিগারেশন পুনরুদ্ধার"
-,"Restaŭriganta agordon ...": "কনফিগারেশন পুনরুদ্ধার করা হচ্ছে ..."
-,"La agordo restaŭrigis!": "কনফিগারেশন পুনরুদ্ধার করা হয়েছে!"
-,"Malsukcesis restaŭri la agordon!": "কনফিগারেশন পুনরুদ্ধার করতে ব্যর্থ!"
-,"Aliri la alŝutan servon malsukcesis: ": "আপলোড পরিষেবা অ্যাক্সেস ব্যর্থ হয়েছে:"
-,"Aliri la alŝutan servon sukcesis!": "আপলোড পরিষেবাটি অ্যাক্সেস করা সফল হয়েছিল!"
-,"Sciiga retpoŝto fiaskis:": "সংবাদ ইমেইল ব্যর্থ হয়েছে:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "সমস্ত কনফিগারেশন বিকল্প বৈধ কিনা তা নিশ্চিত করুন!"
-,"Sciiga Telegramo fiaskis:": "বিজ্ঞপ্তি টেলিগ্রাম ব্যর্থ হয়েছে:"
-,"Sciiga Telegramo sukcesis!": "বিজ্ঞপ্তি টেলিগ্রাম সফল ছিল!"
-,"Aliro al retdividado fiaskis: ": "নেটওয়ার্ক ট্রান্সমিশন অ্যাক্সেস ব্যর্থ হয়েছে:"
-,"Aliro al retdividado sukcesis!": "Retardation অ্যাক্সেস সফল হয়েছে!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "সত্যিই এই ফাইলটি মুছবেন?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "সত্যিই \"%(group)s% (গ্রুপ) গুলি\" থেকে সমস্ত চিত্র মুছবেন?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "সত্যিই \"%(group)s% (গ্রুপ) গুলি\" থেকে সমস্ত চলচ্চিত্র মুছবেন?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "সত্যিই সমস্ত গ্রুপহীন ছবি মুছবেন?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "সত্যিই সমস্ত গ্রুপমুক্ত মুভি মুছবেন?"
-,"aldonadi kameraon...": "ক্যামেরা যুক্ত করুন ..."
-,"Uzantnomo": "ব্যবহারকারীর নাম"
-,"Pasvorto": "পাসওয়ার্ড"
-,"Memoru min": "আমাকে মনে আছে"
-,"Ensaluti": "লগ ইন"
-,"Nuligi": "বাতিল"
-,"Vi abortis la filmeton.": "আপনি ভিডিওটি বাতিল করে দিয়েছেন।"
-,"Reto eraro okazis.": "নেটওয়ার্ক ত্রুটি ঘটেছে।"
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "ডিকোডিং ত্রুটি বা ননপ্রজেক্টযুক্ত ফাংশন।"
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "ফর্ম্যাটটি সমর্থিত নয় বা অ্যাক্সেস অযোগ্য / প্লেব্যাকের জন্য অনুপযুক্ত।"
-,"Nekonata eraro okazis.": "একটি অজানা ত্রুটি ঘটেছে।"
-,"Eraro : ": "ত্রুটি:"
-,"antaŭa bildo": "পূর্ববর্তী চিত্র"
-,"ludi": "খেলতে"
-,"ludi * 5 kaj enĉenigi": "* 5 এবং চেইন খেলুন"
-,"sekva bildo": "পরবর্তী চিত্র"
-,"Fermi": "ঘনিষ্ঠ"
-,"Elŝuti": "ডাউনলোড"
-,"Forigi": "অপসারণ"
-,"Kamerao tipo": "ক্যামেরার ধরণ"
-,"Loka V4L2-kamerao": "স্থানীয় ভি 4 এল 2 ক্যামেরা"
-,"Loka MMAL-kamerao": "স্থানীয় এমএমএল ক্যামেরা"
-,"Reta kamerao": "নেটওয়ার্ক ক্যামেরা"
-,"Fora motionEye kamerao": "বাইরের মোশনই ক্যামেরা"
-,"Simpla MJPEG-kamerao": "সাধারণ এমজেপিইজি ক্যামেরা"
-,"la speco de kamerao, kiun vi volas aldoni": "আপনি যে ধরণের ক্যামেরা যুক্ত করতে চান"
-,"URL": "URL টি"
-,"http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / ক্যাম / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "ক্যামেরা ইউআরএল (উদাঃ http://example.com:8080/cam/)"
-,"uzantnomo...": "ব্যবহারকারীর নাম ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "ইউআরএলটির জন্য ব্যবহারকারীর নাম, যদি প্রয়োজন হয় (যেমন অ্যাডমিন)"
-,"pasvorto...": "পাসওয়ার্ড ..."
-,"la pasvorto por la URL, se bezonata": "ইউআরএল জন্য পাসওয়ার্ড, প্রয়োজন হলে"
-,"Kamerao": "ক্যামেরা"
-,"la kameraon, kiun vi volas aldoni": "আপনি যে ক্যামেরাটি যুক্ত করতে চান"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "একটি রিমোট মোশনই ক্যামেরা হল অন্য একটি মোশনই সার্ভারের পিছনে থাকা একটি ক্যামেরা। এগুলিকে এখানে যুক্ত করা আপনাকে এগুলি দূর থেকে দেখার এবং পরিচালনা করার অনুমতি দেবে।"
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "নেটওয়ার্ক ক্যামেরা (বা আইপি ক্যামেরা) এমন ডিভাইস যা স্থানীয়ভাবে আরটিএসপি / আরটিএমপি বা এমজেপিইজি ভিডিও বা সাধারণ জেপিইজি চিত্রগুলি স্ট্রিম করে। সঠিক আরটিএসপি, আরটিএমপি, এমজেপিইগ বা জেপিজি ইউআরএল খুঁজে পেতে আপনার ডিভাইসের ম্যানুয়ালটির পরামর্শ নিন।"
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "স্থানীয় এমএমএএল ক্যামেরা হ'ল এমন ডিভাইস যা আপনার মোশনই সিস্টেমের সাথে সরাসরি সংযুক্ত থাকে। এগুলি সাধারণত কার্ড-নির্দিষ্ট ক্যামেরা।"
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ওয়েব ক্যামেরার পরিবর্তে আপনার ডিভাইসটিকে একটি সাধারণ এমজেপিইজি ক্যামেরা হিসাবে যুক্ত করা ফটোগ্রাফির উন্নতি করবে, তবে কোনও গতি সনাক্তকরণ, চিত্র ক্যাপচার বা সিনেমা রেকর্ডিং উপলভ্য হবে না। ক্যামেরাটি অবশ্যই আপনার সার্ভার এবং আপনার ব্রাউজারে অ্যাক্সেসযোগ্য। এই ধরণের ক্যামেরাটি ইন্টারনেট এক্সপ্লোরারের সাথে মেলে না।"
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "স্থানীয় ভি 4 এল 2 ক্যামেরা হ'ল সাধারণত ইউএসবির মাধ্যমে আপনার মোশনই সিস্টেমের সাথে সংযুক্ত ক্যামেরা ডিভাইস।"
-,"Aldonadi kameraon...": "ক্যামেরা যুক্ত করুন ..."
-,"Grupo": "গ্রুপ"
-,"Inkluzivi foton prenitan ĉiun": "প্রতিটি তোলা একটি ছবি অন্তর্ভুক্ত করুন"
-,"sekundo": "দ্বিতীয়"
-,"5 sekundoj": "5 সেকেন্ড"
-,"10 sekundoj": "10 সেকেন্ড"
-,"30 sekundoj": "30 সেকেন্ড"
-,"minuto": "মিনিট"
-,"5 minutoj": "5 মিনিট"
-,"10 minutoj": "10 মিনিট"
-,"30 minutoj": "30 মিনিট"
-,"horo": "এক ঘন্টা"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "দুটি নির্বাচিত চিত্রের মধ্যে সময়ের ব্যবধানটি নির্বাচন করুন।"
-,"Filmo framfrekvenco": "চলচ্চিত্রের ফ্রেম রেট"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "আপনি গতিযুক্ত ভিডিওটি কত দ্রুত হতে চান তা চয়ন করুন।"
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "প্রচুর সংখ্যক চিত্র বিবেচনা করে, আপনার নিজস্ব ভিডিও তৈরি করতে কিছুটা সময় লাগতে পারে!"
-,"Krei akselita video": "একটি ত্বকযুক্ত ভিডিও তৈরি করুন"
-,"Filmo kreanta en progreso...": "একটি চলচ্চিত্র চলছে ..."
-,"Zipitaj": "Zipitaj"
-,"Akselita video": "ত্বরণযুক্ত ভিডিও"
-,"Forigi ĉiujn": "তাদের সব সরান"
-,"Bildoj prenitaj de ": "ছবি তোলা"
-,"Filmoj registritaj de ": "দ্বারা রেকর্ড করা ফিল্ম"
-,"montru ĉi tiun fotilon plenekranan": "এই ক্যামেরা পূর্ণ সময় প্রদর্শন করুন"
-,"montri ĉiujn fotilojn": "সব ক্যামেরা দেখান"
-,"montru nur ĉi tiun fotilon": "শুধু এই ক্যামেরা দেখান"
-,"malfermaj bildoj retumilo": "চিত্র ব্রাউজার খুলুন"
-,"malferma videoj retumilo": "ভিডিও ব্রাউজার খুলুন"
-,"agordi ĉi tiun kameraon": "এই ক্যামেরা সেট করুন"
-,"preni instantaron": "একটি স্ন্যাপশট নিতে"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "আপনি এখনো কোন ক্যামেরা কনফিগার করেন নি। এক যোগ করার জন্য এখানে ক্লিক করুন ..."
-,"enigu pozitivan nombron": "একটি ধনাত্মক সংখ্যা লিখুন"
-,"enigu pozitivan entjeran nombron": "ধনাত্মক পূর্ণসংখ্যা প্রবেশ করান"
-,"enigu nombron": "একটি নম্বর লিখুন"
-,"enigu entjeran nombron": "একটি পূর্ণসংখ্যা প্রবেশ করান"
-," inter ": "এর মধ্যে"
-," kaj ": "এবং"
-," pli ol ": "এর চেয়েও বেশি"
-," malpli ol ": "এর চেয়ে কম"
-,"enigu validan tempon en la sekva formato: HH:MM": "নিম্নলিখিত বিন্যাসে বৈধ সময় প্রবেশ করুন: এইচএইচ: এমএম"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "একটি বৈধ URL লিখুন (উদাঃ http://example.com:8080/cams/)"
-,"fermi": "বন্ধ করা"
-,"Ne": "না"
-,"Jes": "হাঁ"
-,"Bone": "ভাল"
-,"Auto Exposure": "অটো এক্সপোজার"
-,"Backlight Compensation": "ব্যাকলাইট ক্ষতিপূরণ"
-,"Brightness": "উজ্জ্বলতা"
-,"Contrast": "বিপরীতে"
-,"Exposure Absolute": "একেবারে এক্সপোজার"
-,"Exposure Auto": "এক্সপোজার অটো"
-,"Exposure Auto Priority": "এক্সপোজার অটো অগ্রাধিকার"
-,"Exposure Time Absolute": "এক্সপোজার সময় একেবারে"
-,"Focus Absolute": "একেবারে ফোকাস"
-,"Focus Auto": "ফোকাস অটো"
-,"Gain": "লাভ করা"
-,"Gamma": "গামা"
-,"Hue": "হিউ"
-,"Led1 Mode": "LED1 মোড"
-,"Led1 Frequency": "এলইডি 1 ফ্রিকোয়েন্সি"
-,"Pan Absolute": "একেবারে প্যান"
-,"Power Line Frequency": "পাওয়ার লাইন ফ্রিকোয়েন্সি"
-,"Saturation": "স্যাচুরেশন"
-,"Sharpness": "তীক্ষ্ণতা"
-,"Tilt Absolute": "একেবারে কাত"
-,"White Balance Temperature": "সাদা ভারসাম্য তাপমাত্রা"
-,"White Balance Temperature Auto": "সাদা ভারসাম্য তাপমাত্রা অটো"
-,"Zoom Absolute": "একেবারে জুম"
+{
+  "": {
+    "language": "bn",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "পাসওয়ার্ডে বিশেষ অক্ষর অনুমোদিত নয়",
+  "Ĉi tiu kampo estas deviga": "এই ক্ষেত্রটি প্রয়োজনীয়",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "বিশেষ অক্ষর ক্যামেরার নামে অনুমোদিত নয়",
+  "valoro devas esti multoblo de 8": "মানটি 8 এর একাধিক হতে হবে",
+  "specialaj signoj ne rajtas en radika voja nomo": "মূল পাথের নামে বিশেষ অক্ষর অনুমোদিত নয়",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "আপনার সিস্টেমে সরাসরি ফাইলগুলি তৈরি করা যায় না",
+  "enigu validan retpoŝtadreson": "একটি বৈধ ইমেল ঠিকানা লিখুন",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "কমা-বিচ্ছিন্ন বৈধ ইমেল ঠিকানাগুলির একটি তালিকা প্রবেশ করান",
+  "specialaj signoj ne rajtas en dosiernomo": "ফাইলের অক্ষরে বিশেষ অক্ষর অনুমোদিত নয়",
+  "enigu validan valoron": "একটি বৈধ মান লিখুন",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "এটি পুনরাবৃত্তভাবে মেঘ ফোল্ডারের সমস্ত ফাইল মুছে ফেলবে \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", মোশনই দ্বারা আপলোড করা কেবল এটিই নয়!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "এটি পুনরাবৃত্তভাবে ফোল্ডারে থাকা সমস্ত পুরানো মিডিয়া ফাইলগুলি মুছে ফেলবে \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", মোশনই দ্বারা নির্মিত কেবল এটিই নয়!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "কোনও বৈধ ক্যামেরা চিত্র ছাড়া মাস্কটি সম্পাদনা করতে পারবেন না!",
+  "Propra": "প্রথা",
+  "Propra dosierindiko": "কাস্টম ফাইলের নাম",
+  "Retan kunlokon": "অনলাইন যোগাযোগ",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "আপনার ব্রাউজার এই বৈশিষ্ট্য বহন করে না!",
+  "Apliki": "প্রয়োগ করা",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "সমস্ত কনফিগারেশন বিকল্প বৈধ কিনা তা নিশ্চিত করুন!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "এটি সিস্টেম পুনরায় আরম্ভ করবে। চালিয়ে যেতে চান?",
+  "Vere fermiti sistemon?": "সত্যিই কি সিস্টেম বন্ধ?",
+  "Malŝaltita": "অক্ষম",
+  "Ĉu vere restartigi ?": "সত্যিই আবার চালু হবে?",
+  "La sistemo rekomencis!": "সিস্টেমটি আবার চালু!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "প্রথমে পরিবর্তিত সেটিংস প্রয়োগ করুন!",
+  "Neniu fotilo por forigi!": "অপসারণের জন্য ক্যামেরা নেই!",
+  "Ĉu forigi kameraon ": "ক্যামেরা সরাতে পারে",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "মোশনই আপডেট হয়েছে (বর্তমান সংস্করণ:",
+  "Nova versio havebla: ": "নতুন সংস্করণ উপলব্ধ:",
+  ". Ĝisdatigi?": "। আপডেট করবেন?",
+  "motionEye estis sukcese ĝisdatigita!": "মোশনই সফলভাবে আপডেট হয়েছে!",
+  "Ĝisdatigo malsukcesis!": "আপডেট ব্যর্থ!",
+  "La ĝisdatiga procezo malsukcesis!": "আপগ্রেড প্রক্রিয়া ব্যর্থ!",
+  "Rezerva dosiero": "ব্যাকআপ ফাইল",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "আপনি আগে ডাউনলোড করেছেন ব্যাকআপ ফাইল।",
+  "Restaŭrigi Agordon": "কনফিগারেশন পুনরুদ্ধার",
+  "Restaŭriganta agordon ...": "কনফিগারেশন পুনরুদ্ধার করা হচ্ছে ...",
+  "La agordo restaŭrigis!": "কনফিগারেশন পুনরুদ্ধার করা হয়েছে!",
+  "Malsukcesis restaŭri la agordon!": "কনফিগারেশন পুনরুদ্ধার করতে ব্যর্থ!",
+  "Aliri la alŝutan servon malsukcesis: ": "আপলোড পরিষেবা অ্যাক্সেস ব্যর্থ হয়েছে:",
+  "Aliri la alŝutan servon sukcesis!": "আপলোড পরিষেবাটি অ্যাক্সেস করা সফল হয়েছিল!",
+  "Sciiga retpoŝto fiaskis:": "সংবাদ ইমেইল ব্যর্থ হয়েছে:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "সমস্ত কনফিগারেশন বিকল্প বৈধ কিনা তা নিশ্চিত করুন!",
+  "Sciiga Telegramo fiaskis:": "বিজ্ঞপ্তি টেলিগ্রাম ব্যর্থ হয়েছে:",
+  "Sciiga Telegramo sukcesis!": "বিজ্ঞপ্তি টেলিগ্রাম সফল ছিল!",
+  "Aliro al retdividado fiaskis: ": "নেটওয়ার্ক ট্রান্সমিশন অ্যাক্সেস ব্যর্থ হয়েছে:",
+  "Aliro al retdividado sukcesis!": "Retardation অ্যাক্সেস সফল হয়েছে!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "সত্যিই এই ফাইলটি মুছবেন?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "সত্যিই \"%(group)s% (গ্রুপ) গুলি\" থেকে সমস্ত চিত্র মুছবেন?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "সত্যিই \"%(group)s% (গ্রুপ) গুলি\" থেকে সমস্ত চলচ্চিত্র মুছবেন?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "সত্যিই সমস্ত গ্রুপহীন ছবি মুছবেন?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "সত্যিই সমস্ত গ্রুপমুক্ত মুভি মুছবেন?",
+  "aldonadi kameraon...": "ক্যামেরা যুক্ত করুন ...",
+  "Uzantnomo": "ব্যবহারকারীর নাম",
+  "Pasvorto": "পাসওয়ার্ড",
+  "Memoru min": "আমাকে মনে আছে",
+  "Ensaluti": "লগ ইন",
+  "Nuligi": "বাতিল",
+  "Vi abortis la filmeton.": "আপনি ভিডিওটি বাতিল করে দিয়েছেন।",
+  "Reto eraro okazis.": "নেটওয়ার্ক ত্রুটি ঘটেছে।",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "ডিকোডিং ত্রুটি বা ননপ্রজেক্টযুক্ত ফাংশন।",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "ফর্ম্যাটটি সমর্থিত নয় বা অ্যাক্সেস অযোগ্য / প্লেব্যাকের জন্য অনুপযুক্ত।",
+  "Nekonata eraro okazis.": "একটি অজানা ত্রুটি ঘটেছে।",
+  "Eraro : ": "ত্রুটি:",
+  "antaŭa bildo": "পূর্ববর্তী চিত্র",
+  "ludi": "খেলতে",
+  "ludi * 5 kaj enĉenigi": "* 5 এবং চেইন খেলুন",
+  "sekva bildo": "পরবর্তী চিত্র",
+  "Fermi": "ঘনিষ্ঠ",
+  "Elŝuti": "ডাউনলোড",
+  "Forigi": "অপসারণ",
+  "Kamerao tipo": "ক্যামেরার ধরণ",
+  "Loka V4L2-kamerao": "স্থানীয় ভি 4 এল 2 ক্যামেরা",
+  "Loka MMAL-kamerao": "স্থানীয় এমএমএল ক্যামেরা",
+  "Reta kamerao": "নেটওয়ার্ক ক্যামেরা",
+  "Fora motionEye kamerao": "বাইরের মোশনই ক্যামেরা",
+  "Simpla MJPEG-kamerao": "সাধারণ এমজেপিইজি ক্যামেরা",
+  "la speco de kamerao, kiun vi volas aldoni": "আপনি যে ধরণের ক্যামেরা যুক্ত করতে চান",
+  "URL": "URL টি",
+  "http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / ক্যাম / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "ক্যামেরা ইউআরএল (উদাঃ http://example.com:8080/cam/)",
+  "uzantnomo...": "ব্যবহারকারীর নাম ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "ইউআরএলটির জন্য ব্যবহারকারীর নাম, যদি প্রয়োজন হয় (যেমন অ্যাডমিন)",
+  "pasvorto...": "পাসওয়ার্ড ...",
+  "la pasvorto por la URL, se bezonata": "ইউআরএল জন্য পাসওয়ার্ড, প্রয়োজন হলে",
+  "Kamerao": "ক্যামেরা",
+  "la kameraon, kiun vi volas aldoni": "আপনি যে ক্যামেরাটি যুক্ত করতে চান",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "একটি রিমোট মোশনই ক্যামেরা হল অন্য একটি মোশনই সার্ভারের পিছনে থাকা একটি ক্যামেরা। এগুলিকে এখানে যুক্ত করা আপনাকে এগুলি দূর থেকে দেখার এবং পরিচালনা করার অনুমতি দেবে।",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "নেটওয়ার্ক ক্যামেরা (বা আইপি ক্যামেরা) এমন ডিভাইস যা স্থানীয়ভাবে আরটিএসপি / আরটিএমপি বা এমজেপিইজি ভিডিও বা সাধারণ জেপিইজি চিত্রগুলি স্ট্রিম করে। সঠিক আরটিএসপি, আরটিএমপি, এমজেপিইগ বা জেপিজি ইউআরএল খুঁজে পেতে আপনার ডিভাইসের ম্যানুয়ালটির পরামর্শ নিন।",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "স্থানীয় এমএমএএল ক্যামেরা হ'ল এমন ডিভাইস যা আপনার মোশনই সিস্টেমের সাথে সরাসরি সংযুক্ত থাকে। এগুলি সাধারণত কার্ড-নির্দিষ্ট ক্যামেরা।",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ওয়েব ক্যামেরার পরিবর্তে আপনার ডিভাইসটিকে একটি সাধারণ এমজেপিইজি ক্যামেরা হিসাবে যুক্ত করা ফটোগ্রাফির উন্নতি করবে, তবে কোনও গতি সনাক্তকরণ, চিত্র ক্যাপচার বা সিনেমা রেকর্ডিং উপলভ্য হবে না। ক্যামেরাটি অবশ্যই আপনার সার্ভার এবং আপনার ব্রাউজারে অ্যাক্সেসযোগ্য। এই ধরণের ক্যামেরাটি ইন্টারনেট এক্সপ্লোরারের সাথে মেলে না।",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "স্থানীয় ভি 4 এল 2 ক্যামেরা হ'ল সাধারণত ইউএসবির মাধ্যমে আপনার মোশনই সিস্টেমের সাথে সংযুক্ত ক্যামেরা ডিভাইস।",
+  "Aldonadi kameraon...": "ক্যামেরা যুক্ত করুন ...",
+  "Grupo": "গ্রুপ",
+  "Inkluzivi foton prenitan ĉiun": "প্রতিটি তোলা একটি ছবি অন্তর্ভুক্ত করুন",
+  "sekundo": "দ্বিতীয়",
+  "5 sekundoj": "5 সেকেন্ড",
+  "10 sekundoj": "10 সেকেন্ড",
+  "30 sekundoj": "30 সেকেন্ড",
+  "minuto": "মিনিট",
+  "5 minutoj": "5 মিনিট",
+  "10 minutoj": "10 মিনিট",
+  "30 minutoj": "30 মিনিট",
+  "horo": "এক ঘন্টা",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "দুটি নির্বাচিত চিত্রের মধ্যে সময়ের ব্যবধানটি নির্বাচন করুন।",
+  "Filmo framfrekvenco": "চলচ্চিত্রের ফ্রেম রেট",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "আপনি গতিযুক্ত ভিডিওটি কত দ্রুত হতে চান তা চয়ন করুন।",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "প্রচুর সংখ্যক চিত্র বিবেচনা করে, আপনার নিজস্ব ভিডিও তৈরি করতে কিছুটা সময় লাগতে পারে!",
+  "Krei akselita video": "একটি ত্বকযুক্ত ভিডিও তৈরি করুন",
+  "Filmo kreanta en progreso...": "একটি চলচ্চিত্র চলছে ...",
+  "Zipitaj": "Zipitaj",
+  "Akselita video": "ত্বরণযুক্ত ভিডিও",
+  "Forigi ĉiujn": "তাদের সব সরান",
+  "Bildoj prenitaj de ": "ছবি তোলা",
+  "Filmoj registritaj de ": "দ্বারা রেকর্ড করা ফিল্ম",
+  "montru ĉi tiun fotilon plenekranan": "এই ক্যামেরা পূর্ণ সময় প্রদর্শন করুন",
+  "montri ĉiujn fotilojn": "সব ক্যামেরা দেখান",
+  "montru nur ĉi tiun fotilon": "শুধু এই ক্যামেরা দেখান",
+  "malfermaj bildoj retumilo": "চিত্র ব্রাউজার খুলুন",
+  "malferma videoj retumilo": "ভিডিও ব্রাউজার খুলুন",
+  "agordi ĉi tiun kameraon": "এই ক্যামেরা সেট করুন",
+  "preni instantaron": "একটি স্ন্যাপশট নিতে",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "আপনি এখনো কোন ক্যামেরা কনফিগার করেন নি। এক যোগ করার জন্য এখানে ক্লিক করুন ...",
+  "enigu pozitivan nombron": "একটি ধনাত্মক সংখ্যা লিখুন",
+  "enigu pozitivan entjeran nombron": "ধনাত্মক পূর্ণসংখ্যা প্রবেশ করান",
+  "enigu nombron": "একটি নম্বর লিখুন",
+  "enigu entjeran nombron": "একটি পূর্ণসংখ্যা প্রবেশ করান",
+  " inter ": "এর মধ্যে",
+  " kaj ": "এবং",
+  " pli ol ": "এর চেয়েও বেশি",
+  " malpli ol ": "এর চেয়ে কম",
+  "enigu validan tempon en la sekva formato: HH:MM": "নিম্নলিখিত বিন্যাসে বৈধ সময় প্রবেশ করুন: এইচএইচ: এমএম",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "একটি বৈধ URL লিখুন (উদাঃ http://example.com:8080/cams/)",
+  "fermi": "বন্ধ করা",
+  "Ne": "না",
+  "Jes": "হাঁ",
+  "Bone": "ভাল",
+  "Auto Exposure": "অটো এক্সপোজার",
+  "Backlight Compensation": "ব্যাকলাইট ক্ষতিপূরণ",
+  "Brightness": "উজ্জ্বলতা",
+  "Contrast": "বিপরীতে",
+  "Exposure Absolute": "একেবারে এক্সপোজার",
+  "Exposure Auto": "এক্সপোজার অটো",
+  "Exposure Auto Priority": "এক্সপোজার অটো অগ্রাধিকার",
+  "Exposure Time Absolute": "এক্সপোজার সময় একেবারে",
+  "Focus Absolute": "একেবারে ফোকাস",
+  "Focus Auto": "ফোকাস অটো",
+  "Gain": "লাভ করা",
+  "Gamma": "গামা",
+  "Hue": "হিউ",
+  "Led1 Mode": "LED1 মোড",
+  "Led1 Frequency": "এলইডি 1 ফ্রিকোয়েন্সি",
+  "Pan Absolute": "একেবারে প্যান",
+  "Power Line Frequency": "পাওয়ার লাইন ফ্রিকোয়েন্সি",
+  "Saturation": "স্যাচুরেশন",
+  "Sharpness": "তীক্ষ্ণতা",
+  "Tilt Absolute": "একেবারে কাত",
+  "White Balance Temperature": "সাদা ভারসাম্য তাপমাত্রা",
+  "White Balance Temperature Auto": "সাদা ভারসাম্য তাপমাত্রা অটো",
+  "Zoom Absolute": "একেবারে জুম",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ca.json
+++ b/motioneye/static/js/motioneye.ca.json
@@ -1,164 +1,176 @@
-{"":{"language":"ca","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "no es permeten caràcters especials a la contrasenya"
-,"Ĉi tiu kampo estas deviga": "Aquest camp és obligatori"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "els caràcters especials no estan permesos al nom de la càmera"
-,"valoro devas esti multoblo de 8": "el valor ha de ser múltiple de 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "els caràcters especials no estan permesos al nom del directori arrel"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "no es poden crear fitxers directament a l'arrel del vostre sistema"
-,"enigu validan retpoŝtadreson": "introduïu una adreça de correu electrònic vàlida"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "introduïu una llista d'adreces de correu electrònic vàlides separades per comes"
-,"specialaj signoj ne rajtas en dosiernomo": "els caràcters especials no estan permesos al nom del fitxer"
-,"enigu validan valoron": "introduïu un valor vàlid"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Això eliminarà recursivament tots els fitxers presents a la carpeta del núvol \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", no només els penjats per motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Això eliminarà recursivament tots els fitxers multimèdia antics presents al directori \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", no només els creats per motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "No es pot editar la màscara sense una imatge de la càmera vàlida!"
-,"Propra": "Personalitzat"
-,"Propra dosierindiko": "Ruta personalitzada"
-,"Retan kunlokon": "Compartició de xarxa"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "El vostre navegador no implementa aquesta funció!"
-,"Apliki": "Aplicar"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Assegureu-vos que totes les opcions de configuració siguin vàlides!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Això reiniciarà el sistema. Voleu continuar?"
-,"Vere fermiti sistemon?": "Realment desitja tancar el sistema?"
-,"Malŝaltita": "Apagat"
-,"Ĉu vere restartigi ?": "Realment desitja reiniciar?"
-,"La sistemo rekomencis!": "El sistema s'ha reiniciat!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Si us plau, apliqueu primer la configuració modificada!"
-,"Neniu fotilo por forigi!": "No hi ha cap càmera per eliminar!"
-,"Ĉu forigi kameraon ": "Elimina la càmera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye està actualitzat (versió actual: "
-,"Nova versio havebla: ": "Nova versió disponible: "
-,". Ĝisdatigi?": ". Actualitzar?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye s'ha actualitzat correctament!"
-,"Ĝisdatigo malsukcesis!": "L'actualització ha fallat!"
-,"La ĝisdatiga procezo malsukcesis!": "Ha fallat el procés d'actualització!"
-,"Rezerva dosiero": "Fitxer de còpia de seguretat"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "el fitxer de còpia de seguretat que heu descarregat prèviament."
-,"Restaŭrigi Agordon": "Restaura la configuració"
-,"Restaŭriganta agordon ...": "S'està restaurant la configuració ..."
-,"La agordo restaŭrigis!": "La configuració s'ha restaurat!"
-,"Malsukcesis restaŭri la agordon!": "No s'ha pogut restaurar la configuració!"
-,"Aliri la alŝutan servon malsukcesis: ": "No s'ha pogut accedir al servei de càrrega: "
-,"Aliri la alŝutan servon sukcesis!": "S'ha pogut accedir al servei de càrrega!"
-,"Sciiga retpoŝto fiaskis:": "La notificació per correu electrònic ha fallat:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assegureu-vos que totes les opcions de configuració siguin vàlides!"
-,"Sciiga Telegramo fiaskis:": "La notificació de Telegram ha fallat:"
-,"Sciiga Telegramo sukcesis!": "La notificació Telegram s'ha enviat correctament!"
-,"Aliro al retdividado fiaskis: ": "No s'ha pogut accedir a la compartició de xarxa: "
-,"Aliro al retdividado sukcesis!": "S'ha pogut accedir a la xarxa compartida!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Esteu segurs que voleu suprimir aquest fitxer?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Realment voleu eliminar totes les imatges de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Realment voleu eliminar totes les pel·lícules de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Realment voleu eliminar totes les imatges no agrupades?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Realment voleu eliminar totes les pel·lícules no agrupades?"
-,"aldonadi kameraon...": "afegir càmera ..."
-,"Uzantnomo": "Nom d'usuari"
-,"Pasvorto": "Contrasenya"
-,"Memoru min": "Recorda'm"
-,"Ensaluti": "Iniciar sessió"
-,"Nuligi": "Cancel·lar"
-,"Vi abortis la filmeton.": "Has avortat el vídeo."
-,"Reto eraro okazis.": "S'ha produït un error de xarxa."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Error de descodificació del suport o funcions multimèdia no compatibles."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format no compatible o inaccessible/no apte per a la reproducció."
-,"Nekonata eraro okazis.": "S'ha produït un error desconegut."
-,"Eraro : ": "Error: "
-,"antaŭa bildo": "imatge anterior"
-,"ludi": "reprodueix"
-,"ludi * 5 kaj enĉenigi": "reproduir * 5 i encadenar"
-,"sekva bildo": "següent imatge"
-,"Fermi": "Tancar"
-,"Elŝuti": "Descarregar"
-,"Forigi": "Eliminar"
-,"Kamerao tipo": "Tipus de càmera"
-,"Loka V4L2-kamerao": "Càmera local V4L2"
-,"Loka MMAL-kamerao": "Càmera local MMAL"
-,"Reta kamerao": "Càmera de xarxa"
-,"Fora motionEye kamerao": "Càmera remota motionEye"
-,"Simpla MJPEG-kamerao": "Càmera simple MJPEG"
-,"la speco de kamerao, kiun vi volas aldoni": "el tipus de càmera que voleu afegir"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://exemple.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL de la càmera (p. ex. http://exemple.com:8080/cam/)"
-,"uzantnomo...": "nom d'usuari ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "el nom d'usuari de l'URL, si cal (p. ex. admin)"
-,"pasvorto...": "contrasenya ..."
-,"la pasvorto por la URL, se bezonata": "la contrasenya de l'URL, si cal"
-,"Kamerao": "Càmera"
-,"la kameraon, kiun vi volas aldoni": "la càmera que voleu afegir"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Les càmeres remotes motionEye són càmeres instal·lades darrere d'un altre servidor motionEye. Afegir-los aquí us permetrà visualitzar-los i gestionar-los de forma remota."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Les càmeres de xarxa (o càmeres IP) són dispositius que transmeten de forma nativa vídeos RTSP/RTMP o MJPEG o imatges JPEG senzilles. Consulteu el manual del vostre dispositiu per esbrinar l'URL correcte de RTSP, RTMP, MJPEG o JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Les càmeres MMAL locals són dispositius connectats directament al vostre sistema motionEye. Normalment són càmeres integrades."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Si afegiu el vostre dispositiu com a càmera MJPEG senzilla en lloc de com a càmera de xarxa, millorarà la velocitat de fotogrames, però no hi haurà disponible cap detecció de moviment, captura d'imatges o gravació de pel·lícules. La càmera ha de ser accessible tant al vostre servidor com al vostre navegador. Aquest tipus de càmera no és compatible amb Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Les càmeres locals V4L2 són dispositius de càmera connectats directament al vostre sistema motionEye, normalment mitjançant USB."
-,"Aldonadi kameraon...": "Afegir càmera ..."
-,"Grupo": "Grup"
-,"Inkluzivi foton prenitan ĉiun": "Incloeu una foto feta cada"
-,"sekundo": "segon"
-,"5 sekundoj": "5 segons"
-,"10 sekundoj": "10 segons"
-,"30 sekundoj": "30 segons"
-,"minuto": "minut"
-,"5 minutoj": "5 minuts"
-,"10 minutoj": "10 minuts"
-,"30 minutoj": "30 minuts"
-,"horo": "hora"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Triar l'interval de temps entre dues imatges seleccionades."
-,"Filmo framfrekvenco": "Velocitat de fotogrames de la pel·lícula"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Tria la rapidesa amb la qual vols que sigui la reproducció en timelapse."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Donada la gran quantitat d'imatges, la creació del vostre timelapse pot trigar una estona!"
-,"Krei akselita video": "Crea una pel·lícula Timelapse"
-,"Filmo kreanta en progreso...": "S'està creant una pel·lícula de timelapse ..."
-,"Zipitaj": "Comprimit"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Eliminar tots"
-,"Bildoj prenitaj de ": "Fotografies fetes per "
-,"Filmoj registritaj de ": "Pel·lícules gravades per "
-,"montru ĉi tiun fotilon plenekranan": "Mostra aquesta càmera a pantalla completa"
-,"montri ĉiujn fotilojn": "Mostra totes les càmeres"
-,"montru nur ĉi tiun fotilon": "Mostra només aquesta càmera"
-,"malfermaj bildoj retumilo": "obre el navegador d'imatges"
-,"malferma videoj retumilo": "obre el navegador de pel·lícules"
-,"agordi ĉi tiun kameraon": "configurar aquesta càmera"
-,"preni instantaron": "prendre una instantània"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Encara no has configurat cap càmera. Feu clic aquí per afegir-ne una ..."
-,"enigu pozitivan nombron": "introduïu un nombre positiu"
-,"enigu pozitivan entjeran nombron": "introduïu un nombre enter positiu"
-,"enigu nombron": "introduïu un número"
-,"enigu entjeran nombron": "introduïu un nombre enter"
-," inter ": " entre "
-," kaj ": " i "
-," pli ol ": " més gran que "
-," malpli ol ": " més petit que "
-,"enigu validan tempon en la sekva formato: HH:MM": "introduïu una hora vàlida amb el format següent: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "introduïu un URL vàlid (p. ex., http://exemple.com:8080/cams/)"
-,"fermi": "tanca"
-,"Ne": "No"
-,"Jes": "Sí"
-,"Bone": "D'acord"
-,"Auto Exposure": "Exposició automàtica"
-,"Backlight Compensation": "Compensació de contrallum"
-,"Brightness": "Brillantor"
-,"Contrast": "Contrast"
-,"Exposure Absolute": "Exposició absoluta"
-,"Exposure Auto": "Exposició automàtica"
-,"Exposure Auto Priority": "Prioritat automàtica de l'exposició"
-,"Exposure Time Absolute": "Temps d'exposició absolut"
-,"Focus Absolute": "Enfocament Absolut"
-,"Focus Auto": "Enfocament automàtic"
-,"Gain": "Guany"
-,"Gamma": "Gamma"
-,"Hue": "Hue"
-,"Led1 Mode": "Mode Led1"
-,"Led1 Frequency": "Freqüència Led1"
-,"Pan Absolute": "Escombratge absolut"
-,"Power Line Frequency": "Freqüència de la línia elèctrica"
-,"Saturation": "Saturació"
-,"Sharpness": "Nitidesa"
-,"Tilt Absolute": "Inclinació absoluta"
-,"White Balance Temperature": "Temperatura del balanç de blancs"
-,"White Balance Temperature Auto": "Temperatura de balanç de blancs automàtica"
-,"Zoom Absolute": "Zoom absolut"
+{
+  "": {
+    "language": "ca",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "no es permeten caràcters especials a la contrasenya",
+  "Ĉi tiu kampo estas deviga": "Aquest camp és obligatori",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "els caràcters especials no estan permesos al nom de la càmera",
+  "valoro devas esti multoblo de 8": "el valor ha de ser múltiple de 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "els caràcters especials no estan permesos al nom del directori arrel",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "no es poden crear fitxers directament a l'arrel del vostre sistema",
+  "enigu validan retpoŝtadreson": "introduïu una adreça de correu electrònic vàlida",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "introduïu una llista d'adreces de correu electrònic vàlides separades per comes",
+  "specialaj signoj ne rajtas en dosiernomo": "els caràcters especials no estan permesos al nom del fitxer",
+  "enigu validan valoron": "introduïu un valor vàlid",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Això eliminarà recursivament tots els fitxers presents a la carpeta del núvol \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", no només els penjats per motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Això eliminarà recursivament tots els fitxers multimèdia antics presents al directori \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", no només els creats per motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "No es pot editar la màscara sense una imatge de la càmera vàlida!",
+  "Propra": "Personalitzat",
+  "Propra dosierindiko": "Ruta personalitzada",
+  "Retan kunlokon": "Compartició de xarxa",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "El vostre navegador no implementa aquesta funció!",
+  "Apliki": "Aplicar",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Assegureu-vos que totes les opcions de configuració siguin vàlides!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Això reiniciarà el sistema. Voleu continuar?",
+  "Vere fermiti sistemon?": "Realment desitja tancar el sistema?",
+  "Malŝaltita": "Apagat",
+  "Ĉu vere restartigi ?": "Realment desitja reiniciar?",
+  "La sistemo rekomencis!": "El sistema s'ha reiniciat!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Si us plau, apliqueu primer la configuració modificada!",
+  "Neniu fotilo por forigi!": "No hi ha cap càmera per eliminar!",
+  "Ĉu forigi kameraon ": "Elimina la càmera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye està actualitzat (versió actual: ",
+  "Nova versio havebla: ": "Nova versió disponible: ",
+  ". Ĝisdatigi?": ". Actualitzar?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye s'ha actualitzat correctament!",
+  "Ĝisdatigo malsukcesis!": "L'actualització ha fallat!",
+  "La ĝisdatiga procezo malsukcesis!": "Ha fallat el procés d'actualització!",
+  "Rezerva dosiero": "Fitxer de còpia de seguretat",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "el fitxer de còpia de seguretat que heu descarregat prèviament.",
+  "Restaŭrigi Agordon": "Restaura la configuració",
+  "Restaŭriganta agordon ...": "S'està restaurant la configuració ...",
+  "La agordo restaŭrigis!": "La configuració s'ha restaurat!",
+  "Malsukcesis restaŭri la agordon!": "No s'ha pogut restaurar la configuració!",
+  "Aliri la alŝutan servon malsukcesis: ": "No s'ha pogut accedir al servei de càrrega: ",
+  "Aliri la alŝutan servon sukcesis!": "S'ha pogut accedir al servei de càrrega!",
+  "Sciiga retpoŝto fiaskis:": "La notificació per correu electrònic ha fallat:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assegureu-vos que totes les opcions de configuració siguin vàlides!",
+  "Sciiga Telegramo fiaskis:": "La notificació de Telegram ha fallat:",
+  "Sciiga Telegramo sukcesis!": "La notificació Telegram s'ha enviat correctament!",
+  "Aliro al retdividado fiaskis: ": "No s'ha pogut accedir a la compartició de xarxa: ",
+  "Aliro al retdividado sukcesis!": "S'ha pogut accedir a la xarxa compartida!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Esteu segurs que voleu suprimir aquest fitxer?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Realment voleu eliminar totes les imatges de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Realment voleu eliminar totes les pel·lícules de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Realment voleu eliminar totes les imatges no agrupades?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Realment voleu eliminar totes les pel·lícules no agrupades?",
+  "aldonadi kameraon...": "afegir càmera ...",
+  "Uzantnomo": "Nom d'usuari",
+  "Pasvorto": "Contrasenya",
+  "Memoru min": "Recorda'm",
+  "Ensaluti": "Iniciar sessió",
+  "Nuligi": "Cancel·lar",
+  "Vi abortis la filmeton.": "Has avortat el vídeo.",
+  "Reto eraro okazis.": "S'ha produït un error de xarxa.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Error de descodificació del suport o funcions multimèdia no compatibles.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format no compatible o inaccessible/no apte per a la reproducció.",
+  "Nekonata eraro okazis.": "S'ha produït un error desconegut.",
+  "Eraro : ": "Error: ",
+  "antaŭa bildo": "imatge anterior",
+  "ludi": "reprodueix",
+  "ludi * 5 kaj enĉenigi": "reproduir * 5 i encadenar",
+  "sekva bildo": "següent imatge",
+  "Fermi": "Tancar",
+  "Elŝuti": "Descarregar",
+  "Forigi": "Eliminar",
+  "Kamerao tipo": "Tipus de càmera",
+  "Loka V4L2-kamerao": "Càmera local V4L2",
+  "Loka MMAL-kamerao": "Càmera local MMAL",
+  "Reta kamerao": "Càmera de xarxa",
+  "Fora motionEye kamerao": "Càmera remota motionEye",
+  "Simpla MJPEG-kamerao": "Càmera simple MJPEG",
+  "la speco de kamerao, kiun vi volas aldoni": "el tipus de càmera que voleu afegir",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://exemple.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL de la càmera (p. ex. http://exemple.com:8080/cam/)",
+  "uzantnomo...": "nom d'usuari ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "el nom d'usuari de l'URL, si cal (p. ex. admin)",
+  "pasvorto...": "contrasenya ...",
+  "la pasvorto por la URL, se bezonata": "la contrasenya de l'URL, si cal",
+  "Kamerao": "Càmera",
+  "la kameraon, kiun vi volas aldoni": "la càmera que voleu afegir",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Les càmeres remotes motionEye són càmeres instal·lades darrere d'un altre servidor motionEye. Afegir-los aquí us permetrà visualitzar-los i gestionar-los de forma remota.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Les càmeres de xarxa (o càmeres IP) són dispositius que transmeten de forma nativa vídeos RTSP/RTMP o MJPEG o imatges JPEG senzilles. Consulteu el manual del vostre dispositiu per esbrinar l'URL correcte de RTSP, RTMP, MJPEG o JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Les càmeres MMAL locals són dispositius connectats directament al vostre sistema motionEye. Normalment són càmeres integrades.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Si afegiu el vostre dispositiu com a càmera MJPEG senzilla en lloc de com a càmera de xarxa, millorarà la velocitat de fotogrames, però no hi haurà disponible cap detecció de moviment, captura d'imatges o gravació de pel·lícules. La càmera ha de ser accessible tant al vostre servidor com al vostre navegador. Aquest tipus de càmera no és compatible amb Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Les càmeres locals V4L2 són dispositius de càmera connectats directament al vostre sistema motionEye, normalment mitjançant USB.",
+  "Aldonadi kameraon...": "Afegir càmera ...",
+  "Grupo": "Grup",
+  "Inkluzivi foton prenitan ĉiun": "Incloeu una foto feta cada",
+  "sekundo": "segon",
+  "5 sekundoj": "5 segons",
+  "10 sekundoj": "10 segons",
+  "30 sekundoj": "30 segons",
+  "minuto": "minut",
+  "5 minutoj": "5 minuts",
+  "10 minutoj": "10 minuts",
+  "30 minutoj": "30 minuts",
+  "horo": "hora",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Triar l'interval de temps entre dues imatges seleccionades.",
+  "Filmo framfrekvenco": "Velocitat de fotogrames de la pel·lícula",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Tria la rapidesa amb la qual vols que sigui la reproducció en timelapse.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Donada la gran quantitat d'imatges, la creació del vostre timelapse pot trigar una estona!",
+  "Krei akselita video": "Crea una pel·lícula Timelapse",
+  "Filmo kreanta en progreso...": "S'està creant una pel·lícula de timelapse ...",
+  "Zipitaj": "Comprimit",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Eliminar tots",
+  "Bildoj prenitaj de ": "Fotografies fetes per ",
+  "Filmoj registritaj de ": "Pel·lícules gravades per ",
+  "montru ĉi tiun fotilon plenekranan": "Mostra aquesta càmera a pantalla completa",
+  "montri ĉiujn fotilojn": "Mostra totes les càmeres",
+  "montru nur ĉi tiun fotilon": "Mostra només aquesta càmera",
+  "malfermaj bildoj retumilo": "obre el navegador d'imatges",
+  "malferma videoj retumilo": "obre el navegador de pel·lícules",
+  "agordi ĉi tiun kameraon": "configurar aquesta càmera",
+  "preni instantaron": "prendre una instantània",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Encara no has configurat cap càmera. Feu clic aquí per afegir-ne una ...",
+  "enigu pozitivan nombron": "introduïu un nombre positiu",
+  "enigu pozitivan entjeran nombron": "introduïu un nombre enter positiu",
+  "enigu nombron": "introduïu un número",
+  "enigu entjeran nombron": "introduïu un nombre enter",
+  " inter ": " entre ",
+  " kaj ": " i ",
+  " pli ol ": " més gran que ",
+  " malpli ol ": " més petit que ",
+  "enigu validan tempon en la sekva formato: HH:MM": "introduïu una hora vàlida amb el format següent: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "introduïu un URL vàlid (p. ex., http://exemple.com:8080/cams/)",
+  "fermi": "tanca",
+  "Ne": "No",
+  "Jes": "Sí",
+  "Bone": "D'acord",
+  "Auto Exposure": "Exposició automàtica",
+  "Backlight Compensation": "Compensació de contrallum",
+  "Brightness": "Brillantor",
+  "Contrast": "Contrast",
+  "Exposure Absolute": "Exposició absoluta",
+  "Exposure Auto": "Exposició automàtica",
+  "Exposure Auto Priority": "Prioritat automàtica de l'exposició",
+  "Exposure Time Absolute": "Temps d'exposició absolut",
+  "Focus Absolute": "Enfocament Absolut",
+  "Focus Auto": "Enfocament automàtic",
+  "Gain": "Guany",
+  "Gamma": "Gamma",
+  "Hue": "Hue",
+  "Led1 Mode": "Mode Led1",
+  "Led1 Frequency": "Freqüència Led1",
+  "Pan Absolute": "Escombratge absolut",
+  "Power Line Frequency": "Freqüència de la línia elèctrica",
+  "Saturation": "Saturació",
+  "Sharpness": "Nitidesa",
+  "Tilt Absolute": "Inclinació absoluta",
+  "White Balance Temperature": "Temperatura del balanç de blancs",
+  "White Balance Temperature Auto": "Temperatura de balanç de blancs automàtica",
+  "Zoom Absolute": "Zoom absolut",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.cs.json
+++ b/motioneye/static/js/motioneye.cs.json
@@ -1,164 +1,176 @@
-{"":{"language":"cs","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "V heslech nejsou povoleny speciální znaky"
-,"Ĉi tiu kampo estas deviga": "Toto pole je povinné"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "Speciální znaky nejsou povoleny ve jménu kamery"
-,"valoro devas esti multoblo de 8": "Hodnota musí být násobek 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "Speciální znaky nejsou povoleny v názvu kořenové silnice"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Soubory nelze vytvořit přímo v kořeni vašeho systému"
-,"enigu validan retpoŝtadreson": "Zadejte platnou e-mailovou adresu"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "Zadejte seznam samostatných platných e -mailových adres Koma"
-,"specialaj signoj ne rajtas en dosiernomo": "V názvu souboru nejsou povoleny speciální znaky"
-,"enigu validan valoron": "Zadejte platnou hodnotu"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Tím se rekurzivně odstraní všechny soubory přítomné ve složce cloudu “"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "„, nejen ti, kteří nahráli MotionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Tato rekurze odstraní všechny staré mediální soubory v adresáři “"
-,"\", ne nur tiuj kreitaj de motionEye!": "„Nejen ti, kteří vytvořili Motionleye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Nelze upravit masku bez platného obrázku kamery!"
-,"Propra": "Vlastní"
-,"Propra dosierindiko": "Vlastní indikace souboru"
-,"Retan kunlokon": "Online co -location"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Váš prohlížeč tuto funkci neprovádí!"
-,"Apliki": "Použít"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Ujistěte se, že všechny možnosti konfigurace jsou platné!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Tím se obnoví systém. Pokračovat?"
-,"Vere fermiti sistemon?": "Opravdu uzavřený systém?"
-,"Malŝaltita": "Vypnutý"
-,"Ĉu vere restartigi ?": "Opravdu restartujte?"
-,"La sistemo rekomencis!": "Systém pokračoval!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Nejprve použijte upravená nastavení!"
-,"Neniu fotilo por forigi!": "Žádná kamera k odstranění!"
-,"Ĉu forigi kameraon ": "Zda odstranit kameru"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "Motionleye je aktualizován (aktuální verze:"
-,"Nova versio havebla: ": "Dostupná nová verze:"
-,". Ĝisdatigi?": ". Aktualizace?"
-,"motionEye estis sukcese ĝisdatigita!": "Motionleye byl úspěšně aktualizován!"
-,"Ĝisdatigo malsukcesis!": "Aktualizace selhala!"
-,"La ĝisdatiga procezo malsukcesis!": "Proces aktualizace selhal!"
-,"Rezerva dosiero": "Záložní soubor"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Záložní soubor, který jste dříve stahovali."
-,"Restaŭrigi Agordon": "Obnovení konfigurace"
-,"Restaŭriganta agordon ...": "Nastavení obnovy ..."
-,"La agordo restaŭrigis!": "Konfigurace byla obnovena!"
-,"Malsukcesis restaŭri la agordon!": "Nepodařilo se obnovit konfiguraci!"
-,"Aliri la alŝutan servon malsukcesis: ": "Pro přístup k nahrávání selhalo:"
-,"Aliri la alŝutan servon sukcesis!": "Přístup k upload služby byl úspěšný!"
-,"Sciiga retpoŝto fiaskis:": "E -mail s oznámením selhal:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Ujistěte se, že všechny možnosti konfigurace jsou platné!"
-,"Sciiga Telegramo fiaskis:": "Novinky Telegram selhaly:"
-,"Sciiga Telegramo sukcesis!": "Novinky Telegram byl úspěšný!"
-,"Aliro al retdividado fiaskis: ": "Přístup k webové divizi selhal:"
-,"Aliro al retdividado sukcesis!": "Přístup k webové divizi byl úspěšný!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Opravdu smažte tento soubor?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Opravdu odstraňte všechny obrázky z „%(skupiny) S“?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Opravdu odstraníte všechny filmy z „%(skupiny) s“?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Opravdu odstraňte všechny ne seskupené obrázky?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Opravdu odstraňte všechny nesklubované filmy?"
-,"aldonadi kameraon...": "Přidejte kameru ..."
-,"Uzantnomo": "Uživatelské jméno"
-,"Pasvorto": "Heslo"
-,"Memoru min": "Zapamatuj si mě"
-,"Ensaluti": "Přihlásit se"
-,"Nuligi": "zrušení"
-,"Vi abortis la filmeton.": "Video jste přerušili."
-,"Reto eraro okazis.": "Došlo k chybě sítě."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Chyba dekódování nebo neprogresivní funkce."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formát není podporován nebo nedostupný/nevhodný pro hru."
-,"Nekonata eraro okazis.": "Nastala neznámá chyba."
-,"Eraro : ": "Chyba:"
-,"antaŭa bildo": "předchozí obrázek"
-,"ludi": "hrát"
-,"ludi * 5 kaj enĉenigi": "hrát * 5 a dostat se dovnitř"
-,"sekva bildo": "Další obrázek"
-,"Fermi": "Zavřít"
-,"Elŝuti": "Stažení"
-,"Forigi": "Odebrat"
-,"Kamerao tipo": "Typ kamery"
-,"Loka V4L2-kamerao": "Lokální kamera V4L2"
-,"Loka MMAL-kamerao": "Lokální kamera MMAL"
-,"Reta kamerao": "Online fotoaparát"
-,"Fora motionEye kamerao": "Far Motionleye Camera"
-,"Simpla MJPEG-kamerao": "Jednoduchá kamera MJPEG"
-,"la speco de kamerao, kiun vi volas aldoni": "Typ fotoaparátu, který chcete přidat"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http: //ekzeMplo.com: 8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL kamery (např. http://ekzemplo.com:8080/cam/)"
-,"uzantnomo...": "Uživatelské jméno ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "Uživatelské jméno pro URL, je -li to požadováno (např. Správce)"
-,"pasvorto...": "Heslo ..."
-,"la pasvorto por la URL, se bezonata": "heslo pro URL, pokud je to požadováno"
-,"Kamerao": "Fotoaparát"
-,"la kameraon, kiun vi volas aldoni": "fotoaparát, který chcete přidat"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Fora MotionEye Camera jsou kamery nainstalované za jiným serverem Motionleye. Přidání zde vám umožní hledat a spravovat je z dálky."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Webové kamery (nebo IP kamery) jsou zařízení, která nativně proudí videa RTSP/RTMP nebo MJPEG nebo jednoduché obrázky JPEG. Poraďte se s příručkou vašeho zařízení a zjistěte správnou adresu URL RTSP, RTMP, MJPEG nebo JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Místní kamery MMAL jsou zařízení připojená přímo k vašemu systému MotionEye. Jedná se obvykle o kamery specifické pro karty."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Přidání zařízení jako jednoduché kamery MJPEG místo toho, jak online fotoaparát zlepší fotografii, ale pro ni nebude k dispozici žádná detekce pohybu, snímání obrázků nebo nahrávání filmů. Fotoaparát musí být přístupný vašemu serveru a prohlížeči. Tento typ fotoaparátu neodpovídá internetovým průzkumníka."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Místní kamery V4L2 jsou kamera, která jsou připojena přímo k vašemu systému Motionleye, obvykle prostřednictvím USB."
-,"Aldonadi kameraon...": "Přidejte kameru ..."
-,"Grupo": "Skupina"
-,"Inkluzivi foton prenitan ĉiun": "Zahrnout fotografii pořízenou každý"
-,"sekundo": "vteřina"
-,"5 sekundoj": "5 sekund"
-,"10 sekundoj": "10 sekund"
-,"30 sekundoj": "30 sekund"
-,"minuto": "minuta"
-,"5 minutoj": "5 minut"
-,"10 minutoj": "10 minut"
-,"30 minutoj": "30 minut"
-,"horo": "hodina"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Vyberte rozsah času mezi dvěma vybranými obrázky."
-,"Filmo framfrekvenco": "FILMOVÁ SRUMENÁ FAMENÁ"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Vyberte si, jak rychle chcete ozbrojené video."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Vzhledem k velkému počtu obrázků může vytvoření videa nějakou dobu trvat!"
-,"Krei akselita video": "Vytvořte ozbrojené video"
-,"Filmo kreanta en progreso...": "Probíhá vytváření filmu ..."
-,"Zipitaj": "Zip"
-,"Akselita video": "Obchodní video"
-,"Forigi ĉiujn": "Odebrat všechny"
-,"Bildoj prenitaj de ": "Obrázky pořízené"
-,"Filmoj registritaj de ": "Filmy zaznamenané"
-,"montru ĉi tiun fotilon plenekranan": "Zobrazit tento fotoaparát plnou obrazovku"
-,"montri ĉiujn fotilojn": "Ukažte všechny kamery"
-,"montru nur ĉi tiun fotilon": "Zobrazit pouze tento fotoaparát"
-,"malfermaj bildoj retumilo": "Otevřený prohlížeč obrázků"
-,"malferma videoj retumilo": "Otevřený prohlížeč videí"
-,"agordi ĉi tiun kameraon": "Nastavte tuto kameru"
-,"preni instantaron": "Udělejte si okamžik"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ještě jste nenastavili žádnou kameru. Kliknutím sem přidáte jednu ..."
-,"enigu pozitivan nombron": "Zadejte kladné číslo"
-,"enigu pozitivan entjeran nombron": "Zadejte pozitivní celé číslo"
-,"enigu nombron": "Zadejte číslo"
-,"enigu entjeran nombron": "Zadejte celé číslo"
-," inter ": "mezi"
-," kaj ": "a"
-," pli ol ": "více než"
-," malpli ol ": "méně než"
-,"enigu validan tempon en la sekva formato: HH:MM": "Zadejte platný čas v následujícím formátu: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Zadejte platnou adresu URL (např. Http://ekzemplo.com:8080/cams/)"
-,"fermi": "zavřít"
-,"Ne": "Ne"
-,"Jes": "Ano"
-,"Bone": "OK"
-,"Auto Exposure": "Automatická expozice"
-,"Backlight Compensation": "Kompenzace podsvícení"
-,"Brightness": "Jas"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Expozice absolutně"
-,"Exposure Auto": "Expozice auto"
-,"Exposure Auto Priority": "Automatická priorita expozice"
-,"Exposure Time Absolute": "Doba expozice absolutně"
-,"Focus Absolute": "Zaměřte se na absolutně"
-,"Focus Auto": "Zaostřit auto"
-,"Gain": "Získat"
-,"Gamma": "Gama"
-,"Hue": "Odstín"
-,"Led1 Mode": "Režim LED1"
-,"Led1 Frequency": "Frekvence LED1"
-,"Pan Absolute": "Pan absolutně"
-,"Power Line Frequency": "Frekvence elektrického vedení"
-,"Saturation": "Nasycení"
-,"Sharpness": "Ostrost"
-,"Tilt Absolute": "Naklonit absolutně"
-,"White Balance Temperature": "Teplota vyvážení bílé"
-,"White Balance Temperature Auto": "Teplota vyvážení bílé automatické automobily"
-,"Zoom Absolute": "Zoom absolutně"
+{
+  "": {
+    "language": "cs",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "V heslech nejsou povoleny speciální znaky",
+  "Ĉi tiu kampo estas deviga": "Toto pole je povinné",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "Speciální znaky nejsou povoleny ve jménu kamery",
+  "valoro devas esti multoblo de 8": "Hodnota musí být násobek 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "Speciální znaky nejsou povoleny v názvu kořenové silnice",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Soubory nelze vytvořit přímo v kořeni vašeho systému",
+  "enigu validan retpoŝtadreson": "Zadejte platnou e-mailovou adresu",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "Zadejte seznam samostatných platných e -mailových adres Koma",
+  "specialaj signoj ne rajtas en dosiernomo": "V názvu souboru nejsou povoleny speciální znaky",
+  "enigu validan valoron": "Zadejte platnou hodnotu",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Tím se rekurzivně odstraní všechny soubory přítomné ve složce cloudu “",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "„, nejen ti, kteří nahráli MotionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Tato rekurze odstraní všechny staré mediální soubory v adresáři “",
+  "\", ne nur tiuj kreitaj de motionEye!": "„Nejen ti, kteří vytvořili Motionleye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Nelze upravit masku bez platného obrázku kamery!",
+  "Propra": "Vlastní",
+  "Propra dosierindiko": "Vlastní indikace souboru",
+  "Retan kunlokon": "Online co -location",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Váš prohlížeč tuto funkci neprovádí!",
+  "Apliki": "Použít",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Ujistěte se, že všechny možnosti konfigurace jsou platné!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Tím se obnoví systém. Pokračovat?",
+  "Vere fermiti sistemon?": "Opravdu uzavřený systém?",
+  "Malŝaltita": "Vypnutý",
+  "Ĉu vere restartigi ?": "Opravdu restartujte?",
+  "La sistemo rekomencis!": "Systém pokračoval!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Nejprve použijte upravená nastavení!",
+  "Neniu fotilo por forigi!": "Žádná kamera k odstranění!",
+  "Ĉu forigi kameraon ": "Zda odstranit kameru",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "Motionleye je aktualizován (aktuální verze:",
+  "Nova versio havebla: ": "Dostupná nová verze:",
+  ". Ĝisdatigi?": ". Aktualizace?",
+  "motionEye estis sukcese ĝisdatigita!": "Motionleye byl úspěšně aktualizován!",
+  "Ĝisdatigo malsukcesis!": "Aktualizace selhala!",
+  "La ĝisdatiga procezo malsukcesis!": "Proces aktualizace selhal!",
+  "Rezerva dosiero": "Záložní soubor",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Záložní soubor, který jste dříve stahovali.",
+  "Restaŭrigi Agordon": "Obnovení konfigurace",
+  "Restaŭriganta agordon ...": "Nastavení obnovy ...",
+  "La agordo restaŭrigis!": "Konfigurace byla obnovena!",
+  "Malsukcesis restaŭri la agordon!": "Nepodařilo se obnovit konfiguraci!",
+  "Aliri la alŝutan servon malsukcesis: ": "Pro přístup k nahrávání selhalo:",
+  "Aliri la alŝutan servon sukcesis!": "Přístup k upload služby byl úspěšný!",
+  "Sciiga retpoŝto fiaskis:": "E -mail s oznámením selhal:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Ujistěte se, že všechny možnosti konfigurace jsou platné!",
+  "Sciiga Telegramo fiaskis:": "Novinky Telegram selhaly:",
+  "Sciiga Telegramo sukcesis!": "Novinky Telegram byl úspěšný!",
+  "Aliro al retdividado fiaskis: ": "Přístup k webové divizi selhal:",
+  "Aliro al retdividado sukcesis!": "Přístup k webové divizi byl úspěšný!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Opravdu smažte tento soubor?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Opravdu odstraňte všechny obrázky z „%(skupiny) S“?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Opravdu odstraníte všechny filmy z „%(skupiny) s“?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Opravdu odstraňte všechny ne seskupené obrázky?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Opravdu odstraňte všechny nesklubované filmy?",
+  "aldonadi kameraon...": "Přidejte kameru ...",
+  "Uzantnomo": "Uživatelské jméno",
+  "Pasvorto": "Heslo",
+  "Memoru min": "Zapamatuj si mě",
+  "Ensaluti": "Přihlásit se",
+  "Nuligi": "zrušení",
+  "Vi abortis la filmeton.": "Video jste přerušili.",
+  "Reto eraro okazis.": "Došlo k chybě sítě.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Chyba dekódování nebo neprogresivní funkce.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formát není podporován nebo nedostupný/nevhodný pro hru.",
+  "Nekonata eraro okazis.": "Nastala neznámá chyba.",
+  "Eraro : ": "Chyba:",
+  "antaŭa bildo": "předchozí obrázek",
+  "ludi": "hrát",
+  "ludi * 5 kaj enĉenigi": "hrát * 5 a dostat se dovnitř",
+  "sekva bildo": "Další obrázek",
+  "Fermi": "Zavřít",
+  "Elŝuti": "Stažení",
+  "Forigi": "Odebrat",
+  "Kamerao tipo": "Typ kamery",
+  "Loka V4L2-kamerao": "Lokální kamera V4L2",
+  "Loka MMAL-kamerao": "Lokální kamera MMAL",
+  "Reta kamerao": "Online fotoaparát",
+  "Fora motionEye kamerao": "Far Motionleye Camera",
+  "Simpla MJPEG-kamerao": "Jednoduchá kamera MJPEG",
+  "la speco de kamerao, kiun vi volas aldoni": "Typ fotoaparátu, který chcete přidat",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http: //ekzeMplo.com: 8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL kamery (např. http://ekzemplo.com:8080/cam/)",
+  "uzantnomo...": "Uživatelské jméno ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "Uživatelské jméno pro URL, je -li to požadováno (např. Správce)",
+  "pasvorto...": "Heslo ...",
+  "la pasvorto por la URL, se bezonata": "heslo pro URL, pokud je to požadováno",
+  "Kamerao": "Fotoaparát",
+  "la kameraon, kiun vi volas aldoni": "fotoaparát, který chcete přidat",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Fora MotionEye Camera jsou kamery nainstalované za jiným serverem Motionleye. Přidání zde vám umožní hledat a spravovat je z dálky.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Webové kamery (nebo IP kamery) jsou zařízení, která nativně proudí videa RTSP/RTMP nebo MJPEG nebo jednoduché obrázky JPEG. Poraďte se s příručkou vašeho zařízení a zjistěte správnou adresu URL RTSP, RTMP, MJPEG nebo JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Místní kamery MMAL jsou zařízení připojená přímo k vašemu systému MotionEye. Jedná se obvykle o kamery specifické pro karty.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Přidání zařízení jako jednoduché kamery MJPEG místo toho, jak online fotoaparát zlepší fotografii, ale pro ni nebude k dispozici žádná detekce pohybu, snímání obrázků nebo nahrávání filmů. Fotoaparát musí být přístupný vašemu serveru a prohlížeči. Tento typ fotoaparátu neodpovídá internetovým průzkumníka.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Místní kamery V4L2 jsou kamera, která jsou připojena přímo k vašemu systému Motionleye, obvykle prostřednictvím USB.",
+  "Aldonadi kameraon...": "Přidejte kameru ...",
+  "Grupo": "Skupina",
+  "Inkluzivi foton prenitan ĉiun": "Zahrnout fotografii pořízenou každý",
+  "sekundo": "vteřina",
+  "5 sekundoj": "5 sekund",
+  "10 sekundoj": "10 sekund",
+  "30 sekundoj": "30 sekund",
+  "minuto": "minuta",
+  "5 minutoj": "5 minut",
+  "10 minutoj": "10 minut",
+  "30 minutoj": "30 minut",
+  "horo": "hodina",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Vyberte rozsah času mezi dvěma vybranými obrázky.",
+  "Filmo framfrekvenco": "FILMOVÁ SRUMENÁ FAMENÁ",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Vyberte si, jak rychle chcete ozbrojené video.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Vzhledem k velkému počtu obrázků může vytvoření videa nějakou dobu trvat!",
+  "Krei akselita video": "Vytvořte ozbrojené video",
+  "Filmo kreanta en progreso...": "Probíhá vytváření filmu ...",
+  "Zipitaj": "Zip",
+  "Akselita video": "Obchodní video",
+  "Forigi ĉiujn": "Odebrat všechny",
+  "Bildoj prenitaj de ": "Obrázky pořízené",
+  "Filmoj registritaj de ": "Filmy zaznamenané",
+  "montru ĉi tiun fotilon plenekranan": "Zobrazit tento fotoaparát plnou obrazovku",
+  "montri ĉiujn fotilojn": "Ukažte všechny kamery",
+  "montru nur ĉi tiun fotilon": "Zobrazit pouze tento fotoaparát",
+  "malfermaj bildoj retumilo": "Otevřený prohlížeč obrázků",
+  "malferma videoj retumilo": "Otevřený prohlížeč videí",
+  "agordi ĉi tiun kameraon": "Nastavte tuto kameru",
+  "preni instantaron": "Udělejte si okamžik",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ještě jste nenastavili žádnou kameru. Kliknutím sem přidáte jednu ...",
+  "enigu pozitivan nombron": "Zadejte kladné číslo",
+  "enigu pozitivan entjeran nombron": "Zadejte pozitivní celé číslo",
+  "enigu nombron": "Zadejte číslo",
+  "enigu entjeran nombron": "Zadejte celé číslo",
+  " inter ": "mezi",
+  " kaj ": "a",
+  " pli ol ": "více než",
+  " malpli ol ": "méně než",
+  "enigu validan tempon en la sekva formato: HH:MM": "Zadejte platný čas v následujícím formátu: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Zadejte platnou adresu URL (např. Http://ekzemplo.com:8080/cams/)",
+  "fermi": "zavřít",
+  "Ne": "Ne",
+  "Jes": "Ano",
+  "Bone": "OK",
+  "Auto Exposure": "Automatická expozice",
+  "Backlight Compensation": "Kompenzace podsvícení",
+  "Brightness": "Jas",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Expozice absolutně",
+  "Exposure Auto": "Expozice auto",
+  "Exposure Auto Priority": "Automatická priorita expozice",
+  "Exposure Time Absolute": "Doba expozice absolutně",
+  "Focus Absolute": "Zaměřte se na absolutně",
+  "Focus Auto": "Zaostřit auto",
+  "Gain": "Získat",
+  "Gamma": "Gama",
+  "Hue": "Odstín",
+  "Led1 Mode": "Režim LED1",
+  "Led1 Frequency": "Frekvence LED1",
+  "Pan Absolute": "Pan absolutně",
+  "Power Line Frequency": "Frekvence elektrického vedení",
+  "Saturation": "Nasycení",
+  "Sharpness": "Ostrost",
+  "Tilt Absolute": "Naklonit absolutně",
+  "White Balance Temperature": "Teplota vyvážení bílé",
+  "White Balance Temperature Auto": "Teplota vyvážení bílé automatické automobily",
+  "Zoom Absolute": "Zoom absolutně",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.de.json
+++ b/motioneye/static/js/motioneye.de.json
@@ -1,164 +1,176 @@
-{"":{"language":"de","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "Das Passwort darf keine Sonderzeichen enthalten"
-,"Ĉi tiu kampo estas deviga": "Dieses Feld ist erforderlich"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "Der Kameraname darf keine Sonderzeichen enthalten"
-,"valoro devas esti multoblo de 8": "Wert muss ein Vielfaches von 8 sein"
-,"specialaj signoj ne rajtas en radika voja nomo": "Der Verzeichnisname darf keine Sonderzeichen enthalten"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Dateien können nicht direkt im Stammverzeichnis Ihres Systems erstellt werden"
-,"enigu validan retpoŝtadreson": "Geben Sie eine gültige E-Mail-Adresse ein"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "Geben Sie eine Liste der durch Kommas getrennten gültigen E-Mail-Adressen ein"
-,"specialaj signoj ne rajtas en dosiernomo": "Der Dateiname darf keine Sonderzeichen enthalten"
-,"enigu validan valoron": "Geben Sie einen gültigen Wert ein"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Das Entfernen löscht alle Dateien im Cloud-Ordner. \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", nicht nur die von motionEye hochgeladenen!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Dadurch werden alle alten Mediendateiein im Ordner gelöscht \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", nicht nur die von motionEye erstellten!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Die Maske kann ohne gültiges Kamerabild nicht bearbeitet werden!"
-,"Propra": "Benutzerdefiniert"
-,"Propra dosierindiko": "Benutzerdefinierter Dateipfad"
-,"Retan kunlokon": "Netzwerkfreigabe"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Ihr Browser kann diese Funktion nicht ausführen!"
-,"Apliki": "Anwenden"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Stellen Sie sicher, dass alle Konfigurationsoptionen gültig sind!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Dadurch wird das System neu gestartet. Fortfahren?"
-,"Vere fermiti sistemon?": "System wirklich herunterfahren?"
-,"Malŝaltita": "Ausgeschaltet"
-,"Ĉu vere restartigi ?": "Wirklich neu starten?"
-,"La sistemo rekomencis!": "Das System wurde neu gestartet!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Bitte übernehmen Sie zuerst die geänderten Einstellungen!"
-,"Neniu fotilo por forigi!": "Keine Kamera zum Entfernen vorhanden!"
-,"Ĉu forigi kameraon ": "Entfernt die Kamera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye ist auf dem aktuellsten Stand (aktuelle Version: "
-,"Nova versio havebla: ": "Neue Version verfügbar: "
-,". Ĝisdatigi?": ". Aktualisieren?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye wurde erfolgreich aktualisiert!"
-,"Ĝisdatigo malsukcesis!": "Aktualisierung fehlgeschlagen!"
-,"La ĝisdatiga procezo malsukcesis!": "Der Update-Vorgang ist fehlgeschlagen!"
-,"Rezerva dosiero": "Sicherungsdatei"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Die zuvor heruntergeladene Sicherungsdatei."
-,"Restaŭrigi Agordon": "Konfiguration wiederherstellen"
-,"Restaŭriganta agordon ...": "Konfiguration wird wiederhergestellt ..."
-,"La agordo restaŭrigis!": "Die Konfiguration wurde wiederhergestellt!"
-,"Malsukcesis restaŭri la agordon!": "Die Konfiguration konnte nicht wiederhergestellt werden!"
-,"Aliri la alŝutan servon malsukcesis: ": "Der Zugriff auf den Upload-Dienst ist fehlgeschlagen: "
-,"Aliri la alŝutan servon sukcesis!": "Der Zugriff auf den Upload-Dienst war erfolgreich!"
-,"Sciiga retpoŝto fiaskis:": "Das Senden der E-Mail ist fehlgeschlagen:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Stellen Sie sicher, dass alle Konfigurationsoptionen gültig sind!"
-,"Sciiga Telegramo fiaskis:": "Das Senden der Benachrichtigung ist fehlgeschlagen:"
-,"Sciiga Telegramo sukcesis!": "Das Senden der Benachrichtigung war erfolgreich!"
-,"Aliro al retdividado fiaskis: ": "Zugriff auf Netzwerkfreigabe fehlgeschlagen: "
-,"Aliro al retdividado sukcesis!": "Zugriff auf Webfreigabe erfolgreich!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Diese Datei wirklich löschen?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Wollen Sie wirklich alle Bilder aus \"%(group)s\" löschen?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Wollen Sie wirklich alle Videos aus \"%(group)s\" löschen?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Wollen Sie wirklich alle nicht gruppierten Bilder löschen?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Wollen Sie wirklich alle nicht gruppierten Videos löschen?"
-,"aldonadi kameraon...": "Kamera hinzufügen ..."
-,"Uzantnomo": "Benutzername"
-,"Pasvorto": "Passwort"
-,"Memoru min": "Bitte merken"
-,"Ensaluti": "Melden Sie sich an"
-,"Nuligi": "Abbrechen"
-,"Vi abortis la filmeton.": "Das Video wurde abgebrochen."
-,"Reto eraro okazis.": "Ein Netzwerkfehler ist aufgetreten."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Dekodierungsfehler oder nicht spezifizierte Funktion."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format nicht unterstützt oder für die Wiedergabe ungeeignet."
-,"Nekonata eraro okazis.": "Es ist ein unbekannter Fehler aufgetreten."
-,"Eraro : ": "Fehler: "
-,"antaŭa bildo": "vorheriges Bild"
-,"ludi": "Abspielen"
-,"ludi * 5 kaj enĉenigi": "Abspielen in 5-facher Geschwindigkeit"
-,"sekva bildo": "nächstes Bild"
-,"Fermi": "Schließen"
-,"Elŝuti": "Herunterladen"
-,"Forigi": "Entfernen"
-,"Kamerao tipo": "Kameratyp"
-,"Loka V4L2-kamerao": "Lokale V4L2-Kamera"
-,"Loka MMAL-kamerao": "Lokale MMAL-Kamera"
-,"Reta kamerao": "Netzwerkkamera"
-,"Fora motionEye kamerao": "Externe motionEye Kamera"
-,"Simpla MJPEG-kamerao": "Einfache MJPEG-Kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "der Kameratyp, den Sie hinzufügen möchten"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://beispiel.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "die Kamera-URL (z. B. http://beispiel.com:8080/cam/)"
-,"uzantnomo...": "Benutzername ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "bei Bedarf den Benutzernamen für die URL (z.B. admin)"
-,"pasvorto...": "Passwort ..."
-,"la pasvorto por la URL, se bezonata": "das Passwort für die URL, falls erforderlich"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "die Kamera, die Sie hinzufügen möchten"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Eine Remote-MotionEye-Kamera ist eine Kamera, die auf einem anderen MotionEye-Server installiert ist. Wenn Sie sie hier hinzufügen, können Sie diese aus der Ferne betrachten und verwalten."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Netzwerkkameras (oder IP-Kameras) sind Geräte, die RTSP / RTMP- oder MJPEG-Videos oder einfache JPEG-Bilder nativ streamen. Informationen zur richtigen RTSP-, RTMP-, MJPEG- oder JPEG-URL finden Sie im Handbuch Ihres Geräts."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL-Kameras sind Geräte, die direkt an Ihr motionEye-System angeschlossen sind. Dies sind normalerweise kartenspezifische Kameras."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Wenn Sie Ihr Gerät als einfache MJPEG-Kamera anstelle einer Webkamera hinzufügen, wird die Fotografie verbessert, es sind jedoch keine Bewegungserkennung, Bilderfassung oder Filmaufzeichnung verfügbar. Die Kamera muss für Ihren Server und Ihren Browser zugänglich sein. Dieser Kameratyp passt nicht zum Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2-Kameras sind Kamerageräte, die normalerweise über USB direkt an Ihr motionEye-System angeschlossen sind."
-,"Aldonadi kameraon...": "Kamera hinzufügen ..."
-,"Grupo": "Gruppe"
-,"Inkluzivi foton prenitan ĉiun": "Inkludiere ein Foto alle"
-,"sekundo": "1 Sekunde"
-,"5 sekundoj": "5 Sekunden"
-,"10 sekundoj": "10 Sekunden"
-,"30 sekundoj": "30 Sekunden"
-,"minuto": "Minute"
-,"5 minutoj": "5 Minuten"
-,"10 minutoj": "10 Minuten"
-,"30 minutoj": "30 Minuten"
-,"horo": "Stunde"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Wählen Sie das Zeitintervall zwischen zwei ausgewählten Bildern."
-,"Filmo framfrekvenco": "Videobildrate"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Wählen Sie aus, wie schnell der Zeitraffer wiedergegeben werden soll."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Angesichts der großen Anzahl von Bildern kann das Erstellen Ihres Videos einige Zeit dauern!"
-,"Krei akselita video": "Timelapse erstellen"
-,"Filmo kreanta en progreso...": "Video in Bearbeitung ..."
-,"Zipitaj": "Gezippt"
-,"Akselita video": "Zeitraffer"
-,"Forigi ĉiujn": "Alles entfernen"
-,"Bildoj prenitaj de ": "Bilder von "
-,"Filmoj registritaj de ": "Videos aufgenommen von "
-,"montru ĉi tiun fotilon plenekranan": "Diese Kamera im Vollbildmodus anzeigen"
-,"montri ĉiujn fotilojn": "Alle Kameras anzeigen"
-,"montru nur ĉi tiun fotilon": "Nur diese Kamera anzeigen"
-,"malfermaj bildoj retumilo": "Fotos öffnen"
-,"malferma videoj retumilo": "Videos öffnen"
-,"agordi ĉi tiun kameraon": "Kamerareinstellungen"
-,"preni instantaron": "Foto erstellen"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Sie haben noch keine Kamera konfiguriert. Klicken Sie hier, um eine ..."
-,"enigu pozitivan nombron": "Geben Sie eine positive Zahl ein"
-,"enigu pozitivan entjeran nombron": "Geben Sie eine positive Ganzzahl ein"
-,"enigu nombron": "Geben Sie eine Zahl ein"
-,"enigu entjeran nombron": "Geben Sie eine Ganzzahl ein"
-," inter ": " zwischen "
-," kaj ": " und "
-," pli ol ": " größer als "
-," malpli ol ": " kleiner als "
-,"enigu validan tempon en la sekva formato: HH:MM": "Geben Sie die gültige Zeit im folgenden Format ein: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Geben Sie eine gültige URL ein (z. B. http://beispiel.com:8080/cams/)"
-,"fermi": "schließen"
-,"Ne": "Nein"
-,"Jes": "Ja"
-,"Bone": "Okay"
-,"Auto Exposure": "Automatische Belichtung"
-,"Backlight Compensation": "Gegenlichtkompensation"
-,"Brightness": "Helligkeit"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Absolute Belichtung"
-,"Exposure Auto": "Belichtungsautomatik"
-,"Exposure Auto Priority": "Automatische Belichtungspriorität"
-,"Exposure Time Absolute": "Absolute Belichtungszeit"
-,"Focus Absolute": "Absoluter Fokus"
-,"Focus Auto": "Autofokus"
-,"Gain": "Verstärkung"
-,"Gamma": "Gamma"
-,"Hue": "Farbton"
-,"Led1 Mode": "LED1-Modus"
-,"Led1 Frequency": "LED1-Frequenz"
-,"Pan Absolute": "Absolute Schwenkposition"
-,"Power Line Frequency": "Netzfrequenz"
-,"Saturation": "Sättigung"
-,"Sharpness": "Schärfe"
-,"Tilt Absolute": "Absolute Neigung"
-,"White Balance Temperature": "Weißabgleich Farbtemperatur"
-,"White Balance Temperature Auto": "Automatischer Weißabgleich"
-,"Zoom Absolute": "Absoluter Zoom"
+{
+  "": {
+    "language": "de",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "Das Passwort darf keine Sonderzeichen enthalten",
+  "Ĉi tiu kampo estas deviga": "Dieses Feld ist erforderlich",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "Der Kameraname darf keine Sonderzeichen enthalten",
+  "valoro devas esti multoblo de 8": "Wert muss ein Vielfaches von 8 sein",
+  "specialaj signoj ne rajtas en radika voja nomo": "Der Verzeichnisname darf keine Sonderzeichen enthalten",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Dateien können nicht direkt im Stammverzeichnis Ihres Systems erstellt werden",
+  "enigu validan retpoŝtadreson": "Geben Sie eine gültige E-Mail-Adresse ein",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "Geben Sie eine Liste der durch Kommas getrennten gültigen E-Mail-Adressen ein",
+  "specialaj signoj ne rajtas en dosiernomo": "Der Dateiname darf keine Sonderzeichen enthalten",
+  "enigu validan valoron": "Geben Sie einen gültigen Wert ein",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Das Entfernen löscht alle Dateien im Cloud-Ordner. \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", nicht nur die von motionEye hochgeladenen!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Dadurch werden alle alten Mediendateiein im Ordner gelöscht \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", nicht nur die von motionEye erstellten!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Die Maske kann ohne gültiges Kamerabild nicht bearbeitet werden!",
+  "Propra": "Benutzerdefiniert",
+  "Propra dosierindiko": "Benutzerdefinierter Dateipfad",
+  "Retan kunlokon": "Netzwerkfreigabe",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Ihr Browser kann diese Funktion nicht ausführen!",
+  "Apliki": "Anwenden",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Stellen Sie sicher, dass alle Konfigurationsoptionen gültig sind!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Dadurch wird das System neu gestartet. Fortfahren?",
+  "Vere fermiti sistemon?": "System wirklich herunterfahren?",
+  "Malŝaltita": "Ausgeschaltet",
+  "Ĉu vere restartigi ?": "Wirklich neu starten?",
+  "La sistemo rekomencis!": "Das System wurde neu gestartet!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Bitte übernehmen Sie zuerst die geänderten Einstellungen!",
+  "Neniu fotilo por forigi!": "Keine Kamera zum Entfernen vorhanden!",
+  "Ĉu forigi kameraon ": "Entfernt die Kamera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye ist auf dem aktuellsten Stand (aktuelle Version: ",
+  "Nova versio havebla: ": "Neue Version verfügbar: ",
+  ". Ĝisdatigi?": ". Aktualisieren?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye wurde erfolgreich aktualisiert!",
+  "Ĝisdatigo malsukcesis!": "Aktualisierung fehlgeschlagen!",
+  "La ĝisdatiga procezo malsukcesis!": "Der Update-Vorgang ist fehlgeschlagen!",
+  "Rezerva dosiero": "Sicherungsdatei",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Die zuvor heruntergeladene Sicherungsdatei.",
+  "Restaŭrigi Agordon": "Konfiguration wiederherstellen",
+  "Restaŭriganta agordon ...": "Konfiguration wird wiederhergestellt ...",
+  "La agordo restaŭrigis!": "Die Konfiguration wurde wiederhergestellt!",
+  "Malsukcesis restaŭri la agordon!": "Die Konfiguration konnte nicht wiederhergestellt werden!",
+  "Aliri la alŝutan servon malsukcesis: ": "Der Zugriff auf den Upload-Dienst ist fehlgeschlagen: ",
+  "Aliri la alŝutan servon sukcesis!": "Der Zugriff auf den Upload-Dienst war erfolgreich!",
+  "Sciiga retpoŝto fiaskis:": "Das Senden der E-Mail ist fehlgeschlagen:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Stellen Sie sicher, dass alle Konfigurationsoptionen gültig sind!",
+  "Sciiga Telegramo fiaskis:": "Das Senden der Benachrichtigung ist fehlgeschlagen:",
+  "Sciiga Telegramo sukcesis!": "Das Senden der Benachrichtigung war erfolgreich!",
+  "Aliro al retdividado fiaskis: ": "Zugriff auf Netzwerkfreigabe fehlgeschlagen: ",
+  "Aliro al retdividado sukcesis!": "Zugriff auf Webfreigabe erfolgreich!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Diese Datei wirklich löschen?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Wollen Sie wirklich alle Bilder aus \"%(group)s\" löschen?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Wollen Sie wirklich alle Videos aus \"%(group)s\" löschen?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Wollen Sie wirklich alle nicht gruppierten Bilder löschen?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Wollen Sie wirklich alle nicht gruppierten Videos löschen?",
+  "aldonadi kameraon...": "Kamera hinzufügen ...",
+  "Uzantnomo": "Benutzername",
+  "Pasvorto": "Passwort",
+  "Memoru min": "Bitte merken",
+  "Ensaluti": "Melden Sie sich an",
+  "Nuligi": "Abbrechen",
+  "Vi abortis la filmeton.": "Das Video wurde abgebrochen.",
+  "Reto eraro okazis.": "Ein Netzwerkfehler ist aufgetreten.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Dekodierungsfehler oder nicht spezifizierte Funktion.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format nicht unterstützt oder für die Wiedergabe ungeeignet.",
+  "Nekonata eraro okazis.": "Es ist ein unbekannter Fehler aufgetreten.",
+  "Eraro : ": "Fehler: ",
+  "antaŭa bildo": "vorheriges Bild",
+  "ludi": "Abspielen",
+  "ludi * 5 kaj enĉenigi": "Abspielen in 5-facher Geschwindigkeit",
+  "sekva bildo": "nächstes Bild",
+  "Fermi": "Schließen",
+  "Elŝuti": "Herunterladen",
+  "Forigi": "Entfernen",
+  "Kamerao tipo": "Kameratyp",
+  "Loka V4L2-kamerao": "Lokale V4L2-Kamera",
+  "Loka MMAL-kamerao": "Lokale MMAL-Kamera",
+  "Reta kamerao": "Netzwerkkamera",
+  "Fora motionEye kamerao": "Externe motionEye Kamera",
+  "Simpla MJPEG-kamerao": "Einfache MJPEG-Kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "der Kameratyp, den Sie hinzufügen möchten",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://beispiel.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "die Kamera-URL (z. B. http://beispiel.com:8080/cam/)",
+  "uzantnomo...": "Benutzername ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "bei Bedarf den Benutzernamen für die URL (z.B. admin)",
+  "pasvorto...": "Passwort ...",
+  "la pasvorto por la URL, se bezonata": "das Passwort für die URL, falls erforderlich",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "die Kamera, die Sie hinzufügen möchten",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Eine Remote-MotionEye-Kamera ist eine Kamera, die auf einem anderen MotionEye-Server installiert ist. Wenn Sie sie hier hinzufügen, können Sie diese aus der Ferne betrachten und verwalten.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Netzwerkkameras (oder IP-Kameras) sind Geräte, die RTSP / RTMP- oder MJPEG-Videos oder einfache JPEG-Bilder nativ streamen. Informationen zur richtigen RTSP-, RTMP-, MJPEG- oder JPEG-URL finden Sie im Handbuch Ihres Geräts.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL-Kameras sind Geräte, die direkt an Ihr motionEye-System angeschlossen sind. Dies sind normalerweise kartenspezifische Kameras.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Wenn Sie Ihr Gerät als einfache MJPEG-Kamera anstelle einer Webkamera hinzufügen, wird die Fotografie verbessert, es sind jedoch keine Bewegungserkennung, Bilderfassung oder Filmaufzeichnung verfügbar. Die Kamera muss für Ihren Server und Ihren Browser zugänglich sein. Dieser Kameratyp passt nicht zum Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2-Kameras sind Kamerageräte, die normalerweise über USB direkt an Ihr motionEye-System angeschlossen sind.",
+  "Aldonadi kameraon...": "Kamera hinzufügen ...",
+  "Grupo": "Gruppe",
+  "Inkluzivi foton prenitan ĉiun": "Inkludiere ein Foto alle",
+  "sekundo": "1 Sekunde",
+  "5 sekundoj": "5 Sekunden",
+  "10 sekundoj": "10 Sekunden",
+  "30 sekundoj": "30 Sekunden",
+  "minuto": "Minute",
+  "5 minutoj": "5 Minuten",
+  "10 minutoj": "10 Minuten",
+  "30 minutoj": "30 Minuten",
+  "horo": "Stunde",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Wählen Sie das Zeitintervall zwischen zwei ausgewählten Bildern.",
+  "Filmo framfrekvenco": "Videobildrate",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Wählen Sie aus, wie schnell der Zeitraffer wiedergegeben werden soll.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Angesichts der großen Anzahl von Bildern kann das Erstellen Ihres Videos einige Zeit dauern!",
+  "Krei akselita video": "Timelapse erstellen",
+  "Filmo kreanta en progreso...": "Video in Bearbeitung ...",
+  "Zipitaj": "Gezippt",
+  "Akselita video": "Zeitraffer",
+  "Forigi ĉiujn": "Alles entfernen",
+  "Bildoj prenitaj de ": "Bilder von ",
+  "Filmoj registritaj de ": "Videos aufgenommen von ",
+  "montru ĉi tiun fotilon plenekranan": "Diese Kamera im Vollbildmodus anzeigen",
+  "montri ĉiujn fotilojn": "Alle Kameras anzeigen",
+  "montru nur ĉi tiun fotilon": "Nur diese Kamera anzeigen",
+  "malfermaj bildoj retumilo": "Fotos öffnen",
+  "malferma videoj retumilo": "Videos öffnen",
+  "agordi ĉi tiun kameraon": "Kamerareinstellungen",
+  "preni instantaron": "Foto erstellen",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Sie haben noch keine Kamera konfiguriert. Klicken Sie hier, um eine ...",
+  "enigu pozitivan nombron": "Geben Sie eine positive Zahl ein",
+  "enigu pozitivan entjeran nombron": "Geben Sie eine positive Ganzzahl ein",
+  "enigu nombron": "Geben Sie eine Zahl ein",
+  "enigu entjeran nombron": "Geben Sie eine Ganzzahl ein",
+  " inter ": " zwischen ",
+  " kaj ": " und ",
+  " pli ol ": " größer als ",
+  " malpli ol ": " kleiner als ",
+  "enigu validan tempon en la sekva formato: HH:MM": "Geben Sie die gültige Zeit im folgenden Format ein: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Geben Sie eine gültige URL ein (z. B. http://beispiel.com:8080/cams/)",
+  "fermi": "schließen",
+  "Ne": "Nein",
+  "Jes": "Ja",
+  "Bone": "Okay",
+  "Auto Exposure": "Automatische Belichtung",
+  "Backlight Compensation": "Gegenlichtkompensation",
+  "Brightness": "Helligkeit",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Absolute Belichtung",
+  "Exposure Auto": "Belichtungsautomatik",
+  "Exposure Auto Priority": "Automatische Belichtungspriorität",
+  "Exposure Time Absolute": "Absolute Belichtungszeit",
+  "Focus Absolute": "Absoluter Fokus",
+  "Focus Auto": "Autofokus",
+  "Gain": "Verstärkung",
+  "Gamma": "Gamma",
+  "Hue": "Farbton",
+  "Led1 Mode": "LED1-Modus",
+  "Led1 Frequency": "LED1-Frequenz",
+  "Pan Absolute": "Absolute Schwenkposition",
+  "Power Line Frequency": "Netzfrequenz",
+  "Saturation": "Sättigung",
+  "Sharpness": "Schärfe",
+  "Tilt Absolute": "Absolute Neigung",
+  "White Balance Temperature": "Weißabgleich Farbtemperatur",
+  "White Balance Temperature Auto": "Automatischer Weißabgleich",
+  "Zoom Absolute": "Absoluter Zoom",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.el.json
+++ b/motioneye/static/js/motioneye.el.json
@@ -1,164 +1,176 @@
-{"":{"language":"el","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "δεν επιτρέπονται ειδικοί χαρακτήρες στον κωδικό"
-,"Ĉi tiu kampo estas deviga": "Αυτό το πεδίο είναι υποχρεωτικό"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "δεν επιτρέπονται ειδικοί χαρακτήρες στο όνομα της κάμερας"
-,"valoro devas esti multoblo de 8": "η τιμή πρέπει να είναι πολλαπλάσια του 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "ειδικοί χαρακτήρες δεν επιτρέπονται στο όνομα του ριζικού φακέλου"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "αρχεία δεν μπορούν να δημιουργηθούν κατευθείαν στο root του συστήματός σας"
-,"enigu validan retpoŝtadreson": "εισάγετε μια έγκυρη διεύθυνση ηλεκτρονικού ταχυδρομείου"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "εισάγετε μια λίστα με έγκυρες, διαχωρισμένες με κόμμα, διευθύνσεις ηλεκτρονικού ταχυδρομείου"
-,"specialaj signoj ne rajtas en dosiernomo": "ειδικοί χαρακτήρες δεν επιτρέπονται στο όνομα του αρχείου"
-,"enigu validan valoron": "εισάγετε μια έγκυρη τιμή"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Αυτό θα διαγράψει όλα τα αρχεία και τους υποφακέλους που βρίσκονται στον cloud φάκελο \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", όχι μόνο αυτά που έχουν ανέβει από το motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Αυτό θα διαγράψει όλα τα παλιά αρχεία πολυμέσων που βρίσκονται στο φάκελο και στους υποφακέλους του \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", όχι μόνο αυτά που δημιουργήθηκαν από το motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Δεν μπορείτε να επεξεργαστείτε τη μάσκα χωρίς μια έγκυρη εικόνα από την κάμερα!"
-,"Propra": "Προσαρμοσμένες"
-,"Propra dosierindiko": "Προσαρμοσμένη διαδρομή"
-,"Retan kunlokon": "Κοινόχρηστο Δικτύου"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Ο περιηγητής σας δεν υλοποιεί αυτήν τη λειτουργία!"
-,"Apliki": "Εφαρμογή"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Βεβαιωθείτε ότι όλες οι επιλογές παραμετροποίησης είναι έγκυρες!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Αυτό θα επανεκκινήσει το σύστημα. Συνέχεια;"
-,"Vere fermiti sistemon?": "Πραγματικά θέλετε να γίνει τερματισμός;"
-,"Malŝaltita": "Απενεργοποιημένο"
-,"Ĉu vere restartigi ?": "Πραγματικά θέλετε να γίνει επανεκκίνηση;"
-,"La sistemo rekomencis!": "Το σύστημα επανεκκινήθηκε!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Παρακαλώ εφαρμόστε πρώτα τις τροποποιημένες ρυθμίσεις!"
-,"Neniu fotilo por forigi!": "Δεν υπάρχει κάμερα για αφαίρεση!"
-,"Ĉu forigi kameraon ": "Αφαίρεση κάμερας "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "Το motionEye είναι ενημερωμένο (τρέχουσα έκδοση: "
-,"Nova versio havebla: ": "Νέα έκδοση διαθέσιμη: "
-,". Ĝisdatigi?": ". Ενημέρωση;"
-,"motionEye estis sukcese ĝisdatigita!": "Το motionEye ενημερώθηκε με επιτυχία!"
-,"Ĝisdatigo malsukcesis!": "Η ενημέρωση απέτυχε!"
-,"La ĝisdatiga procezo malsukcesis!": "Η διαδικασία ενημέρωσης απέτυχε!"
-,"Rezerva dosiero": "Αρχείο Αντιγράφου Ασφαλείας"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "το αρχείο αντιγράφου ασφαλείας που κάνατε πριν λήψη."
-,"Restaŭrigi Agordon": "Επαναφορά Ρυθμίσεων"
-,"Restaŭriganta agordon ...": "Γίνεται επαναφορά ρυθμίσεων..."
-,"La agordo restaŭrigis!": "Η επαναφορά ρυθμίσεων έγινε!"
-,"Malsukcesis restaŭri la agordon!": "Αποτυχία επαναφοράς ρυθμίσεων!"
-,"Aliri la alŝutan servon malsukcesis: ": "Αποτυχία πρόσβασης στην υπηρεσία μεταφόρτωσης: "
-,"Aliri la alŝutan servon sukcesis!": "Επιτυχής πρόσβαση στην υπηρεσία μεταφόρτωσης!"
-,"Sciiga retpoŝto fiaskis:": "Ειδοποίηση ηλ. ταχυδρομείου απέτυχε:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Βεβαιωθείτε ότι όλες οι επιλογές παραμετροποίησης είναι έγκυρες!"
-,"Sciiga Telegramo fiaskis:": "Ειδοποίηση μέσω Telegram απέτυχε:"
-,"Sciiga Telegramo sukcesis!": "Ειδοποίηση μέσω Telegram επιτυχής!"
-,"Aliro al retdividado fiaskis: ": "Αποτυχία πρόσβασης στο κοινόχρηστο δικτύου: "
-,"Aliro al retdividado sukcesis!": "Η πρόσβαση στο κοινόχρηστο δικτύου ήταν επιτυχής!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Πραγματικά διαγραφή αυτού του αρχείου;"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Πραγματικά διαγραφή όλων των εικόνων από τα \"%(group)s\";"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Πραγματικά αφαίρεση όλων των βίντεο από τα \"%(group)s\";"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Πραγματικά διαγραφή όλων των μη ομαδοποιημένων εικόνων;"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Πραγματικά διαγραφή όλων τη μη ομαδοποιημένων βίντεο;"
-,"aldonadi kameraon...": "προσθήκη κάμερας..."
-,"Uzantnomo": "Όνομα Χρήστη"
-,"Pasvorto": "Κωδικός Πρόσβασης"
-,"Memoru min": "Να με θυμάσαι"
-,"Ensaluti": "Σύνδεση"
-,"Nuligi": "Άκυρο"
-,"Vi abortis la filmeton.": "Ματαιώσατε το βίντεο."
-,"Reto eraro okazis.": "Προέκυψε ένα σφάλμα δικτύου."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Σφάλμα αποκωδικοποίησης ή μη υποστηριζόμενα χαρακτηριστικά πολυμέσων."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Η μορφή δεν υποστηρίζεται ή μη προσβάσιμη/ακατάλληλη για αναπαραγωγή."
-,"Nekonata eraro okazis.": "Προέκυψε άγνωστο σφάλμα."
-,"Eraro : ": "Σφάλμα: "
-,"antaŭa bildo": "προηγούμενη εικόνα"
-,"ludi": "αναπαραγωγή"
-,"ludi * 5 kaj enĉenigi": "για να παίξετε * 5 και να μπείτε"
-,"sekva bildo": "επόμενη εικόνα"
-,"Fermi": "Κλείσιμο"
-,"Elŝuti": "Λήψη"
-,"Forigi": "Αφαίρεση"
-,"Kamerao tipo": "Τύπος Κάμερας"
-,"Loka V4L2-kamerao": "Τοπική V4L2-Κάμερα"
-,"Loka MMAL-kamerao": "Τοπική MMAL Κάμερα"
-,"Reta kamerao": "Δικτυακή Κάμερα"
-,"Fora motionEye kamerao": "Απομακρυσμένη Κάμερα motionEye"
-,"Simpla MJPEG-kamerao": "Απλή MJPEG-Κάμερα"
-,"la speco de kamerao, kiun vi volas aldoni": "ο τύπος της κάμερας που θέλετε να προσθέσετε"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "το URL της κάμερας (π.χ. http://example.com:8080/cam/)"
-,"uzantnomo...": "όνομα χρήστη..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "το όνομα χρήστη για το URL, αν χρειάζεται (π.χ. admin)"
-,"pasvorto...": "κωδικός πρόσβασης..."
-,"la pasvorto por la URL, se bezonata": "ο κωδικός για το URL, αν χρειάζεται"
-,"Kamerao": "Κάμερα"
-,"la kameraon, kiun vi volas aldoni": "η κάμερα που θέλετε να προσθέσετε"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Οι απομακρυσμένες κάμερες motionEye είναι κάμερες που είναι εγκατεστημένες σε κάποιον άλλο διακομιστή motionEye. Προστίθοντάς τες εδώ θα σας επιτρέψει να τις βλέπετε και να τις διαχειρίζεστε απομακρυσμένα."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Οι δικτυακές κάμερες (ή IP κάμερες) είναι συσκευές που εγγενώς στριμάρουν RTSP/RTMP ή MJPEG βίντεο ή απλές εικόνες JPEG. Συμβουλευτείτε το εγχειρίδιο της συσκευής σας για να βρείτε το σωστό RTSP, RTMP, MJPEG ή JPEG URL."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Οι τοπικές MMAL κάμερες είναι συσκευές που είναι απευθείας συνδεμένες με το σύστημα motionEye. Αυτές συνήθως είναι συγκεκριμένες για τη συσκευή/μητρική σας."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Προσθέτοντας τη συσκευή σας σαν απλή κάμερα MJPEG αντί για δικτυακή κάμερα θα βελτιώσει την ταχύτητα των καρέ, αλλά δεν θα είναι για αυτήν διαθέσιμα ανίχνευση κίνησης, λήψη εικόνων και καταγραφή βίντεο. Η κάμερα πρέπει να είναι προσβάσιμη και από το διακομιστή αλλά και από τον περιηγητή σας. Αυτού του τύπου η κάμερα δεν είναι συμβατή με τον Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Οι τοπικές κάμερες V4L2 είναι συσκευές κάμερας που συνδέονται απευθείας με το σύστημα MotionEye, συνήθως μέσω USB."
-,"Aldonadi kameraon...": "Προσθέστε μια κάμερα ..."
-,"Grupo": "Μία ομάδα"
-,"Inkluzivi foton prenitan ĉiun": "Συμπεριλάβετε μια φωτογραφία που τραβήχτηκε το καθένα"
-,"sekundo": "ένα δεύτερο"
-,"5 sekundoj": "5 δευτερόλεπτα"
-,"10 sekundoj": "10 δευτερόλεπτα"
-,"30 sekundoj": "30 δευτερόλεπτα"
-,"minuto": "λεπτό"
-,"5 minutoj": "5 λεπτά"
-,"10 minutoj": "10 λεπτά"
-,"30 minutoj": "30 λεπτά"
-,"horo": "ώρα"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Επιλέξτε το εύρος του χρόνου μεταξύ δύο επιλεγμένων εικόνων."
-,"Filmo framfrekvenco": "Ρυθμός καρέ"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Επιλέξτε πόσο γρήγορα θέλετε να είναι το ένοπλο βίντεο."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Λαμβάνοντας υπόψη τον μεγάλο αριθμό εικόνων, η δημιουργία του βίντεό σας θα μπορούσε να πάρει κάποιο χρόνο!"
-,"Krei akselita video": "Δημιουργήστε ένα ένοπλο βίντεο"
-,"Filmo kreanta en progreso...": "Κινηματογραφική ταινία σε εξέλιξη ..."
-,"Zipitaj": "Φερμουάρ"
-,"Akselita video": "Έμφυτο βίντεο"
-,"Forigi ĉiujn": "Αφαίρεση όλων"
-,"Bildoj prenitaj de ": "Εικόνες που λαμβάνονται από"
-,"Filmoj registritaj de ": "Ταινίες που καταγράφηκαν από"
-,"montru ĉi tiun fotilon plenekranan": "Δείξτε αυτήν την κάμερα πλήρη -Screen"
-,"montri ĉiujn fotilojn": "Δείξτε όλες τις κάμερες"
-,"montru nur ĉi tiun fotilon": "Εμφάνιση μόνο αυτής της κάμερας"
-,"malfermaj bildoj retumilo": "Ανοίξτε το πρόγραμμα περιήγησης"
-,"malferma videoj retumilo": "Ανοίξτε το πρόγραμμα περιήγησης βίντεο"
-,"agordi ĉi tiun kameraon": "Ορίστε αυτήν την κάμερα"
-,"preni instantaron": "Για να πάρετε μια στιγμή"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Δεν έχετε ρυθμίσει ακόμα καμία κάμερα. Κάντε κλικ εδώ για να προσθέσετε ένα ..."
-,"enigu pozitivan nombron": "Εισαγάγετε έναν θετικό αριθμό"
-,"enigu pozitivan entjeran nombron": "Εισαγάγετε έναν θετικό ακέραιο αριθμό"
-,"enigu nombron": "Εισαγάγετε έναν αριθμό"
-,"enigu entjeran nombron": "Εισαγάγετε έναν ακέραιο αριθμό"
-," inter ": "μεταξύ"
-," kaj ": "και"
-," pli ol ": "περισσότερο από"
-," malpli ol ": "λιγότερο από"
-,"enigu validan tempon en la sekva formato: HH:MM": "Εισαγάγετε έναν έγκυρο χρόνο στην ακόλουθη μορφή: HH: mm"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Εισαγάγετε μια έγκυρη διεύθυνση URL (π.χ. http://ekzemplo.com:8080/cams/)"
-,"fermi": "να κλείσω"
-,"Ne": "Οχι"
-,"Jes": "Ναί"
-,"Bone": "Εντάξει"
-,"Auto Exposure": "Αυτόματη έκθεση"
-,"Backlight Compensation": "Αντιστάθμιση οπίσθιου φωτισμού"
-,"Brightness": "Λάμψη"
-,"Contrast": "Αντίθεση"
-,"Exposure Absolute": "Έκθεση απολύτως"
-,"Exposure Auto": "Εκθέσεις αυτοκινήτων"
-,"Exposure Auto Priority": "Προτεραιότητα αυτόματης έκθεσης"
-,"Exposure Time Absolute": "Ο χρόνος έκθεσης απολύτως"
-,"Focus Absolute": "Επικεντρώνεται απολύτως"
-,"Focus Auto": "Εστίαση αυτοκινήτων"
-,"Gain": "Κέρδος"
-,"Gamma": "Γάμμα"
-,"Hue": "Απόχρωση"
-,"Led1 Mode": "Λειτουργία LED1"
-,"Led1 Frequency": "Συχνότητα LED1"
-,"Pan Absolute": "Παναγιά απολύτως"
-,"Power Line Frequency": "Συχνότητα γραμμής ισχύος"
-,"Saturation": "Κορεσμός"
-,"Sharpness": "Οξύτητα"
-,"Tilt Absolute": "Κλίση απολύτως"
-,"White Balance Temperature": "Θερμοκρασία ισορροπίας λευκού"
-,"White Balance Temperature Auto": "Θερμοκρασία ισορροπίας λευκού"
-,"Zoom Absolute": "Μεγέθυνση απολύτως"
+{
+  "": {
+    "language": "el",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "δεν επιτρέπονται ειδικοί χαρακτήρες στον κωδικό",
+  "Ĉi tiu kampo estas deviga": "Αυτό το πεδίο είναι υποχρεωτικό",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "δεν επιτρέπονται ειδικοί χαρακτήρες στο όνομα της κάμερας",
+  "valoro devas esti multoblo de 8": "η τιμή πρέπει να είναι πολλαπλάσια του 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "ειδικοί χαρακτήρες δεν επιτρέπονται στο όνομα του ριζικού φακέλου",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "αρχεία δεν μπορούν να δημιουργηθούν κατευθείαν στο root του συστήματός σας",
+  "enigu validan retpoŝtadreson": "εισάγετε μια έγκυρη διεύθυνση ηλεκτρονικού ταχυδρομείου",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "εισάγετε μια λίστα με έγκυρες, διαχωρισμένες με κόμμα, διευθύνσεις ηλεκτρονικού ταχυδρομείου",
+  "specialaj signoj ne rajtas en dosiernomo": "ειδικοί χαρακτήρες δεν επιτρέπονται στο όνομα του αρχείου",
+  "enigu validan valoron": "εισάγετε μια έγκυρη τιμή",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Αυτό θα διαγράψει όλα τα αρχεία και τους υποφακέλους που βρίσκονται στον cloud φάκελο \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", όχι μόνο αυτά που έχουν ανέβει από το motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Αυτό θα διαγράψει όλα τα παλιά αρχεία πολυμέσων που βρίσκονται στο φάκελο και στους υποφακέλους του \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", όχι μόνο αυτά που δημιουργήθηκαν από το motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Δεν μπορείτε να επεξεργαστείτε τη μάσκα χωρίς μια έγκυρη εικόνα από την κάμερα!",
+  "Propra": "Προσαρμοσμένες",
+  "Propra dosierindiko": "Προσαρμοσμένη διαδρομή",
+  "Retan kunlokon": "Κοινόχρηστο Δικτύου",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Ο περιηγητής σας δεν υλοποιεί αυτήν τη λειτουργία!",
+  "Apliki": "Εφαρμογή",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Βεβαιωθείτε ότι όλες οι επιλογές παραμετροποίησης είναι έγκυρες!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Αυτό θα επανεκκινήσει το σύστημα. Συνέχεια;",
+  "Vere fermiti sistemon?": "Πραγματικά θέλετε να γίνει τερματισμός;",
+  "Malŝaltita": "Απενεργοποιημένο",
+  "Ĉu vere restartigi ?": "Πραγματικά θέλετε να γίνει επανεκκίνηση;",
+  "La sistemo rekomencis!": "Το σύστημα επανεκκινήθηκε!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Παρακαλώ εφαρμόστε πρώτα τις τροποποιημένες ρυθμίσεις!",
+  "Neniu fotilo por forigi!": "Δεν υπάρχει κάμερα για αφαίρεση!",
+  "Ĉu forigi kameraon ": "Αφαίρεση κάμερας ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "Το motionEye είναι ενημερωμένο (τρέχουσα έκδοση: ",
+  "Nova versio havebla: ": "Νέα έκδοση διαθέσιμη: ",
+  ". Ĝisdatigi?": ". Ενημέρωση;",
+  "motionEye estis sukcese ĝisdatigita!": "Το motionEye ενημερώθηκε με επιτυχία!",
+  "Ĝisdatigo malsukcesis!": "Η ενημέρωση απέτυχε!",
+  "La ĝisdatiga procezo malsukcesis!": "Η διαδικασία ενημέρωσης απέτυχε!",
+  "Rezerva dosiero": "Αρχείο Αντιγράφου Ασφαλείας",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "το αρχείο αντιγράφου ασφαλείας που κάνατε πριν λήψη.",
+  "Restaŭrigi Agordon": "Επαναφορά Ρυθμίσεων",
+  "Restaŭriganta agordon ...": "Γίνεται επαναφορά ρυθμίσεων...",
+  "La agordo restaŭrigis!": "Η επαναφορά ρυθμίσεων έγινε!",
+  "Malsukcesis restaŭri la agordon!": "Αποτυχία επαναφοράς ρυθμίσεων!",
+  "Aliri la alŝutan servon malsukcesis: ": "Αποτυχία πρόσβασης στην υπηρεσία μεταφόρτωσης: ",
+  "Aliri la alŝutan servon sukcesis!": "Επιτυχής πρόσβαση στην υπηρεσία μεταφόρτωσης!",
+  "Sciiga retpoŝto fiaskis:": "Ειδοποίηση ηλ. ταχυδρομείου απέτυχε:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Βεβαιωθείτε ότι όλες οι επιλογές παραμετροποίησης είναι έγκυρες!",
+  "Sciiga Telegramo fiaskis:": "Ειδοποίηση μέσω Telegram απέτυχε:",
+  "Sciiga Telegramo sukcesis!": "Ειδοποίηση μέσω Telegram επιτυχής!",
+  "Aliro al retdividado fiaskis: ": "Αποτυχία πρόσβασης στο κοινόχρηστο δικτύου: ",
+  "Aliro al retdividado sukcesis!": "Η πρόσβαση στο κοινόχρηστο δικτύου ήταν επιτυχής!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Πραγματικά διαγραφή αυτού του αρχείου;",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Πραγματικά διαγραφή όλων των εικόνων από τα \"%(group)s\";",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Πραγματικά αφαίρεση όλων των βίντεο από τα \"%(group)s\";",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Πραγματικά διαγραφή όλων των μη ομαδοποιημένων εικόνων;",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Πραγματικά διαγραφή όλων τη μη ομαδοποιημένων βίντεο;",
+  "aldonadi kameraon...": "προσθήκη κάμερας...",
+  "Uzantnomo": "Όνομα Χρήστη",
+  "Pasvorto": "Κωδικός Πρόσβασης",
+  "Memoru min": "Να με θυμάσαι",
+  "Ensaluti": "Σύνδεση",
+  "Nuligi": "Άκυρο",
+  "Vi abortis la filmeton.": "Ματαιώσατε το βίντεο.",
+  "Reto eraro okazis.": "Προέκυψε ένα σφάλμα δικτύου.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Σφάλμα αποκωδικοποίησης ή μη υποστηριζόμενα χαρακτηριστικά πολυμέσων.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Η μορφή δεν υποστηρίζεται ή μη προσβάσιμη/ακατάλληλη για αναπαραγωγή.",
+  "Nekonata eraro okazis.": "Προέκυψε άγνωστο σφάλμα.",
+  "Eraro : ": "Σφάλμα: ",
+  "antaŭa bildo": "προηγούμενη εικόνα",
+  "ludi": "αναπαραγωγή",
+  "ludi * 5 kaj enĉenigi": "για να παίξετε * 5 και να μπείτε",
+  "sekva bildo": "επόμενη εικόνα",
+  "Fermi": "Κλείσιμο",
+  "Elŝuti": "Λήψη",
+  "Forigi": "Αφαίρεση",
+  "Kamerao tipo": "Τύπος Κάμερας",
+  "Loka V4L2-kamerao": "Τοπική V4L2-Κάμερα",
+  "Loka MMAL-kamerao": "Τοπική MMAL Κάμερα",
+  "Reta kamerao": "Δικτυακή Κάμερα",
+  "Fora motionEye kamerao": "Απομακρυσμένη Κάμερα motionEye",
+  "Simpla MJPEG-kamerao": "Απλή MJPEG-Κάμερα",
+  "la speco de kamerao, kiun vi volas aldoni": "ο τύπος της κάμερας που θέλετε να προσθέσετε",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "το URL της κάμερας (π.χ. http://example.com:8080/cam/)",
+  "uzantnomo...": "όνομα χρήστη...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "το όνομα χρήστη για το URL, αν χρειάζεται (π.χ. admin)",
+  "pasvorto...": "κωδικός πρόσβασης...",
+  "la pasvorto por la URL, se bezonata": "ο κωδικός για το URL, αν χρειάζεται",
+  "Kamerao": "Κάμερα",
+  "la kameraon, kiun vi volas aldoni": "η κάμερα που θέλετε να προσθέσετε",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Οι απομακρυσμένες κάμερες motionEye είναι κάμερες που είναι εγκατεστημένες σε κάποιον άλλο διακομιστή motionEye. Προστίθοντάς τες εδώ θα σας επιτρέψει να τις βλέπετε και να τις διαχειρίζεστε απομακρυσμένα.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Οι δικτυακές κάμερες (ή IP κάμερες) είναι συσκευές που εγγενώς στριμάρουν RTSP/RTMP ή MJPEG βίντεο ή απλές εικόνες JPEG. Συμβουλευτείτε το εγχειρίδιο της συσκευής σας για να βρείτε το σωστό RTSP, RTMP, MJPEG ή JPEG URL.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Οι τοπικές MMAL κάμερες είναι συσκευές που είναι απευθείας συνδεμένες με το σύστημα motionEye. Αυτές συνήθως είναι συγκεκριμένες για τη συσκευή/μητρική σας.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Προσθέτοντας τη συσκευή σας σαν απλή κάμερα MJPEG αντί για δικτυακή κάμερα θα βελτιώσει την ταχύτητα των καρέ, αλλά δεν θα είναι για αυτήν διαθέσιμα ανίχνευση κίνησης, λήψη εικόνων και καταγραφή βίντεο. Η κάμερα πρέπει να είναι προσβάσιμη και από το διακομιστή αλλά και από τον περιηγητή σας. Αυτού του τύπου η κάμερα δεν είναι συμβατή με τον Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Οι τοπικές κάμερες V4L2 είναι συσκευές κάμερας που συνδέονται απευθείας με το σύστημα MotionEye, συνήθως μέσω USB.",
+  "Aldonadi kameraon...": "Προσθέστε μια κάμερα ...",
+  "Grupo": "Μία ομάδα",
+  "Inkluzivi foton prenitan ĉiun": "Συμπεριλάβετε μια φωτογραφία που τραβήχτηκε το καθένα",
+  "sekundo": "ένα δεύτερο",
+  "5 sekundoj": "5 δευτερόλεπτα",
+  "10 sekundoj": "10 δευτερόλεπτα",
+  "30 sekundoj": "30 δευτερόλεπτα",
+  "minuto": "λεπτό",
+  "5 minutoj": "5 λεπτά",
+  "10 minutoj": "10 λεπτά",
+  "30 minutoj": "30 λεπτά",
+  "horo": "ώρα",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Επιλέξτε το εύρος του χρόνου μεταξύ δύο επιλεγμένων εικόνων.",
+  "Filmo framfrekvenco": "Ρυθμός καρέ",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Επιλέξτε πόσο γρήγορα θέλετε να είναι το ένοπλο βίντεο.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Λαμβάνοντας υπόψη τον μεγάλο αριθμό εικόνων, η δημιουργία του βίντεό σας θα μπορούσε να πάρει κάποιο χρόνο!",
+  "Krei akselita video": "Δημιουργήστε ένα ένοπλο βίντεο",
+  "Filmo kreanta en progreso...": "Κινηματογραφική ταινία σε εξέλιξη ...",
+  "Zipitaj": "Φερμουάρ",
+  "Akselita video": "Έμφυτο βίντεο",
+  "Forigi ĉiujn": "Αφαίρεση όλων",
+  "Bildoj prenitaj de ": "Εικόνες που λαμβάνονται από",
+  "Filmoj registritaj de ": "Ταινίες που καταγράφηκαν από",
+  "montru ĉi tiun fotilon plenekranan": "Δείξτε αυτήν την κάμερα πλήρη -Screen",
+  "montri ĉiujn fotilojn": "Δείξτε όλες τις κάμερες",
+  "montru nur ĉi tiun fotilon": "Εμφάνιση μόνο αυτής της κάμερας",
+  "malfermaj bildoj retumilo": "Ανοίξτε το πρόγραμμα περιήγησης",
+  "malferma videoj retumilo": "Ανοίξτε το πρόγραμμα περιήγησης βίντεο",
+  "agordi ĉi tiun kameraon": "Ορίστε αυτήν την κάμερα",
+  "preni instantaron": "Για να πάρετε μια στιγμή",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Δεν έχετε ρυθμίσει ακόμα καμία κάμερα. Κάντε κλικ εδώ για να προσθέσετε ένα ...",
+  "enigu pozitivan nombron": "Εισαγάγετε έναν θετικό αριθμό",
+  "enigu pozitivan entjeran nombron": "Εισαγάγετε έναν θετικό ακέραιο αριθμό",
+  "enigu nombron": "Εισαγάγετε έναν αριθμό",
+  "enigu entjeran nombron": "Εισαγάγετε έναν ακέραιο αριθμό",
+  " inter ": "μεταξύ",
+  " kaj ": "και",
+  " pli ol ": "περισσότερο από",
+  " malpli ol ": "λιγότερο από",
+  "enigu validan tempon en la sekva formato: HH:MM": "Εισαγάγετε έναν έγκυρο χρόνο στην ακόλουθη μορφή: HH: mm",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Εισαγάγετε μια έγκυρη διεύθυνση URL (π.χ. http://ekzemplo.com:8080/cams/)",
+  "fermi": "να κλείσω",
+  "Ne": "Οχι",
+  "Jes": "Ναί",
+  "Bone": "Εντάξει",
+  "Auto Exposure": "Αυτόματη έκθεση",
+  "Backlight Compensation": "Αντιστάθμιση οπίσθιου φωτισμού",
+  "Brightness": "Λάμψη",
+  "Contrast": "Αντίθεση",
+  "Exposure Absolute": "Έκθεση απολύτως",
+  "Exposure Auto": "Εκθέσεις αυτοκινήτων",
+  "Exposure Auto Priority": "Προτεραιότητα αυτόματης έκθεσης",
+  "Exposure Time Absolute": "Ο χρόνος έκθεσης απολύτως",
+  "Focus Absolute": "Επικεντρώνεται απολύτως",
+  "Focus Auto": "Εστίαση αυτοκινήτων",
+  "Gain": "Κέρδος",
+  "Gamma": "Γάμμα",
+  "Hue": "Απόχρωση",
+  "Led1 Mode": "Λειτουργία LED1",
+  "Led1 Frequency": "Συχνότητα LED1",
+  "Pan Absolute": "Παναγιά απολύτως",
+  "Power Line Frequency": "Συχνότητα γραμμής ισχύος",
+  "Saturation": "Κορεσμός",
+  "Sharpness": "Οξύτητα",
+  "Tilt Absolute": "Κλίση απολύτως",
+  "White Balance Temperature": "Θερμοκρασία ισορροπίας λευκού",
+  "White Balance Temperature Auto": "Θερμοκρασία ισορροπίας λευκού",
+  "Zoom Absolute": "Μεγέθυνση απολύτως",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.en.json
+++ b/motioneye/static/js/motioneye.en.json
@@ -1,164 +1,176 @@
-{"":{"language":"en","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "special characters are not allowed in password"
-,"Ĉi tiu kampo estas deviga": "This field is required"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "special characters are not allowed in camera's name"
-,"valoro devas esti multoblo de 8": "value must be a multiple of 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "special characters are not allowed in root directory name"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "files cannot be created directly on the root of your system"
-,"enigu validan retpoŝtadreson": "enter a valid email address"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "enter a list of comma-separated valid email addresses"
-,"specialaj signoj ne rajtas en dosiernomo": "special characters are not allowed in filename"
-,"enigu validan valoron": "enter a valid value"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "This will recursively remove all files present in the cloud folder \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", not just those uploaded by motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "This will recursively remove all old media files present in the directory \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", not just those created by motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Cannot edit the mask without a valid camera image!"
-,"Propra": "Custom"
-,"Propra dosierindiko": "Custom Path"
-,"Retan kunlokon": "Network Share"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Your browser doesn't implement this function!"
-,"Apliki": "Apply"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Make sure all configuration options are valid!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "This will reboot the system. Continue?"
-,"Vere fermiti sistemon?": "Really shut down?"
-,"Malŝaltita": "Powered Off"
-,"Ĉu vere restartigi ?": "Really reboot?"
-,"La sistemo rekomencis!": "The system has been rebooted!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Please apply the modified settings first!"
-,"Neniu fotilo por forigi!": "No camera to remove!"
-,"Ĉu forigi kameraon ": "Remove camera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye is up to date (current version: "
-,"Nova versio havebla: ": "New version available: "
-,". Ĝisdatigi?": ". Update?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye was successfully updated!"
-,"Ĝisdatigo malsukcesis!": "Update failed!"
-,"La ĝisdatiga procezo malsukcesis!": "The update process failed!"
-,"Rezerva dosiero": "Backup File"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "the backup file you have previously downloaded."
-,"Restaŭrigi Agordon": "Restore Configuration"
-,"Restaŭriganta agordon ...": "Restoring configuration ..."
-,"La agordo restaŭrigis!": "The configuration has been restored!"
-,"Malsukcesis restaŭri la agordon!": "Failed to restore configuration!"
-,"Aliri la alŝutan servon malsukcesis: ": "Accessing the upload service failed: "
-,"Aliri la alŝutan servon sukcesis!": "Accessing the upload service succeeded!"
-,"Sciiga retpoŝto fiaskis:": "Notification email failed:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Make sure all configuration options are valid!"
-,"Sciiga Telegramo fiaskis:": "Notification Telegram failed:"
-,"Sciiga Telegramo sukcesis!": "Notification Telegram succeeded!"
-,"Aliro al retdividado fiaskis: ": "Accessing network share failed: "
-,"Aliro al retdividado sukcesis!": "Accessing network share succeeded!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Really delete this file?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Really delete all pictures from \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Really remove all movies from \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Really delete all ungrouped pictures?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Really delete all ungrouped movies?"
-,"aldonadi kameraon...": "add camera ..."
-,"Uzantnomo": "Username"
-,"Pasvorto": "Password"
-,"Memoru min": "Remember me"
-,"Ensaluti": "Login"
-,"Nuligi": "Cancel"
-,"Vi abortis la filmeton.": "You aborted the video."
-,"Reto eraro okazis.": "A network error occurred."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Media decode error or unsupported media features."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format not supported or inaccessible/unsuitable for playback."
-,"Nekonata eraro okazis.": "Unknown error occurred."
-,"Eraro : ": "Error : "
-,"antaŭa bildo": "previous picture"
-,"ludi": "play"
-,"ludi * 5 kaj enĉenigi": "play * 5 and chain"
-,"sekva bildo": "next picture"
-,"Fermi": "Close"
-,"Elŝuti": "Download"
-,"Forigi": "Remove"
-,"Kamerao tipo": "Camera Type"
-,"Loka V4L2-kamerao": "Local V4L2 Camera"
-,"Loka MMAL-kamerao": "Local MMAL Camera"
-,"Reta kamerao": "Network Camera"
-,"Fora motionEye kamerao": "Remote motionEye Camera"
-,"Simpla MJPEG-kamerao": "Simple MJPEG Camera"
-,"la speco de kamerao, kiun vi volas aldoni": "the type of camera you wish to add"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "the camera URL (eg http://example.com:8080/cam/)"
-,"uzantnomo...": "username ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "the username for the URL, if needed (eg admin)"
-,"pasvorto...": "password ..."
-,"la pasvorto por la URL, se bezonata": "the password for the URL, if needed"
-,"Kamerao": "Camera"
-,"la kameraon, kiun vi volas aldoni": "the camera you want to add"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Remote motionEye cameras are cameras installed behind another motionEye server. Adding them here will allow you to view and manage them remotely."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Network cameras (or IP cameras) are devices that natively stream RTSP/RTMP or MJPEG videos or plain JPEG images. Consult your device's manual to find out the correct RTSP, RTMP, MJPEG or JPEG URL."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Local MMAL cameras are devices that are connected directly to your motionEye system. These are usually board-specific cameras."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adding your device as a simple MJPEG camera instead of as a network camera will improve the framerate, but no motion detection, picture capturing or movie recording will be available for it. The camera must be accessible to both your server and your browser. This type of camera is not compatible with Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Local V4L2 cameras are camera devices that are connected directly to your motionEye system, usually via USB."
-,"Aldonadi kameraon...": "Add Camera ..."
-,"Grupo": "Group"
-,"Inkluzivi foton prenitan ĉiun": "Include a picture taken every"
-,"sekundo": "second"
-,"5 sekundoj": "5 seconds"
-,"10 sekundoj": "10 seconds"
-,"30 sekundoj": "30 seconds"
-,"minuto": "minute"
-,"5 minutoj": "5 minutes"
-,"10 minutoj": "10 minutes"
-,"30 minutoj": "30 minutes"
-,"horo": "hour"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "choose the interval of time between two selected pictures."
-,"Filmo framfrekvenco": "Movie framerate"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "choose how fast you want the timelapse playback to be."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Given the large number of pictures, creating your timelapse might take a while!"
-,"Krei akselita video": "Create Timelapse Movie"
-,"Filmo kreanta en progreso...": "Creating Timelapse Movie..."
-,"Zipitaj": "Zipped"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Delete all"
-,"Bildoj prenitaj de ": "Pictures taken by "
-,"Filmoj registritaj de ": "Movies recorded by "
-,"montru ĉi tiun fotilon plenekranan": "Show this camera fullscreen"
-,"montri ĉiujn fotilojn": "Show all cameras"
-,"montru nur ĉi tiun fotilon": "Show only this camera"
-,"malfermaj bildoj retumilo": "open pictures browser"
-,"malferma videoj retumilo": "open movies browser"
-,"agordi ĉi tiun kameraon": "configure this camera"
-,"preni instantaron": "take a snapshot"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "You have not configured any camera yet. Click here to add one..."
-,"enigu pozitivan nombron": "enter a positive number"
-,"enigu pozitivan entjeran nombron": "enter a positive integer"
-,"enigu nombron": "enter a number"
-,"enigu entjeran nombron": "enter an integer"
-," inter ": " between "
-," kaj ": " and "
-," pli ol ": " greater than "
-," malpli ol ": " smaller than "
-,"enigu validan tempon en la sekva formato: HH:MM": "enter valid time in the following format: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "enter a valid URL (e.g. http://example.com:8080/cams/)"
-,"fermi": "close"
-,"Ne": "No"
-,"Jes": "Yes"
-,"Bone": "OK"
-,"Auto Exposure": "Auto Exposure"
-,"Backlight Compensation": "Backlight Compensation"
-,"Brightness": "Brightness"
-,"Contrast": "Contrast"
-,"Exposure Absolute": "Exposure Absolute"
-,"Exposure Auto": "Exposure Auto"
-,"Exposure Auto Priority": "Exposure Auto Priority"
-,"Exposure Time Absolute": "Exposure Time Absolute"
-,"Focus Absolute": "Focus Absolute"
-,"Focus Auto": "Focus Auto"
-,"Gain": "Gain"
-,"Gamma": "Gamma"
-,"Hue": "Hue"
-,"Led1 Mode": "Led1 Mode"
-,"Led1 Frequency": "Led1 Frequency"
-,"Pan Absolute": "Pan Absolute"
-,"Power Line Frequency": "Power Line Frequency"
-,"Saturation": "Saturation"
-,"Sharpness": "Sharpness"
-,"Tilt Absolute": "Tilt Absolute"
-,"White Balance Temperature": "White Balance Temperature"
-,"White Balance Temperature Auto": "White Balance Temperature Auto"
-,"Zoom Absolute": "Zoom Absolute"
+{
+  "": {
+    "language": "en",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "special characters are not allowed in password",
+  "Ĉi tiu kampo estas deviga": "This field is required",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "special characters are not allowed in camera's name",
+  "valoro devas esti multoblo de 8": "value must be a multiple of 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "special characters are not allowed in root directory name",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "files cannot be created directly on the root of your system",
+  "enigu validan retpoŝtadreson": "enter a valid email address",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "enter a list of comma-separated valid email addresses",
+  "specialaj signoj ne rajtas en dosiernomo": "special characters are not allowed in filename",
+  "enigu validan valoron": "enter a valid value",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "This will recursively remove all files present in the cloud folder \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", not just those uploaded by motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "This will recursively remove all old media files present in the directory \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", not just those created by motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Cannot edit the mask without a valid camera image!",
+  "Propra": "Custom",
+  "Propra dosierindiko": "Custom Path",
+  "Retan kunlokon": "Network Share",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Your browser doesn't implement this function!",
+  "Apliki": "Apply",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Make sure all configuration options are valid!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "This will reboot the system. Continue?",
+  "Vere fermiti sistemon?": "Really shut down?",
+  "Malŝaltita": "Powered Off",
+  "Ĉu vere restartigi ?": "Really reboot?",
+  "La sistemo rekomencis!": "The system has been rebooted!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Please apply the modified settings first!",
+  "Neniu fotilo por forigi!": "No camera to remove!",
+  "Ĉu forigi kameraon ": "Remove camera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye is up to date (current version: ",
+  "Nova versio havebla: ": "New version available: ",
+  ". Ĝisdatigi?": ". Update?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye was successfully updated!",
+  "Ĝisdatigo malsukcesis!": "Update failed!",
+  "La ĝisdatiga procezo malsukcesis!": "The update process failed!",
+  "Rezerva dosiero": "Backup File",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "the backup file you have previously downloaded.",
+  "Restaŭrigi Agordon": "Restore Configuration",
+  "Restaŭriganta agordon ...": "Restoring configuration ...",
+  "La agordo restaŭrigis!": "The configuration has been restored!",
+  "Malsukcesis restaŭri la agordon!": "Failed to restore configuration!",
+  "Aliri la alŝutan servon malsukcesis: ": "Accessing the upload service failed: ",
+  "Aliri la alŝutan servon sukcesis!": "Accessing the upload service succeeded!",
+  "Sciiga retpoŝto fiaskis:": "Notification email failed:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Make sure all configuration options are valid!",
+  "Sciiga Telegramo fiaskis:": "Notification Telegram failed:",
+  "Sciiga Telegramo sukcesis!": "Notification Telegram succeeded!",
+  "Aliro al retdividado fiaskis: ": "Accessing network share failed: ",
+  "Aliro al retdividado sukcesis!": "Accessing network share succeeded!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Really delete this file?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Really delete all pictures from \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Really remove all movies from \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Really delete all ungrouped pictures?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Really delete all ungrouped movies?",
+  "aldonadi kameraon...": "add camera ...",
+  "Uzantnomo": "Username",
+  "Pasvorto": "Password",
+  "Memoru min": "Remember me",
+  "Ensaluti": "Login",
+  "Nuligi": "Cancel",
+  "Vi abortis la filmeton.": "You aborted the video.",
+  "Reto eraro okazis.": "A network error occurred.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Media decode error or unsupported media features.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format not supported or inaccessible/unsuitable for playback.",
+  "Nekonata eraro okazis.": "Unknown error occurred.",
+  "Eraro : ": "Error : ",
+  "antaŭa bildo": "previous picture",
+  "ludi": "play",
+  "ludi * 5 kaj enĉenigi": "play * 5 and chain",
+  "sekva bildo": "next picture",
+  "Fermi": "Close",
+  "Elŝuti": "Download",
+  "Forigi": "Remove",
+  "Kamerao tipo": "Camera Type",
+  "Loka V4L2-kamerao": "Local V4L2 Camera",
+  "Loka MMAL-kamerao": "Local MMAL Camera",
+  "Reta kamerao": "Network Camera",
+  "Fora motionEye kamerao": "Remote motionEye Camera",
+  "Simpla MJPEG-kamerao": "Simple MJPEG Camera",
+  "la speco de kamerao, kiun vi volas aldoni": "the type of camera you wish to add",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "the camera URL (eg http://example.com:8080/cam/)",
+  "uzantnomo...": "username ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "the username for the URL, if needed (eg admin)",
+  "pasvorto...": "password ...",
+  "la pasvorto por la URL, se bezonata": "the password for the URL, if needed",
+  "Kamerao": "Camera",
+  "la kameraon, kiun vi volas aldoni": "the camera you want to add",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Remote motionEye cameras are cameras installed behind another motionEye server. Adding them here will allow you to view and manage them remotely.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Network cameras (or IP cameras) are devices that natively stream RTSP/RTMP or MJPEG videos or plain JPEG images. Consult your device's manual to find out the correct RTSP, RTMP, MJPEG or JPEG URL.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Local MMAL cameras are devices that are connected directly to your motionEye system. These are usually board-specific cameras.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adding your device as a simple MJPEG camera instead of as a network camera will improve the framerate, but no motion detection, picture capturing or movie recording will be available for it. The camera must be accessible to both your server and your browser. This type of camera is not compatible with Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Local V4L2 cameras are camera devices that are connected directly to your motionEye system, usually via USB.",
+  "Aldonadi kameraon...": "Add Camera ...",
+  "Grupo": "Group",
+  "Inkluzivi foton prenitan ĉiun": "Include a picture taken every",
+  "sekundo": "second",
+  "5 sekundoj": "5 seconds",
+  "10 sekundoj": "10 seconds",
+  "30 sekundoj": "30 seconds",
+  "minuto": "minute",
+  "5 minutoj": "5 minutes",
+  "10 minutoj": "10 minutes",
+  "30 minutoj": "30 minutes",
+  "horo": "hour",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "choose the interval of time between two selected pictures.",
+  "Filmo framfrekvenco": "Movie framerate",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "choose how fast you want the timelapse playback to be.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Given the large number of pictures, creating your timelapse might take a while!",
+  "Krei akselita video": "Create Timelapse Movie",
+  "Filmo kreanta en progreso...": "Creating Timelapse Movie...",
+  "Zipitaj": "Zipped",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Delete all",
+  "Bildoj prenitaj de ": "Pictures taken by ",
+  "Filmoj registritaj de ": "Movies recorded by ",
+  "montru ĉi tiun fotilon plenekranan": "Show this camera fullscreen",
+  "montri ĉiujn fotilojn": "Show all cameras",
+  "montru nur ĉi tiun fotilon": "Show only this camera",
+  "malfermaj bildoj retumilo": "open pictures browser",
+  "malferma videoj retumilo": "open movies browser",
+  "agordi ĉi tiun kameraon": "configure this camera",
+  "preni instantaron": "take a snapshot",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "You have not configured any camera yet. Click here to add one...",
+  "enigu pozitivan nombron": "enter a positive number",
+  "enigu pozitivan entjeran nombron": "enter a positive integer",
+  "enigu nombron": "enter a number",
+  "enigu entjeran nombron": "enter an integer",
+  " inter ": " between ",
+  " kaj ": " and ",
+  " pli ol ": " greater than ",
+  " malpli ol ": " smaller than ",
+  "enigu validan tempon en la sekva formato: HH:MM": "enter valid time in the following format: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "enter a valid URL (e.g. http://example.com:8080/cams/)",
+  "fermi": "close",
+  "Ne": "No",
+  "Jes": "Yes",
+  "Bone": "OK",
+  "Auto Exposure": "Auto Exposure",
+  "Backlight Compensation": "Backlight Compensation",
+  "Brightness": "Brightness",
+  "Contrast": "Contrast",
+  "Exposure Absolute": "Exposure Absolute",
+  "Exposure Auto": "Exposure Auto",
+  "Exposure Auto Priority": "Exposure Auto Priority",
+  "Exposure Time Absolute": "Exposure Time Absolute",
+  "Focus Absolute": "Focus Absolute",
+  "Focus Auto": "Focus Auto",
+  "Gain": "Gain",
+  "Gamma": "Gamma",
+  "Hue": "Hue",
+  "Led1 Mode": "Led1 Mode",
+  "Led1 Frequency": "Led1 Frequency",
+  "Pan Absolute": "Pan Absolute",
+  "Power Line Frequency": "Power Line Frequency",
+  "Saturation": "Saturation",
+  "Sharpness": "Sharpness",
+  "Tilt Absolute": "Tilt Absolute",
+  "White Balance Temperature": "White Balance Temperature",
+  "White Balance Temperature Auto": "White Balance Temperature Auto",
+  "Zoom Absolute": "Zoom Absolute",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.es.json
+++ b/motioneye/static/js/motioneye.es.json
@@ -1,164 +1,176 @@
-{"":{"language":"es","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "no se permiten caracteres especiales en la contraseña"
-,"Ĉi tiu kampo estas deviga": "Este campo es obligatorio"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "no se permiten caracteres especiales en el nombre de la cámara"
-,"valoro devas esti multoblo de 8": "el valor debe ser un múltiplo de 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "no se permiten caracteres especiales en el nombre del directorio raíz"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "los archivos no se pueden crear directamente en la raíz de su sistema"
-,"enigu validan retpoŝtadreson": "ingrese una dirección de correo electrónico válida"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "ingrese una lista de direcciones de correo electrónico válidas separadas por comas"
-,"specialaj signoj ne rajtas en dosiernomo": "no se permiten caracteres especiales en el nombre del archivo"
-,"enigu validan valoron": "ingrese un valor válido"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Esto eliminará recursivamente todos los archivos en la carpeta de la nube \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", no solo los subidos por motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Esto eliminará de forma recursiva todos los archivos multimedia antiguos en la carpeta \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", no solo los creados por motion Eye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "¡No se puede editar la máscara sin una imagen de cámara válida!"
-,"Propra": "Personalizado"
-,"Propra dosierindiko": "Ruta personalizada"
-,"Retan kunlokon": "Carpeta Compartida en red"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "¡Su navegador no implementa esta función!"
-,"Apliki": "Aplicar"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "¡Asegúrese de que todas las opciones de configuración sean válidas!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Esto reiniciará el sistema. ¿Continuar?"
-,"Vere fermiti sistemon?": "¿Realmente desea apagar el sistema?"
-,"Malŝaltita": "Apagado"
-,"Ĉu vere restartigi ?": "¿Realmente desea reiniciar?"
-,"La sistemo rekomencis!": "¡El sistema ha sido reiniciado!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "¡Por favor aplique primero la configuración modificada!"
-,"Neniu fotilo por forigi!": "¡No hay cámara para quitar!"
-,"Ĉu forigi kameraon ": "Quitar cámara "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye está actualizado (versión actual: "
-,"Nova versio havebla: ": "Nueva versión disponible: "
-,". Ĝisdatigi?": ". Actualizar?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye ha sido actualizado con éxito!"
-,"Ĝisdatigo malsukcesis!": "¡Actualización fallida!"
-,"La ĝisdatiga procezo malsukcesis!": "¡El proceso de actualización falló!"
-,"Rezerva dosiero": "Archivo de respaldo"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "El archivo de respaldo que descargó anteriormente."
-,"Restaŭrigi Agordon": "Restaurar configuración"
-,"Restaŭriganta agordon ...": "Se está restaurando la configuración ..."
-,"La agordo restaŭrigis!": "¡La configuración ha sido restaurada!"
-,"Malsukcesis restaŭri la agordon!": "¡Error al restaurar la configuración!"
-,"Aliri la alŝutan servon malsukcesis: ": "Error al acceder al servicio de carga: "
-,"Aliri la alŝutan servon sukcesis!": "¡El acceso al servicio de carga fue exitoso!"
-,"Sciiga retpoŝto fiaskis:": "La notificación por correo ha fallado:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "¡Asegúrese de que todas las opciones de configuración sean válidas!"
-,"Sciiga Telegramo fiaskis:": "Falló en la notificación de telegram:"
-,"Sciiga Telegramo sukcesis!": "¡La notificación de telegram funcionó!"
-,"Aliro al retdividado fiaskis: ": "El acceso a la transmisión de red falló: "
-,"Aliro al retdividado sukcesis!": "¡El acceso a la carpeta compartida ha sido exitoso!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "¿Realmente desea borrar este archivo?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "¿Realmente deseas eliminar todas las imágenes de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "¿Eliminar realmente todas las películas de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "¿Realmente desea eliminar todas las imágenes desagrupadas?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "¿Realmente deseas eliminar todas las películas desagrupadas?"
-,"aldonadi kameraon...": "agregar cámara ..."
-,"Uzantnomo": "Nombre de usuario"
-,"Pasvorto": "Contraseña"
-,"Memoru min": "Recordar"
-,"Ensaluti": "Iniciar sesión"
-,"Nuligi": "Cancelar"
-,"Vi abortis la filmeton.": "Abortaste el video."
-,"Reto eraro okazis.": "Se produjo un error de red."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Error de decodificación o función no soportada."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato no compatible o inaccesible/inadecuado para la reproducción."
-,"Nekonata eraro okazis.": "Ocurrió un error desconocido."
-,"Eraro : ": "Error: "
-,"antaŭa bildo": "imagen anterior"
-,"ludi": "reproducir"
-,"ludi * 5 kaj enĉenigi": "reproducir * 5 y encadenar"
-,"sekva bildo": "siguiente imagen"
-,"Fermi": "Cerrar"
-,"Elŝuti": "Descargar"
-,"Forigi": "Eliminar"
-,"Kamerao tipo": "Tipo de cámara"
-,"Loka V4L2-kamerao": "Cámara local V4L2"
-,"Loka MMAL-kamerao": "Cámara local MMAL"
-,"Reta kamerao": "Camara en la red"
-,"Fora motionEye kamerao": "Camara remota de motionEye"
-,"Simpla MJPEG-kamerao": "Cámara simple MJPEG"
-,"la speco de kamerao, kiun vi volas aldoni": "el tipo de cámara que desea agregar"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://ejemplo.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "la URL de la cámara (por ejemplo, http://ejemplo.com:8080/cam/)"
-,"uzantnomo...": "nombre de usuario ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "el nombre de usuario para la URL, si es necesario (por ejemplo, administrador)"
-,"pasvorto...": "contraseña ..."
-,"la pasvorto por la URL, se bezonata": "la contraseña de la URL, si es necesario"
-,"Kamerao": "Cámara"
-,"la kameraon, kiun vi volas aldoni": "la cámara que quieres agregar"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Las cámaras motionEye remotas son cámaras instaladas detrás de otro servidor MotionEye. Agregarlos aquí le permitirá verlos y administrarlos de forma remota."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Las cámaras de red (o cámaras IP) son dispositivos que transmiten de forma nativa videos RTSP / RTMP o MJPEG o imágenes JPEG simples. Consulte el manual de su dispositivo para averiguar la URL correcta de RTSP, RTMP, MJPEG o JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Las cámaras MMAL locales son dispositivos que están conectados directamente a su sistema motionEye. Estas suelen ser cámaras específicas para tarjetas."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Agregar su dispositivo como una cámara MJPEG simple en lugar de una cámara de red mejorará la velocidad de fotogramas, pero no estará disponible la detección de movimiento, captura de imágenes o grabación de películas. La cámara debe ser accesible para su servidor y su navegador. Este tipo de cámara no es compatible con Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Las cámaras locales V4L2 son dispositivos de cámara conectados directamente a su sistema motionEye, generalmente a través de USB."
-,"Aldonadi kameraon...": "Agregar cámara ..."
-,"Grupo": "Grupo"
-,"Inkluzivi foton prenitan ĉiun": "Incluya una foto tomada cada"
-,"sekundo": "segundo"
-,"5 sekundoj": "5 segundos"
-,"10 sekundoj": "10 segundos"
-,"30 sekundoj": "30 segundos"
-,"minuto": "minuto"
-,"5 minutoj": "5 minutos"
-,"10 minutoj": "10 minutos"
-,"30 minutoj": "30 minutos"
-,"horo": "hora"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seleccione el intervalo de tiempo entre dos imágenes seleccionadas."
-,"Filmo framfrekvenco": "Velocidad de fotogramas de la película"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Elija la velocidad de reproducción del timelapse."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Teniendo en cuenta la gran cantidad de imágenes, ¡crear su video podría tomar algún tiempo!"
-,"Krei akselita video": "Crea un timelapse"
-,"Filmo kreanta en progreso...": "Creando un timelapse..."
-,"Zipitaj": "Comprimido"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Eliminar todos"
-,"Bildoj prenitaj de ": "Fotografías tomadas por "
-,"Filmoj registritaj de ": "Películas grabadas por "
-,"montru ĉi tiun fotilon plenekranan": "Mostrar esta cámara a pantalla completa"
-,"montri ĉiujn fotilojn": "Mostrar todas las cámaras"
-,"montru nur ĉi tiun fotilon": "Mostrar solo esta cámara"
-,"malfermaj bildoj retumilo": "abrir el navegador de imágenes"
-,"malferma videoj retumilo": "abrir navegador de videos"
-,"agordi ĉi tiun kameraon": "configurar esta cámara"
-,"preni instantaron": "tomar una instantánea"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Aún no has configurado ninguna cámara. Haga clic aquí para añadir una..."
-,"enigu pozitivan nombron": "ingrese un número positivo"
-,"enigu pozitivan entjeran nombron": "ingrese un entero positivo"
-,"enigu nombron": "ingrese un número"
-,"enigu entjeran nombron": "ingrese un número entero"
-," inter ": " en el medio "
-," kaj ": " y "
-," pli ol ": " mas que "
-," malpli ol ": " menos de "
-,"enigu validan tempon en la sekva formato: HH:MM": "ingrese el tiempo válido en el siguiente formato: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ingrese una URL válida (por ejemplo, http://ejemplo.com:8080/cams/)"
-,"fermi": "cerrar"
-,"Ne": "No"
-,"Jes": "Sí"
-,"Bone": "Ok"
-,"Auto Exposure": "Exposición automática"
-,"Backlight Compensation": "Compensación de retroiluminación"
-,"Brightness": "Brillo"
-,"Contrast": "Contraste"
-,"Exposure Absolute": "Exposición absoluta"
-,"Exposure Auto": "Exposición automática"
-,"Exposure Auto Priority": "Prioridad automática de exposición"
-,"Exposure Time Absolute": "Tiempo de exposición absoluto"
-,"Focus Absolute": "Enfoque absoluto"
-,"Focus Auto": "Auto-foco"
-,"Gain": "Ganancia"
-,"Gamma": "Gama"
-,"Hue": "Tinte"
-,"Led1 Mode": "Modo LED1"
-,"Led1 Frequency": "Frecuencia LED1"
-,"Pan Absolute": "Pan absoluto"
-,"Power Line Frequency": "Frecuencia de línea eléctrica"
-,"Saturation": "Saturación"
-,"Sharpness": "Nitidez"
-,"Tilt Absolute": "Inclinado absoluto"
-,"White Balance Temperature": "Temperatura de balance de blancos"
-,"White Balance Temperature Auto": "Temperatura de balance de blancos automática"
-,"Zoom Absolute": "Zoom absoluto"
+{
+  "": {
+    "language": "es",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "no se permiten caracteres especiales en la contraseña",
+  "Ĉi tiu kampo estas deviga": "Este campo es obligatorio",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "no se permiten caracteres especiales en el nombre de la cámara",
+  "valoro devas esti multoblo de 8": "el valor debe ser un múltiplo de 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "no se permiten caracteres especiales en el nombre del directorio raíz",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "los archivos no se pueden crear directamente en la raíz de su sistema",
+  "enigu validan retpoŝtadreson": "ingrese una dirección de correo electrónico válida",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "ingrese una lista de direcciones de correo electrónico válidas separadas por comas",
+  "specialaj signoj ne rajtas en dosiernomo": "no se permiten caracteres especiales en el nombre del archivo",
+  "enigu validan valoron": "ingrese un valor válido",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Esto eliminará recursivamente todos los archivos en la carpeta de la nube \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", no solo los subidos por motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Esto eliminará de forma recursiva todos los archivos multimedia antiguos en la carpeta \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", no solo los creados por motion Eye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "¡No se puede editar la máscara sin una imagen de cámara válida!",
+  "Propra": "Personalizado",
+  "Propra dosierindiko": "Ruta personalizada",
+  "Retan kunlokon": "Carpeta Compartida en red",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "¡Su navegador no implementa esta función!",
+  "Apliki": "Aplicar",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "¡Asegúrese de que todas las opciones de configuración sean válidas!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Esto reiniciará el sistema. ¿Continuar?",
+  "Vere fermiti sistemon?": "¿Realmente desea apagar el sistema?",
+  "Malŝaltita": "Apagado",
+  "Ĉu vere restartigi ?": "¿Realmente desea reiniciar?",
+  "La sistemo rekomencis!": "¡El sistema ha sido reiniciado!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "¡Por favor aplique primero la configuración modificada!",
+  "Neniu fotilo por forigi!": "¡No hay cámara para quitar!",
+  "Ĉu forigi kameraon ": "Quitar cámara ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye está actualizado (versión actual: ",
+  "Nova versio havebla: ": "Nueva versión disponible: ",
+  ". Ĝisdatigi?": ". Actualizar?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye ha sido actualizado con éxito!",
+  "Ĝisdatigo malsukcesis!": "¡Actualización fallida!",
+  "La ĝisdatiga procezo malsukcesis!": "¡El proceso de actualización falló!",
+  "Rezerva dosiero": "Archivo de respaldo",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "El archivo de respaldo que descargó anteriormente.",
+  "Restaŭrigi Agordon": "Restaurar configuración",
+  "Restaŭriganta agordon ...": "Se está restaurando la configuración ...",
+  "La agordo restaŭrigis!": "¡La configuración ha sido restaurada!",
+  "Malsukcesis restaŭri la agordon!": "¡Error al restaurar la configuración!",
+  "Aliri la alŝutan servon malsukcesis: ": "Error al acceder al servicio de carga: ",
+  "Aliri la alŝutan servon sukcesis!": "¡El acceso al servicio de carga fue exitoso!",
+  "Sciiga retpoŝto fiaskis:": "La notificación por correo ha fallado:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "¡Asegúrese de que todas las opciones de configuración sean válidas!",
+  "Sciiga Telegramo fiaskis:": "Falló en la notificación de telegram:",
+  "Sciiga Telegramo sukcesis!": "¡La notificación de telegram funcionó!",
+  "Aliro al retdividado fiaskis: ": "El acceso a la transmisión de red falló: ",
+  "Aliro al retdividado sukcesis!": "¡El acceso a la carpeta compartida ha sido exitoso!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "¿Realmente desea borrar este archivo?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "¿Realmente deseas eliminar todas las imágenes de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "¿Eliminar realmente todas las películas de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "¿Realmente desea eliminar todas las imágenes desagrupadas?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "¿Realmente deseas eliminar todas las películas desagrupadas?",
+  "aldonadi kameraon...": "agregar cámara ...",
+  "Uzantnomo": "Nombre de usuario",
+  "Pasvorto": "Contraseña",
+  "Memoru min": "Recordar",
+  "Ensaluti": "Iniciar sesión",
+  "Nuligi": "Cancelar",
+  "Vi abortis la filmeton.": "Abortaste el video.",
+  "Reto eraro okazis.": "Se produjo un error de red.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Error de decodificación o función no soportada.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato no compatible o inaccesible/inadecuado para la reproducción.",
+  "Nekonata eraro okazis.": "Ocurrió un error desconocido.",
+  "Eraro : ": "Error: ",
+  "antaŭa bildo": "imagen anterior",
+  "ludi": "reproducir",
+  "ludi * 5 kaj enĉenigi": "reproducir * 5 y encadenar",
+  "sekva bildo": "siguiente imagen",
+  "Fermi": "Cerrar",
+  "Elŝuti": "Descargar",
+  "Forigi": "Eliminar",
+  "Kamerao tipo": "Tipo de cámara",
+  "Loka V4L2-kamerao": "Cámara local V4L2",
+  "Loka MMAL-kamerao": "Cámara local MMAL",
+  "Reta kamerao": "Camara en la red",
+  "Fora motionEye kamerao": "Camara remota de motionEye",
+  "Simpla MJPEG-kamerao": "Cámara simple MJPEG",
+  "la speco de kamerao, kiun vi volas aldoni": "el tipo de cámara que desea agregar",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://ejemplo.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "la URL de la cámara (por ejemplo, http://ejemplo.com:8080/cam/)",
+  "uzantnomo...": "nombre de usuario ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "el nombre de usuario para la URL, si es necesario (por ejemplo, administrador)",
+  "pasvorto...": "contraseña ...",
+  "la pasvorto por la URL, se bezonata": "la contraseña de la URL, si es necesario",
+  "Kamerao": "Cámara",
+  "la kameraon, kiun vi volas aldoni": "la cámara que quieres agregar",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Las cámaras motionEye remotas son cámaras instaladas detrás de otro servidor MotionEye. Agregarlos aquí le permitirá verlos y administrarlos de forma remota.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Las cámaras de red (o cámaras IP) son dispositivos que transmiten de forma nativa videos RTSP / RTMP o MJPEG o imágenes JPEG simples. Consulte el manual de su dispositivo para averiguar la URL correcta de RTSP, RTMP, MJPEG o JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Las cámaras MMAL locales son dispositivos que están conectados directamente a su sistema motionEye. Estas suelen ser cámaras específicas para tarjetas.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Agregar su dispositivo como una cámara MJPEG simple en lugar de una cámara de red mejorará la velocidad de fotogramas, pero no estará disponible la detección de movimiento, captura de imágenes o grabación de películas. La cámara debe ser accesible para su servidor y su navegador. Este tipo de cámara no es compatible con Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Las cámaras locales V4L2 son dispositivos de cámara conectados directamente a su sistema motionEye, generalmente a través de USB.",
+  "Aldonadi kameraon...": "Agregar cámara ...",
+  "Grupo": "Grupo",
+  "Inkluzivi foton prenitan ĉiun": "Incluya una foto tomada cada",
+  "sekundo": "segundo",
+  "5 sekundoj": "5 segundos",
+  "10 sekundoj": "10 segundos",
+  "30 sekundoj": "30 segundos",
+  "minuto": "minuto",
+  "5 minutoj": "5 minutos",
+  "10 minutoj": "10 minutos",
+  "30 minutoj": "30 minutos",
+  "horo": "hora",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seleccione el intervalo de tiempo entre dos imágenes seleccionadas.",
+  "Filmo framfrekvenco": "Velocidad de fotogramas de la película",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Elija la velocidad de reproducción del timelapse.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Teniendo en cuenta la gran cantidad de imágenes, ¡crear su video podría tomar algún tiempo!",
+  "Krei akselita video": "Crea un timelapse",
+  "Filmo kreanta en progreso...": "Creando un timelapse...",
+  "Zipitaj": "Comprimido",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Eliminar todos",
+  "Bildoj prenitaj de ": "Fotografías tomadas por ",
+  "Filmoj registritaj de ": "Películas grabadas por ",
+  "montru ĉi tiun fotilon plenekranan": "Mostrar esta cámara a pantalla completa",
+  "montri ĉiujn fotilojn": "Mostrar todas las cámaras",
+  "montru nur ĉi tiun fotilon": "Mostrar solo esta cámara",
+  "malfermaj bildoj retumilo": "abrir el navegador de imágenes",
+  "malferma videoj retumilo": "abrir navegador de videos",
+  "agordi ĉi tiun kameraon": "configurar esta cámara",
+  "preni instantaron": "tomar una instantánea",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Aún no has configurado ninguna cámara. Haga clic aquí para añadir una...",
+  "enigu pozitivan nombron": "ingrese un número positivo",
+  "enigu pozitivan entjeran nombron": "ingrese un entero positivo",
+  "enigu nombron": "ingrese un número",
+  "enigu entjeran nombron": "ingrese un número entero",
+  " inter ": " en el medio ",
+  " kaj ": " y ",
+  " pli ol ": " mas que ",
+  " malpli ol ": " menos de ",
+  "enigu validan tempon en la sekva formato: HH:MM": "ingrese el tiempo válido en el siguiente formato: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ingrese una URL válida (por ejemplo, http://ejemplo.com:8080/cams/)",
+  "fermi": "cerrar",
+  "Ne": "No",
+  "Jes": "Sí",
+  "Bone": "Ok",
+  "Auto Exposure": "Exposición automática",
+  "Backlight Compensation": "Compensación de retroiluminación",
+  "Brightness": "Brillo",
+  "Contrast": "Contraste",
+  "Exposure Absolute": "Exposición absoluta",
+  "Exposure Auto": "Exposición automática",
+  "Exposure Auto Priority": "Prioridad automática de exposición",
+  "Exposure Time Absolute": "Tiempo de exposición absoluto",
+  "Focus Absolute": "Enfoque absoluto",
+  "Focus Auto": "Auto-foco",
+  "Gain": "Ganancia",
+  "Gamma": "Gama",
+  "Hue": "Tinte",
+  "Led1 Mode": "Modo LED1",
+  "Led1 Frequency": "Frecuencia LED1",
+  "Pan Absolute": "Pan absoluto",
+  "Power Line Frequency": "Frecuencia de línea eléctrica",
+  "Saturation": "Saturación",
+  "Sharpness": "Nitidez",
+  "Tilt Absolute": "Inclinado absoluto",
+  "White Balance Temperature": "Temperatura de balance de blancos",
+  "White Balance Temperature Auto": "Temperatura de balance de blancos automática",
+  "Zoom Absolute": "Zoom absoluto",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.fi.json
+++ b/motioneye/static/js/motioneye.fi.json
@@ -1,164 +1,176 @@
-{"":{"language":"fi","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "erikoismerkkejä ei sallita salasanassa"
-,"Ĉi tiu kampo estas deviga": "Tämä kenttä vaaditaan"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "erikoismerkit eivät ole sallittuja kameran nimessä"
-,"valoro devas esti multoblo de 8": "arvon on oltava 8:n kerrannainen"
-,"specialaj signoj ne rajtas en radika voja nomo": "erikoismerkit eivät ole sallittuja juurihakemiston nimessä"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "tiedostoja ei voi luoda suoraan järjestelmän juureen"
-,"enigu validan retpoŝtadreson": "syötä voimassa oleva sähköpostiosoite"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "kirjoita pilkuilla eroteltu luettelo kelvollisista sähköpostiosoitteista"
-,"specialaj signoj ne rajtas en dosiernomo": "erikoismerkit eivät ole sallittuja tiedoston nimessä"
-,"enigu validan valoron": "syötä kelvollinen arvo"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Tämä poistaa rekursiivisesti kaikki pilvikansiossa olevat tiedostot ”"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", ei pelkästään motionEyen lataamat!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Tämä poistaa rekursiivisesti kaikki vanhat mediatiedostot kansiosta \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", ei vain motionEyen luomat!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Maskia ei voida muokata ilman kelvollista kuvaa kameralta!"
-,"Propra": "Mukautettu"
-,"Propra dosierindiko": "Mukautettu palku"
-,"Retan kunlokon": "Verkkojako"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Selaimesi ei tue tätä toimintoa!"
-,"Apliki": "Käytä"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Varmista, että kaikki asetukset ovat kelvollisia!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Tämä käynnistää järjestelmän uudelleen. Jatketaanko?"
-,"Vere fermiti sistemon?": "Haluatko varmasti sammuttaa?"
-,"Malŝaltita": "Sammutettu"
-,"Ĉu vere restartigi ?": "Haluatko varmasti käynnistää uudelleen?"
-,"La sistemo rekomencis!": "Järjestelmä on käynnistetty uudelleen!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Ole hyvä, ja ota käyttöön mukautetut asetukset ensin!"
-,"Neniu fotilo por forigi!": "Ei kameraa poistettavaksi!"
-,"Ĉu forigi kameraon ": "Poista kamera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye on päivitetty (tämänhetkinen versio: "
-,"Nova versio havebla: ": "Uusi versio saatavilla: "
-,". Ĝisdatigi?": ". Päivitä?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye on päivitetty onnistuneesti!"
-,"Ĝisdatigo malsukcesis!": "Päivitys epäonnistui!"
-,"La ĝisdatiga procezo malsukcesis!": "Päivitysprosessi epäonnistui!"
-,"Rezerva dosiero": "Varmuuskopiotiedosto"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Varmuuskopiotiedosto, jonka latasit aiemmin."
-,"Restaŭrigi Agordon": "Palauta asetukset"
-,"Restaŭriganta agordon ...": "Palautetaan asetuksia ..."
-,"La agordo restaŭrigis!": "Asetukset on palautettu!"
-,"Malsukcesis restaŭri la agordon!": "Asetusten palauttaminen epäonnistui!"
-,"Aliri la alŝutan servon malsukcesis: ": "Lähetyspalveluun pääsy epäonnistui: "
-,"Aliri la alŝutan servon sukcesis!": "Latauspalveluun pääsy onnistui!"
-,"Sciiga retpoŝto fiaskis:": "Sähköposti-ilmoitus epäonnistui:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Varmista, että kaikki asetukset ovat kelvollisia!"
-,"Sciiga Telegramo fiaskis:": "Telegram ilmoitus epäonnistui:"
-,"Sciiga Telegramo sukcesis!": "Telegram-ilmoitus onnistui!"
-,"Aliro al retdividado fiaskis: ": "Verkkojakoon yhdistäminen epäonnistui: "
-,"Aliro al retdividado sukcesis!": "Verkkojakoon yhdistäminen onnistui!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Haluatko varmasti poistaa tämän tiedoston?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Haluatko varmasti poistaa kaikki kuvat \"%(ryhmästä/ryhmistä)\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Haluatko varmasti poistaa kaikki videot \"%(ryhmästä/ryhmistä)\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Haluatko varmasti poistaa kaikki ryhmiin kuulumattomat kuvat?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Haluatko varmasti poistaa kaikki ryhmiin kuulumattomat videot?"
-,"aldonadi kameraon...": "lisää kamera..."
-,"Uzantnomo": "Käyttäjänimi"
-,"Pasvorto": "Salasana"
-,"Memoru min": "Muista minut"
-,"Ensaluti": "Kirjaudu sisään"
-,"Nuligi": "Peruuta"
-,"Vi abortis la filmeton.": "Keskeytit videon."
-,"Reto eraro okazis.": "Tapahtui verkkovirhe."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Median purkuvirhe tai ei-tuettu mediaominaisuus."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formaattia ei tueta tai se ei ole saavutettavissa / sovellu toistettavaksi."
-,"Nekonata eraro okazis.": "Tapahtui tuntematon virhe."
-,"Eraro : ": "Virhe : "
-,"antaŭa bildo": "edellinen kuva"
-,"ludi": "toista"
-,"ludi * 5 kaj enĉenigi": "toista * 5 ja ketju"
-,"sekva bildo": "seuraava kuva"
-,"Fermi": "Sulje"
-,"Elŝuti": "Lataa"
-,"Forigi": "Poista"
-,"Kamerao tipo": "Kameran tyyppi"
-,"Loka V4L2-kamerao": "Paikallinen V4L2-kamera"
-,"Loka MMAL-kamerao": "Paikallinen MMAL-kamera"
-,"Reta kamerao": "Verkkokamera"
-,"Fora motionEye kamerao": "Etäkamera motionEye"
-,"Simpla MJPEG-kamerao": "Yksinkertainen MJPEG-kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "lisättävän kameran tyyppi"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://esimerkki.com:8765/kamerat/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kameran URL (esim. http://example.com:8080/kamera/)"
-,"uzantnomo...": "käyttäjänimi ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "URL-osoitteen käyttäjätunnus tarvittaessa (esim. ylläpitäjä)"
-,"pasvorto...": "salasana..."
-,"la pasvorto por la URL, se bezonata": "URL-osoitteen salasana tarvittaessa"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kamera, jonka haluat lisätä"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Etä-motionEye-kamera, joka on asennettu toisen MotionEye-palvelimen taakse. Niiden lisääminen antaa sinun katsoa ja hallita niitä etänä."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Verkkokamerat (tai IP-kamerat) ovat laitteita, jotka tukevat RTSP/RTMP- tai MJPEG-videoita tai yksinkertaisia JPEG-kuvia. Selvitä oikea RTSP, RTMP, MJPEG tai JPEG URL laitteesi käsikirjasta."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Paikalliset MMAL-kamerat ovat laitteita, jotka on liitetty suoraan motionEye-järjestelmään. Nämä ovat yleensä piirilevykohtiasia kameroita."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Laitteen lisääminen pelkäksi MJPEG-kameraksi verkkokameran sijaan parantaa päivitysnopeutta, mutta siihen ei ole saatavilla liikkeen tunnistusta, kuvan tallentamista tai videon tallennusta. Kameran on oltava palvelimen ja selaimesi käytettävissä. Tämä kamera ei ole yhteensopiva Internet Explorerin kanssa."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Paikalliset V4L2-kamerat ovat kameralaitteita, jotka on kytketty suoraan motionEye-järjestelmään, yleensä USB:n kautta."
-,"Aldonadi kameraon...": "Lisää kamera..."
-,"Grupo": "Ryhmä"
-,"Inkluzivi foton prenitan ĉiun": "Sisällytä kuva, joka on otettu joka"
-,"sekundo": "sekunti"
-,"5 sekundoj": "5 sekuntia"
-,"10 sekundoj": "10 sekuntia"
-,"30 sekundoj": "30 sekuntia"
-,"minuto": "minuuttia"
-,"5 minutoj": "5 minuuttia"
-,"10 minutoj": "10 minuuttia"
-,"30 minutoj": "30 minuuttia"
-,"horo": "tunti"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "valitse aikaväli kahden valitun kuvan välillä."
-,"Filmo framfrekvenco": "Videon kuvataajuus"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Valitse miten nopea haluat intervallivideon olevan."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Huomioiden suuren kuvien määrän, intervallivideon luominen saattaa kestää jonkin aikaa!"
-,"Krei akselita video": "Luo intervallivideo"
-,"Filmo kreanta en progreso...": "Luodaan intervallivideota..."
-,"Zipitaj": "Pakattu"
-,"Akselita video": "Ajastettu kuvaus"
-,"Forigi ĉiujn": "Poista kaikki"
-,"Bildoj prenitaj de ": "Kuvat, jotka on ottanut "
-,"Filmoj registritaj de ": "Videot, jotka on ottanut "
-,"montru ĉi tiun fotilon plenekranan": "Näytä tämä kamera koko ruudun tilassa"
-,"montri ĉiujn fotilojn": "Näytä kaikki kamerat"
-,"montru nur ĉi tiun fotilon": "Näytä vain tämä kamera"
-,"malfermaj bildoj retumilo": "avaa kuvaselain"
-,"malferma videoj retumilo": "avaa videoselain"
-,"agordi ĉi tiun kameraon": "konfiguroi tämä kamera"
-,"preni instantaron": "ota kuvakaappaus"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Et ole konfiguroinut vielä yhtään kameraa. Paina tästä lisätäksesi..."
-,"enigu pozitivan nombron": "syötä positiivinen luku"
-,"enigu pozitivan entjeran nombron": "syötä positiivinen muuttuja"
-,"enigu nombron": "syötä numero"
-,"enigu entjeran nombron": "syötä muuttuja"
-," inter ": " välissä "
-," kaj ": " ja "
-," pli ol ": " suurempi kuin "
-," malpli ol ": " pienempi kuin "
-,"enigu validan tempon en la sekva formato: HH:MM": "syötä aika muodossa: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "syötä kelvollinen URL (esim. http://example.com:8080/kamerat/)"
-,"fermi": "sulje"
-,"Ne": "Ei"
-,"Jes": "Kyllä"
-,"Bone": "OK"
-,"Auto Exposure": "Automaattivalotus"
-,"Backlight Compensation": "Taustavalon kompensointi"
-,"Brightness": "Kirkkaus"
-,"Contrast": "Kontrasti"
-,"Exposure Absolute": "Absoluuttinen valotus"
-,"Exposure Auto": "Automaattinen valotus"
-,"Exposure Auto Priority": "Valotuksen automaattinen prioriteetti"
-,"Exposure Time Absolute": "Absoluuttinen valotusaika"
-,"Focus Absolute": "Absoluuttinen tarkennus"
-,"Focus Auto": "Automaattinen tarkennus"
-,"Gain": "Vahvistus"
-,"Gamma": "Gamma"
-,"Hue": "Sävy"
-,"Led1 Mode": "Led1 moodi"
-,"Led1 Frequency": "LED1 taajuus"
-,"Pan Absolute": "Absoluuttinen panorointi"
-,"Power Line Frequency": "Sähköverkon taajuus"
-,"Saturation": "Satuaatio"
-,"Sharpness": "Terävyys"
-,"Tilt Absolute": "Absoluuttinen kääntö"
-,"White Balance Temperature": "Valkotasapainon lämpötila"
-,"White Balance Temperature Auto": "Automaattinen valkotasapaino"
-,"Zoom Absolute": "Absoluuttinen zoomaus"
+{
+  "": {
+    "language": "fi",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "erikoismerkkejä ei sallita salasanassa",
+  "Ĉi tiu kampo estas deviga": "Tämä kenttä vaaditaan",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "erikoismerkit eivät ole sallittuja kameran nimessä",
+  "valoro devas esti multoblo de 8": "arvon on oltava 8:n kerrannainen",
+  "specialaj signoj ne rajtas en radika voja nomo": "erikoismerkit eivät ole sallittuja juurihakemiston nimessä",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "tiedostoja ei voi luoda suoraan järjestelmän juureen",
+  "enigu validan retpoŝtadreson": "syötä voimassa oleva sähköpostiosoite",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "kirjoita pilkuilla eroteltu luettelo kelvollisista sähköpostiosoitteista",
+  "specialaj signoj ne rajtas en dosiernomo": "erikoismerkit eivät ole sallittuja tiedoston nimessä",
+  "enigu validan valoron": "syötä kelvollinen arvo",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Tämä poistaa rekursiivisesti kaikki pilvikansiossa olevat tiedostot ”",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", ei pelkästään motionEyen lataamat!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Tämä poistaa rekursiivisesti kaikki vanhat mediatiedostot kansiosta \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", ei vain motionEyen luomat!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Maskia ei voida muokata ilman kelvollista kuvaa kameralta!",
+  "Propra": "Mukautettu",
+  "Propra dosierindiko": "Mukautettu palku",
+  "Retan kunlokon": "Verkkojako",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Selaimesi ei tue tätä toimintoa!",
+  "Apliki": "Käytä",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Varmista, että kaikki asetukset ovat kelvollisia!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Tämä käynnistää järjestelmän uudelleen. Jatketaanko?",
+  "Vere fermiti sistemon?": "Haluatko varmasti sammuttaa?",
+  "Malŝaltita": "Sammutettu",
+  "Ĉu vere restartigi ?": "Haluatko varmasti käynnistää uudelleen?",
+  "La sistemo rekomencis!": "Järjestelmä on käynnistetty uudelleen!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Ole hyvä, ja ota käyttöön mukautetut asetukset ensin!",
+  "Neniu fotilo por forigi!": "Ei kameraa poistettavaksi!",
+  "Ĉu forigi kameraon ": "Poista kamera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye on päivitetty (tämänhetkinen versio: ",
+  "Nova versio havebla: ": "Uusi versio saatavilla: ",
+  ". Ĝisdatigi?": ". Päivitä?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye on päivitetty onnistuneesti!",
+  "Ĝisdatigo malsukcesis!": "Päivitys epäonnistui!",
+  "La ĝisdatiga procezo malsukcesis!": "Päivitysprosessi epäonnistui!",
+  "Rezerva dosiero": "Varmuuskopiotiedosto",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Varmuuskopiotiedosto, jonka latasit aiemmin.",
+  "Restaŭrigi Agordon": "Palauta asetukset",
+  "Restaŭriganta agordon ...": "Palautetaan asetuksia ...",
+  "La agordo restaŭrigis!": "Asetukset on palautettu!",
+  "Malsukcesis restaŭri la agordon!": "Asetusten palauttaminen epäonnistui!",
+  "Aliri la alŝutan servon malsukcesis: ": "Lähetyspalveluun pääsy epäonnistui: ",
+  "Aliri la alŝutan servon sukcesis!": "Latauspalveluun pääsy onnistui!",
+  "Sciiga retpoŝto fiaskis:": "Sähköposti-ilmoitus epäonnistui:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Varmista, että kaikki asetukset ovat kelvollisia!",
+  "Sciiga Telegramo fiaskis:": "Telegram ilmoitus epäonnistui:",
+  "Sciiga Telegramo sukcesis!": "Telegram-ilmoitus onnistui!",
+  "Aliro al retdividado fiaskis: ": "Verkkojakoon yhdistäminen epäonnistui: ",
+  "Aliro al retdividado sukcesis!": "Verkkojakoon yhdistäminen onnistui!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Haluatko varmasti poistaa tämän tiedoston?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Haluatko varmasti poistaa kaikki kuvat \"%(ryhmästä/ryhmistä)\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Haluatko varmasti poistaa kaikki videot \"%(ryhmästä/ryhmistä)\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Haluatko varmasti poistaa kaikki ryhmiin kuulumattomat kuvat?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Haluatko varmasti poistaa kaikki ryhmiin kuulumattomat videot?",
+  "aldonadi kameraon...": "lisää kamera...",
+  "Uzantnomo": "Käyttäjänimi",
+  "Pasvorto": "Salasana",
+  "Memoru min": "Muista minut",
+  "Ensaluti": "Kirjaudu sisään",
+  "Nuligi": "Peruuta",
+  "Vi abortis la filmeton.": "Keskeytit videon.",
+  "Reto eraro okazis.": "Tapahtui verkkovirhe.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Median purkuvirhe tai ei-tuettu mediaominaisuus.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formaattia ei tueta tai se ei ole saavutettavissa / sovellu toistettavaksi.",
+  "Nekonata eraro okazis.": "Tapahtui tuntematon virhe.",
+  "Eraro : ": "Virhe : ",
+  "antaŭa bildo": "edellinen kuva",
+  "ludi": "toista",
+  "ludi * 5 kaj enĉenigi": "toista * 5 ja ketju",
+  "sekva bildo": "seuraava kuva",
+  "Fermi": "Sulje",
+  "Elŝuti": "Lataa",
+  "Forigi": "Poista",
+  "Kamerao tipo": "Kameran tyyppi",
+  "Loka V4L2-kamerao": "Paikallinen V4L2-kamera",
+  "Loka MMAL-kamerao": "Paikallinen MMAL-kamera",
+  "Reta kamerao": "Verkkokamera",
+  "Fora motionEye kamerao": "Etäkamera motionEye",
+  "Simpla MJPEG-kamerao": "Yksinkertainen MJPEG-kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "lisättävän kameran tyyppi",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://esimerkki.com:8765/kamerat/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kameran URL (esim. http://example.com:8080/kamera/)",
+  "uzantnomo...": "käyttäjänimi ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "URL-osoitteen käyttäjätunnus tarvittaessa (esim. ylläpitäjä)",
+  "pasvorto...": "salasana...",
+  "la pasvorto por la URL, se bezonata": "URL-osoitteen salasana tarvittaessa",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kamera, jonka haluat lisätä",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Etä-motionEye-kamera, joka on asennettu toisen MotionEye-palvelimen taakse. Niiden lisääminen antaa sinun katsoa ja hallita niitä etänä.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Verkkokamerat (tai IP-kamerat) ovat laitteita, jotka tukevat RTSP/RTMP- tai MJPEG-videoita tai yksinkertaisia JPEG-kuvia. Selvitä oikea RTSP, RTMP, MJPEG tai JPEG URL laitteesi käsikirjasta.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Paikalliset MMAL-kamerat ovat laitteita, jotka on liitetty suoraan motionEye-järjestelmään. Nämä ovat yleensä piirilevykohtiasia kameroita.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Laitteen lisääminen pelkäksi MJPEG-kameraksi verkkokameran sijaan parantaa päivitysnopeutta, mutta siihen ei ole saatavilla liikkeen tunnistusta, kuvan tallentamista tai videon tallennusta. Kameran on oltava palvelimen ja selaimesi käytettävissä. Tämä kamera ei ole yhteensopiva Internet Explorerin kanssa.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Paikalliset V4L2-kamerat ovat kameralaitteita, jotka on kytketty suoraan motionEye-järjestelmään, yleensä USB:n kautta.",
+  "Aldonadi kameraon...": "Lisää kamera...",
+  "Grupo": "Ryhmä",
+  "Inkluzivi foton prenitan ĉiun": "Sisällytä kuva, joka on otettu joka",
+  "sekundo": "sekunti",
+  "5 sekundoj": "5 sekuntia",
+  "10 sekundoj": "10 sekuntia",
+  "30 sekundoj": "30 sekuntia",
+  "minuto": "minuuttia",
+  "5 minutoj": "5 minuuttia",
+  "10 minutoj": "10 minuuttia",
+  "30 minutoj": "30 minuuttia",
+  "horo": "tunti",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "valitse aikaväli kahden valitun kuvan välillä.",
+  "Filmo framfrekvenco": "Videon kuvataajuus",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Valitse miten nopea haluat intervallivideon olevan.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Huomioiden suuren kuvien määrän, intervallivideon luominen saattaa kestää jonkin aikaa!",
+  "Krei akselita video": "Luo intervallivideo",
+  "Filmo kreanta en progreso...": "Luodaan intervallivideota...",
+  "Zipitaj": "Pakattu",
+  "Akselita video": "Ajastettu kuvaus",
+  "Forigi ĉiujn": "Poista kaikki",
+  "Bildoj prenitaj de ": "Kuvat, jotka on ottanut ",
+  "Filmoj registritaj de ": "Videot, jotka on ottanut ",
+  "montru ĉi tiun fotilon plenekranan": "Näytä tämä kamera koko ruudun tilassa",
+  "montri ĉiujn fotilojn": "Näytä kaikki kamerat",
+  "montru nur ĉi tiun fotilon": "Näytä vain tämä kamera",
+  "malfermaj bildoj retumilo": "avaa kuvaselain",
+  "malferma videoj retumilo": "avaa videoselain",
+  "agordi ĉi tiun kameraon": "konfiguroi tämä kamera",
+  "preni instantaron": "ota kuvakaappaus",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Et ole konfiguroinut vielä yhtään kameraa. Paina tästä lisätäksesi...",
+  "enigu pozitivan nombron": "syötä positiivinen luku",
+  "enigu pozitivan entjeran nombron": "syötä positiivinen muuttuja",
+  "enigu nombron": "syötä numero",
+  "enigu entjeran nombron": "syötä muuttuja",
+  " inter ": " välissä ",
+  " kaj ": " ja ",
+  " pli ol ": " suurempi kuin ",
+  " malpli ol ": " pienempi kuin ",
+  "enigu validan tempon en la sekva formato: HH:MM": "syötä aika muodossa: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "syötä kelvollinen URL (esim. http://example.com:8080/kamerat/)",
+  "fermi": "sulje",
+  "Ne": "Ei",
+  "Jes": "Kyllä",
+  "Bone": "OK",
+  "Auto Exposure": "Automaattivalotus",
+  "Backlight Compensation": "Taustavalon kompensointi",
+  "Brightness": "Kirkkaus",
+  "Contrast": "Kontrasti",
+  "Exposure Absolute": "Absoluuttinen valotus",
+  "Exposure Auto": "Automaattinen valotus",
+  "Exposure Auto Priority": "Valotuksen automaattinen prioriteetti",
+  "Exposure Time Absolute": "Absoluuttinen valotusaika",
+  "Focus Absolute": "Absoluuttinen tarkennus",
+  "Focus Auto": "Automaattinen tarkennus",
+  "Gain": "Vahvistus",
+  "Gamma": "Gamma",
+  "Hue": "Sävy",
+  "Led1 Mode": "Led1 moodi",
+  "Led1 Frequency": "LED1 taajuus",
+  "Pan Absolute": "Absoluuttinen panorointi",
+  "Power Line Frequency": "Sähköverkon taajuus",
+  "Saturation": "Satuaatio",
+  "Sharpness": "Terävyys",
+  "Tilt Absolute": "Absoluuttinen kääntö",
+  "White Balance Temperature": "Valkotasapainon lämpötila",
+  "White Balance Temperature Auto": "Automaattinen valkotasapaino",
+  "Zoom Absolute": "Absoluuttinen zoomaus",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.fr.json
+++ b/motioneye/static/js/motioneye.fr.json
@@ -1,164 +1,176 @@
-{"":{"language":"fr","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "les caractères spéciaux ne sont pas autorisés dans le mot de passe"
-,"Ĉi tiu kampo estas deviga": "Ce champ est obligatoire"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "les caractères spéciaux ne sont pas autorisés dans le nom de la caméra"
-,"valoro devas esti multoblo de 8": "la valeur doit être un multiple de 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "les caractères spéciaux ne sont pas autorisés dans le nom du chemin racine"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "les fichiers ne peuvent pas être créés directement à la racine de votre système"
-,"enigu validan retpoŝtadreson": "entrez une adresse e-mail valide"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "entrez une liste d'adresses e-mail valides séparées par des virgules"
-,"specialaj signoj ne rajtas en dosiernomo": "les caractères spéciaux ne sont pas autorisés dans le nom de fichier"
-,"enigu validan valoron": "entrez une valeur valide"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Cela supprimera récursivement tous les fichiers du dossier cloud \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", pas seulement ceux téléchargés par motionEye !"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Cela supprimera récursivement tous les anciens fichiers multimédias du dossier \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", pas seulement ceux créés par motionEye !"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Impossible de modifier le masque sans une image de caméra valide !"
-,"Propra": "Personnalisé"
-,"Propra dosierindiko": "Dossier personnalisé"
-,"Retan kunlokon": "Partage réseau"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Votre navigateur ne gère pas cette fonctionnalité !"
-,"Apliki": "Appliquer"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Assurez-vous que toutes les options de configuration sont valides !"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Cela redémarrera le système. Continuer ?"
-,"Vere fermiti sistemon?": "Vraiment arrêter le système ?"
-,"Malŝaltita": "Éteint"
-,"Ĉu vere restartigi ?": "Vraiment redémarrer ?"
-,"La sistemo rekomencis!": "Le système a redémarré !"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Veuillez d'abord appliquer les paramètres modifiés !"
-,"Neniu fotilo por forigi!": "Pas de caméra à retirer !"
-,"Ĉu forigi kameraon ": "Retirer la caméra "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye est à jour (version actuelle : "
-,"Nova versio havebla: ": "Nouvelle version disponible : "
-,". Ĝisdatigi?": ". Mettre à jour ?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye a été mis à jour avec succès !"
-,"Ĝisdatigo malsukcesis!": "La mise à jour a échoué !"
-,"La ĝisdatiga procezo malsukcesis!": "Le processus de mise à niveau a échoué !"
-,"Rezerva dosiero": "Fichier de sauvegarde"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Le fichier de sauvegarde que vous avez téléchargé précédemment."
-,"Restaŭrigi Agordon": "Restaurer la configuration"
-,"Restaŭriganta agordon ...": "Restauration de la configuration ..."
-,"La agordo restaŭrigis!": "La configuration a été restaurée !"
-,"Malsukcesis restaŭri la agordon!": "Impossible de restaurer la configuration !"
-,"Aliri la alŝutan servon malsukcesis: ": "Échec de l'accès au service de téléchargement : "
-,"Aliri la alŝutan servon sukcesis!": "L'accès au service de téléchargement a réussi !"
-,"Sciiga retpoŝto fiaskis:": "L'e-mail de notification a échoué :"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assurez-vous que toutes les options de configuration sont valides !"
-,"Sciiga Telegramo fiaskis:": "Le «Telegrem» de notification a échoué :"
-,"Sciiga Telegramo sukcesis!": "Le «Telegram» de notification a réussi !"
-,"Aliro al retdividado fiaskis: ": "L'accès au partage réseau a échoué : "
-,"Aliro al retdividado sukcesis!": "L'accès au partage réseau a réussi !"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Voulez-vous vraiment supprimer ce fichier ?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Voulez-vous vraiment supprimer toutes les images de \"%(group)s\" ?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Voulez-vous vraiment supprimer tous les films de \"%(group)s\" ?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Voulez-vous vraiment supprimer toutes les images non groupées ?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Certain de vouloir supprimer tous les films non groupés ?"
-,"aldonadi kameraon...": "ajouter une caméra ..."
-,"Uzantnomo": "Identifiant"
-,"Pasvorto": "Mot de passe"
-,"Memoru min": "Souviens toi de moi"
-,"Ensaluti": "Connectez-vous"
-,"Nuligi": "Annuler"
-,"Vi abortis la filmeton.": "Vous avez abandonné la vidéo."
-,"Reto eraro okazis.": "Une erreur réseau s'est produite."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Erreur de décodage ou fonction pas supportée."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format non pris en charge ou inaccessible/inadapté à la lecture."
-,"Nekonata eraro okazis.": "Une erreur inconnue s'est produite."
-,"Eraro : ": "Erreur : "
-,"antaŭa bildo": "vue précédente"
-,"ludi": "lire"
-,"ludi * 5 kaj enĉenigi": "lire x5 et enchaîner"
-,"sekva bildo": "vue suivante"
-,"Fermi": "Fermer"
-,"Elŝuti": "Télécharger"
-,"Forigi": "Supprimer"
-,"Kamerao tipo": "Type de caméra"
-,"Loka V4L2-kamerao": "Caméra V4L2 locale"
-,"Loka MMAL-kamerao": "Caméra MMAL locale"
-,"Reta kamerao": "Caméra réseau"
-,"Fora motionEye kamerao": "Caméra motionEye distante"
-,"Simpla MJPEG-kamerao": "Caméra MJPEG simple"
-,"la speco de kamerao, kiun vi volas aldoni": "le type de caméra que vous souhaitez ajouter"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://exemple.com:8765/cams/.."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL de la caméra (ex. http://exemple.com:8080/cam/)"
-,"uzantnomo...": "nom d'utilisateur ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "le nom d'utilisateur de l'URL, si nécessaire (ex. admin)"
-,"pasvorto...": "mot de passe ..."
-,"la pasvorto por la URL, se bezonata": "le mot de passe de l'URL, si nécessaire"
-,"Kamerao": "Caméra"
-,"la kameraon, kiun vi volas aldoni": "la caméra que vous souhaitez ajouter"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Une caméra motionEye distante est une caméra installée derrière un autre serveur MotionEye. L'ajouter ici vous permettra de la regarder et de la gérer à distance."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Les caméras réseau (ou caméras IP) sont des appareils qui diffusent en mode natif des vidéos RTSP/RTMP ou MJPEG ou de simples images JPEG. Consultez le manuel de votre appareil pour connaître l'URL RTSP, RTMP, MJPEG ou JPEG correcte."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Les caméras MMAL locales sont des appareils directement connectés à votre système motionEye. Ce sont généralement des appareils photo spécifiques à la carte-mère."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "L'ajout de votre appareil en tant que simple caméra MJPEG au lieu d'une caméra réseau améliorera la qualité d'image, mais aucune détection de mouvement, capture d'image ou enregistrement de film ne sera disponible. La caméra doit être accessible à votre serveur et à votre navigateur. Ce type de caméra est incompatible avec Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Les caméras V4L2 locales sont des périphériques connectés directement à votre système motionEye, généralement par USB."
-,"Aldonadi kameraon...": "Ajouter une caméra ..."
-,"Grupo": "Groupe"
-,"Inkluzivi foton prenitan ĉiun": "Inclure une photo prise chaque"
-,"sekundo": "seconde"
-,"5 sekundoj": "5 secondes"
-,"10 sekundoj": "10 secondes"
-,"30 sekundoj": "30 secondes"
-,"minuto": "minute"
-,"5 minutoj": "5 minutes"
-,"10 minutoj": "10 minutes"
-,"30 minutoj": "30 minutes"
-,"horo": "heure"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Sélectionnez l'intervalle de temps entre deux images sélectionnées."
-,"Filmo framfrekvenco": "Fréquence d'images du film"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Choisissez la vitesse à laquelle vous souhaitez que la vidéo accélérée soit."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Compte tenu du grand nombre d'images, la création de votre vidéo peut prendre un certain temps !"
-,"Krei akselita video": "Créer une vidéo accélérée"
-,"Filmo kreanta en progreso...": "Création du film en cours ..."
-,"Zipitaj": "Zippées"
-,"Akselita video": "Vidéo accélérée"
-,"Forigi ĉiujn": "Tout supprimer"
-,"Bildoj prenitaj de ": "Photos prises par "
-,"Filmoj registritaj de ": "Films enregistrés par "
-,"montru ĉi tiun fotilon plenekranan": "Afficher cette caméra en plein écran"
-,"montri ĉiujn fotilojn": "Afficher toutes les caméras"
-,"montru nur ĉi tiun fotilon": "Afficher seulement cette caméra"
-,"malfermaj bildoj retumilo": "ouvrir le navigateur d'images"
-,"malferma videoj retumilo": "ouvrir le navigateur de vidéos"
-,"agordi ĉi tiun kameraon": "régler cette caméra"
-,"preni instantaron": "prendre un instantané"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Vous n'avez pas encore configuré de caméra. Cliquez ici pour en ajouter une ..."
-,"enigu pozitivan nombron": "entrez un nombre positif"
-,"enigu pozitivan entjeran nombron": "entrez un entier positif"
-,"enigu nombron": "entrez un nombre"
-,"enigu entjeran nombron": "entrez un entier"
-," inter ": " entre "
-," kaj ": " et "
-," pli ol ": " supérieur à "
-," malpli ol ": " inférieur à "
-,"enigu validan tempon en la sekva formato: HH:MM": "entrez une heure valide au format suivant : HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "entrez une URL valide (par exemple http://exemple.com:8080/cams/)"
-,"fermi": "fermer"
-,"Ne": "Non"
-,"Jes": "Oui"
-,"Bone": "OK"
-,"Auto Exposure": "Exposition auto"
-,"Backlight Compensation": "Compensation de rétroéclairage"
-,"Brightness": "Luminosité"
-,"Contrast": "Contraste"
-,"Exposure Absolute": "Exposition absolue"
-,"Exposure Auto": "Exposition auto"
-,"Exposure Auto Priority": "Priorité automatique de l'exposition"
-,"Exposure Time Absolute": "Temps d'exposition absolu"
-,"Focus Absolute": "Mise au point absolue"
-,"Focus Auto": "Mise au point auto"
-,"Gain": "Gain"
-,"Gamma": "Gamma"
-,"Hue": "Teinte"
-,"Led1 Mode": "Mode DEL1"
-,"Led1 Frequency": "Fréquence DEL1"
-,"Pan Absolute": "Pan absolu"
-,"Power Line Frequency": "Fréquence du réseau électrique"
-,"Saturation": "Saturation"
-,"Sharpness": "Acuité"
-,"Tilt Absolute": "Inclinaison absolue"
-,"White Balance Temperature": "Température de la balance des blancs"
-,"White Balance Temperature Auto": "Température de la balance des blancs auto"
-,"Zoom Absolute": "Zoom absolu"
+{
+  "": {
+    "language": "fr",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "les caractères spéciaux ne sont pas autorisés dans le mot de passe",
+  "Ĉi tiu kampo estas deviga": "Ce champ est obligatoire",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "les caractères spéciaux ne sont pas autorisés dans le nom de la caméra",
+  "valoro devas esti multoblo de 8": "la valeur doit être un multiple de 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "les caractères spéciaux ne sont pas autorisés dans le nom du chemin racine",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "les fichiers ne peuvent pas être créés directement à la racine de votre système",
+  "enigu validan retpoŝtadreson": "entrez une adresse e-mail valide",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "entrez une liste d'adresses e-mail valides séparées par des virgules",
+  "specialaj signoj ne rajtas en dosiernomo": "les caractères spéciaux ne sont pas autorisés dans le nom de fichier",
+  "enigu validan valoron": "entrez une valeur valide",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Cela supprimera récursivement tous les fichiers du dossier cloud \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", pas seulement ceux téléchargés par motionEye !",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Cela supprimera récursivement tous les anciens fichiers multimédias du dossier \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", pas seulement ceux créés par motionEye !",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Impossible de modifier le masque sans une image de caméra valide !",
+  "Propra": "Personnalisé",
+  "Propra dosierindiko": "Dossier personnalisé",
+  "Retan kunlokon": "Partage réseau",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Votre navigateur ne gère pas cette fonctionnalité !",
+  "Apliki": "Appliquer",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Assurez-vous que toutes les options de configuration sont valides !",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Cela redémarrera le système. Continuer ?",
+  "Vere fermiti sistemon?": "Vraiment arrêter le système ?",
+  "Malŝaltita": "Éteint",
+  "Ĉu vere restartigi ?": "Vraiment redémarrer ?",
+  "La sistemo rekomencis!": "Le système a redémarré !",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Veuillez d'abord appliquer les paramètres modifiés !",
+  "Neniu fotilo por forigi!": "Pas de caméra à retirer !",
+  "Ĉu forigi kameraon ": "Retirer la caméra ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye est à jour (version actuelle : ",
+  "Nova versio havebla: ": "Nouvelle version disponible : ",
+  ". Ĝisdatigi?": ". Mettre à jour ?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye a été mis à jour avec succès !",
+  "Ĝisdatigo malsukcesis!": "La mise à jour a échoué !",
+  "La ĝisdatiga procezo malsukcesis!": "Le processus de mise à niveau a échoué !",
+  "Rezerva dosiero": "Fichier de sauvegarde",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Le fichier de sauvegarde que vous avez téléchargé précédemment.",
+  "Restaŭrigi Agordon": "Restaurer la configuration",
+  "Restaŭriganta agordon ...": "Restauration de la configuration ...",
+  "La agordo restaŭrigis!": "La configuration a été restaurée !",
+  "Malsukcesis restaŭri la agordon!": "Impossible de restaurer la configuration !",
+  "Aliri la alŝutan servon malsukcesis: ": "Échec de l'accès au service de téléchargement : ",
+  "Aliri la alŝutan servon sukcesis!": "L'accès au service de téléchargement a réussi !",
+  "Sciiga retpoŝto fiaskis:": "L'e-mail de notification a échoué :",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assurez-vous que toutes les options de configuration sont valides !",
+  "Sciiga Telegramo fiaskis:": "Le «Telegrem» de notification a échoué :",
+  "Sciiga Telegramo sukcesis!": "Le «Telegram» de notification a réussi !",
+  "Aliro al retdividado fiaskis: ": "L'accès au partage réseau a échoué : ",
+  "Aliro al retdividado sukcesis!": "L'accès au partage réseau a réussi !",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Voulez-vous vraiment supprimer ce fichier ?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Voulez-vous vraiment supprimer toutes les images de \"%(group)s\" ?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Voulez-vous vraiment supprimer tous les films de \"%(group)s\" ?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Voulez-vous vraiment supprimer toutes les images non groupées ?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Certain de vouloir supprimer tous les films non groupés ?",
+  "aldonadi kameraon...": "ajouter une caméra ...",
+  "Uzantnomo": "Identifiant",
+  "Pasvorto": "Mot de passe",
+  "Memoru min": "Souviens toi de moi",
+  "Ensaluti": "Connectez-vous",
+  "Nuligi": "Annuler",
+  "Vi abortis la filmeton.": "Vous avez abandonné la vidéo.",
+  "Reto eraro okazis.": "Une erreur réseau s'est produite.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Erreur de décodage ou fonction pas supportée.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format non pris en charge ou inaccessible/inadapté à la lecture.",
+  "Nekonata eraro okazis.": "Une erreur inconnue s'est produite.",
+  "Eraro : ": "Erreur : ",
+  "antaŭa bildo": "vue précédente",
+  "ludi": "lire",
+  "ludi * 5 kaj enĉenigi": "lire x5 et enchaîner",
+  "sekva bildo": "vue suivante",
+  "Fermi": "Fermer",
+  "Elŝuti": "Télécharger",
+  "Forigi": "Supprimer",
+  "Kamerao tipo": "Type de caméra",
+  "Loka V4L2-kamerao": "Caméra V4L2 locale",
+  "Loka MMAL-kamerao": "Caméra MMAL locale",
+  "Reta kamerao": "Caméra réseau",
+  "Fora motionEye kamerao": "Caméra motionEye distante",
+  "Simpla MJPEG-kamerao": "Caméra MJPEG simple",
+  "la speco de kamerao, kiun vi volas aldoni": "le type de caméra que vous souhaitez ajouter",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://exemple.com:8765/cams/..",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL de la caméra (ex. http://exemple.com:8080/cam/)",
+  "uzantnomo...": "nom d'utilisateur ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "le nom d'utilisateur de l'URL, si nécessaire (ex. admin)",
+  "pasvorto...": "mot de passe ...",
+  "la pasvorto por la URL, se bezonata": "le mot de passe de l'URL, si nécessaire",
+  "Kamerao": "Caméra",
+  "la kameraon, kiun vi volas aldoni": "la caméra que vous souhaitez ajouter",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Une caméra motionEye distante est une caméra installée derrière un autre serveur MotionEye. L'ajouter ici vous permettra de la regarder et de la gérer à distance.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Les caméras réseau (ou caméras IP) sont des appareils qui diffusent en mode natif des vidéos RTSP/RTMP ou MJPEG ou de simples images JPEG. Consultez le manuel de votre appareil pour connaître l'URL RTSP, RTMP, MJPEG ou JPEG correcte.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Les caméras MMAL locales sont des appareils directement connectés à votre système motionEye. Ce sont généralement des appareils photo spécifiques à la carte-mère.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "L'ajout de votre appareil en tant que simple caméra MJPEG au lieu d'une caméra réseau améliorera la qualité d'image, mais aucune détection de mouvement, capture d'image ou enregistrement de film ne sera disponible. La caméra doit être accessible à votre serveur et à votre navigateur. Ce type de caméra est incompatible avec Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Les caméras V4L2 locales sont des périphériques connectés directement à votre système motionEye, généralement par USB.",
+  "Aldonadi kameraon...": "Ajouter une caméra ...",
+  "Grupo": "Groupe",
+  "Inkluzivi foton prenitan ĉiun": "Inclure une photo prise chaque",
+  "sekundo": "seconde",
+  "5 sekundoj": "5 secondes",
+  "10 sekundoj": "10 secondes",
+  "30 sekundoj": "30 secondes",
+  "minuto": "minute",
+  "5 minutoj": "5 minutes",
+  "10 minutoj": "10 minutes",
+  "30 minutoj": "30 minutes",
+  "horo": "heure",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Sélectionnez l'intervalle de temps entre deux images sélectionnées.",
+  "Filmo framfrekvenco": "Fréquence d'images du film",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Choisissez la vitesse à laquelle vous souhaitez que la vidéo accélérée soit.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Compte tenu du grand nombre d'images, la création de votre vidéo peut prendre un certain temps !",
+  "Krei akselita video": "Créer une vidéo accélérée",
+  "Filmo kreanta en progreso...": "Création du film en cours ...",
+  "Zipitaj": "Zippées",
+  "Akselita video": "Vidéo accélérée",
+  "Forigi ĉiujn": "Tout supprimer",
+  "Bildoj prenitaj de ": "Photos prises par ",
+  "Filmoj registritaj de ": "Films enregistrés par ",
+  "montru ĉi tiun fotilon plenekranan": "Afficher cette caméra en plein écran",
+  "montri ĉiujn fotilojn": "Afficher toutes les caméras",
+  "montru nur ĉi tiun fotilon": "Afficher seulement cette caméra",
+  "malfermaj bildoj retumilo": "ouvrir le navigateur d'images",
+  "malferma videoj retumilo": "ouvrir le navigateur de vidéos",
+  "agordi ĉi tiun kameraon": "régler cette caméra",
+  "preni instantaron": "prendre un instantané",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Vous n'avez pas encore configuré de caméra. Cliquez ici pour en ajouter une ...",
+  "enigu pozitivan nombron": "entrez un nombre positif",
+  "enigu pozitivan entjeran nombron": "entrez un entier positif",
+  "enigu nombron": "entrez un nombre",
+  "enigu entjeran nombron": "entrez un entier",
+  " inter ": " entre ",
+  " kaj ": " et ",
+  " pli ol ": " supérieur à ",
+  " malpli ol ": " inférieur à ",
+  "enigu validan tempon en la sekva formato: HH:MM": "entrez une heure valide au format suivant : HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "entrez une URL valide (par exemple http://exemple.com:8080/cams/)",
+  "fermi": "fermer",
+  "Ne": "Non",
+  "Jes": "Oui",
+  "Bone": "OK",
+  "Auto Exposure": "Exposition auto",
+  "Backlight Compensation": "Compensation de rétroéclairage",
+  "Brightness": "Luminosité",
+  "Contrast": "Contraste",
+  "Exposure Absolute": "Exposition absolue",
+  "Exposure Auto": "Exposition auto",
+  "Exposure Auto Priority": "Priorité automatique de l'exposition",
+  "Exposure Time Absolute": "Temps d'exposition absolu",
+  "Focus Absolute": "Mise au point absolue",
+  "Focus Auto": "Mise au point auto",
+  "Gain": "Gain",
+  "Gamma": "Gamma",
+  "Hue": "Teinte",
+  "Led1 Mode": "Mode DEL1",
+  "Led1 Frequency": "Fréquence DEL1",
+  "Pan Absolute": "Pan absolu",
+  "Power Line Frequency": "Fréquence du réseau électrique",
+  "Saturation": "Saturation",
+  "Sharpness": "Acuité",
+  "Tilt Absolute": "Inclinaison absolue",
+  "White Balance Temperature": "Température de la balance des blancs",
+  "White Balance Temperature Auto": "Température de la balance des blancs auto",
+  "Zoom Absolute": "Zoom absolu",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.hi.json
+++ b/motioneye/static/js/motioneye.hi.json
@@ -1,164 +1,176 @@
-{"":{"language":"hi","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "पासवर्ड में विशेष वर्णों की अनुमति नहीं है"
-,"Ĉi tiu kampo estas deviga": "इस क्षेत्र की आवश्यकता है"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "विशेष पात्रों को कैमरे के नाम पर अनुमति नहीं है"
-,"valoro devas esti multoblo de 8": "मान 8 का एक से अधिक होना चाहिए"
-,"specialaj signoj ne rajtas en radika voja nomo": "मूल पथ नाम में विशेष वर्णों की अनुमति नहीं है"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "फ़ाइलें सीधे आपके सिस्टम की जड़ में नहीं बनाई जा सकतीं"
-,"enigu validan retpoŝtadreson": "एक मान्य ईमेल पता दर्ज करें"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "अल्पविराम द्वारा अलग किए गए मान्य ईमेल पतों की सूची दर्ज करें"
-,"specialaj signoj ne rajtas en dosiernomo": "फ़ाइल नाम में विशेष वर्णों की अनुमति नहीं है"
-,"enigu validan valoron": "एक मान्य मान दर्ज करें"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "यह पुन: क्लाउड फ़ोल्डर में सभी फ़ाइलों को हटा देगा \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", न केवल प्रस्ताव द्वारा अपलोड किए गए!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "यह फ़ोल्डर में सभी पुरानी मीडिया फ़ाइलों को पुन: हटा देगा \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", नहीं बस उन गति द्वारा बनाई गई!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "मान्य कैमरा छवि के बिना मास्क को संपादित नहीं किया जा सकता है!"
-,"Propra": "रिवाज"
-,"Propra dosierindiko": "कस्टम फ़ाइल नाम"
-,"Retan kunlokon": "ऑनलाइन संचार"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "आपका ब्राउज़र इस सुविधा को नहीं ले जाता है!"
-,"Apliki": "लागू"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "सुनिश्चित करें कि सभी कॉन्फ़िगरेशन विकल्प मान्य हैं!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "यह सिस्टम को पुनरारंभ करेगा। रहना चाहते हैं?"
-,"Vere fermiti sistemon?": "सच में सिस्टम बंद?"
-,"Malŝaltita": "विकलांग"
-,"Ĉu vere restartigi ?": "वास्तव में पुनः आरंभ?"
-,"La sistemo rekomencis!": "सिस्टम फिर से शुरू हुआ!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "कृपया संशोधित सेटिंग्स पहले लागू करें!"
-,"Neniu fotilo por forigi!": "हटाने के लिए कोई कैमरा नहीं!"
-,"Ĉu forigi kameraon ": "कैमरा निकाल सकते हैं"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye अपडेट किया गया है (वर्तमान संस्करण:"
-,"Nova versio havebla: ": "नया संस्करण उपलब्ध:"
-,". Ĝisdatigi?": "। अद्यतन?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye को सफलतापूर्वक अपडेट कर दिया गया है!"
-,"Ĝisdatigo malsukcesis!": "अपडेट विफल!"
-,"La ĝisdatiga procezo malsukcesis!": "अपग्रेड प्रक्रिया विफल रही!"
-,"Rezerva dosiero": "बैकअप फ़ाइल"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "बैकअप फ़ाइल जिसे आपने पहले डाउनलोड किया था।"
-,"Restaŭrigi Agordon": "कॉन्फ़िगरेशन पुनर्स्थापित करें"
-,"Restaŭriganta agordon ...": "कॉन्फ़िगरेशन पुनर्स्थापित कर रहा है ..."
-,"La agordo restaŭrigis!": "कॉन्फ़िगरेशन बहाल कर दिया गया है!"
-,"Malsukcesis restaŭri la agordon!": "कॉन्फ़िगरेशन को पुनर्स्थापित करने में विफल!"
-,"Aliri la alŝutan servon malsukcesis: ": "अपलोड सेवा तक पहुँच विफल रही:"
-,"Aliri la alŝutan servon sukcesis!": "अपलोड सेवा तक पहुँच सफल रही!"
-,"Sciiga retpoŝto fiaskis:": "समाचार ईमेल विफल:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "सुनिश्चित करें कि सभी कॉन्फ़िगरेशन विकल्प मान्य हैं!"
-,"Sciiga Telegramo fiaskis:": "अधिसूचना टेलीग्राम विफल:"
-,"Sciiga Telegramo sukcesis!": "अधिसूचना टेलीग्राम सफल रहा!"
-,"Aliro al retdividado fiaskis: ": "नेटवर्क ट्रांसमिटिंग तक पहुंच विफल:"
-,"Aliro al retdividado sukcesis!": "मंदता तक पहुंच सफल रही है!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "वास्तव में इस फ़ाइल को हटा दें?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "वास्तव में \"%(group)s% (समूह) s\" से सभी छवियां हटाएं?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "वास्तव में सभी फिल्मों को \"%(group)s% (समूह) s\" से हटा दें?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "वास्तव में सभी अनियंत्रित चित्र हटाएं?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "वास्तव में सभी अनियंत्रित फिल्में हटाएं?"
-,"aldonadi kameraon...": "कैमरा जोड़ें ..."
-,"Uzantnomo": "प्रयोक्ता नाम"
-,"Pasvorto": "पासवर्ड"
-,"Memoru min": "मुझे याद करो"
-,"Ensaluti": "लॉग इन करें"
-,"Nuligi": "रद्द करना"
-,"Vi abortis la filmeton.": "आपने वीडियो को निरस्त कर दिया।"
-,"Reto eraro okazis.": "नेटवर्क त्रुटि हुई।"
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "डिकोडिंग त्रुटि या गैर-अस्वीकृत फ़ंक्शन।"
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "प्लेबैक के लिए प्रारूप समर्थित या दुर्गम / अनुपयुक्त नहीं है।"
-,"Nekonata eraro okazis.": "एक अज्ञात त्रुटि हुई।"
-,"Eraro : ": "त्रुटि:"
-,"antaŭa bildo": "पिछली छवि"
-,"ludi": "खेलने के लिए"
-,"ludi * 5 kaj enĉenigi": "खेल * 5 और श्रृंखला"
-,"sekva bildo": "अगली छवि"
-,"Fermi": "पास"
-,"Elŝuti": "डाउनलोड"
-,"Forigi": "निकालें"
-,"Kamerao tipo": "कैमरा प्रकार"
-,"Loka V4L2-kamerao": "स्थानीय V4L2 कैमरा"
-,"Loka MMAL-kamerao": "स्थानीय MMAL कैमरा"
-,"Reta kamerao": "नेटवर्क कैमरा"
-,"Fora motionEye kamerao": "बाहर गति कैमरा"
-,"Simpla MJPEG-kamerao": "सरल MJPEG कैमरा"
-,"la speco de kamerao, kiun vi volas aldoni": "जिस प्रकार का कैमरा आप जोड़ना चाहते हैं"
-,"URL": "यूआरएल"
-,"http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / cams / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "कैमरा URL (जैसे http://example.com:8080/cam/)"
-,"uzantnomo...": "उपयोगकर्ता नाम ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "यदि आवश्यक हो, तो URL के लिए उपयोगकर्ता नाम (उदाहरण के लिए)"
-,"pasvorto...": "पासवर्ड ..."
-,"la pasvorto por la URL, se bezonata": "जरूरत पड़ने पर URL के लिए पासवर्ड"
-,"Kamerao": "कैमरा"
-,"la kameraon, kiun vi volas aldoni": "कैमरा जिसे आप जोड़ना चाहते हैं"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "एक रिमोट मोशन कैमरा एक कैमरा है जो दूसरे MotionEye सर्वर के पीछे स्थापित होता है। उन्हें यहां जोड़ने से आप उन्हें दूर से देख और प्रबंधित कर पाएंगे।"
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "नेटवर्क कैमरा (या आईपी कैमरा) ऐसे उपकरण हैं जो मूल रूप से RTSP / RTMP या MJPEG वीडियो या सरल JPEG छवियों को स्ट्रीम करते हैं। सही RTSP, RTMP, MJPEG या JPEG URL का पता लगाने के लिए अपने डिवाइस के मैनुअल से परामर्श करें।"
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "स्थानीय एमएमएएल कैमरे ऐसे उपकरण हैं जो सीधे आपके मोशन सिस्टम से जुड़े होते हैं। ये आमतौर पर कार्ड-विशिष्ट कैमरे होते हैं।"
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "वेब कैमरा के बजाय एक साधारण MJPEG कैमरे के रूप में अपने डिवाइस को जोड़ने से फोटोग्राफी में सुधार होगा, लेकिन इसके लिए कोई मोशन डिटेक्शन, इमेज कैप्चर या मूवी रिकॉर्डिंग उपलब्ध नहीं होगी। कैमरा आपके सर्वर और आपके ब्राउज़र के लिए सुलभ होना चाहिए। इस प्रकार का कैमरा इंटरनेट एक्सप्लोरर से मेल नहीं खाता है।"
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "स्थानीय V4L2 कैमरे आमतौर पर USB के माध्यम से सीधे आपके मोशन सिस्टम से जुड़े कैमरा डिवाइस होते हैं।"
-,"Aldonadi kameraon...": "कैमरा जोड़ें ..."
-,"Grupo": "समूह"
-,"Inkluzivi foton prenitan ĉiun": "प्रत्येक में शामिल एक तस्वीर शामिल करें"
-,"sekundo": "दूसरा"
-,"5 sekundoj": "5 सेकंड"
-,"10 sekundoj": "10 सेकंड"
-,"30 sekundoj": "30 सेकंड"
-,"minuto": "मिनट"
-,"5 minutoj": "5 मिनट"
-,"10 minutoj": "10 मिनट"
-,"30 minutoj": "30 मिनट"
-,"horo": "एक घंटा"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "दो चयनित छवियों के बीच समय अंतराल का चयन करें।"
-,"Filmo framfrekvenco": "मूवी फ्रेम दर"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "चुनें कि आप कितनी तेजी से त्वरित वीडियो चाहते हैं।"
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "बड़ी संख्या में छवियों को ध्यान में रखते हुए, आपके वीडियो को बनाने में कुछ समय लग सकता है!"
-,"Krei akselita video": "एक त्वरित वीडियो बनाएं"
-,"Filmo kreanta en progreso...": "एक फिल्म प्रगति पर है ..."
-,"Zipitaj": "Zipitaj"
-,"Akselita video": "त्वरित वीडियो"
-,"Forigi ĉiujn": "उन सबको हटाओ"
-,"Bildoj prenitaj de ": "द्वारा लिए गए चित्र"
-,"Filmoj registritaj de ": "द्वारा दर्ज की गई फिल्में"
-,"montru ĉi tiun fotilon plenekranan": "इस कैमरे को पूर्णकालिक दिखाएं"
-,"montri ĉiujn fotilojn": "सभी कैमरे दिखाएं"
-,"montru nur ĉi tiun fotilon": "केवल यह कैमरा दिखाएं"
-,"malfermaj bildoj retumilo": "खुले चित्र ब्राउज़र"
-,"malferma videoj retumilo": "खुले वीडियो ब्राउज़र"
-,"agordi ĉi tiun kameraon": "इस कैमरे को सेट करें"
-,"preni instantaron": "एक स्नैपशॉट ले लो"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "आपने अभी तक कोई कैमरा कॉन्फ़िगर नहीं किया है। एक जोड़ने के लिए यहां क्लिक करें ..."
-,"enigu pozitivan nombron": "एक सकारात्मक संख्या दर्ज करें"
-,"enigu pozitivan entjeran nombron": "एक सकारात्मक पूर्णांक दर्ज करें"
-,"enigu nombron": "एक नंबर दर्ज करें"
-,"enigu entjeran nombron": "पूर्णांक दर्ज करें"
-," inter ": "बीच में"
-," kaj ": "और"
-," pli ol ": "से अधिक है"
-," malpli ol ": "से कम है"
-,"enigu validan tempon en la sekva formato: HH:MM": "निम्न प्रारूप में मान्य समय दर्ज करें: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "एक मान्य URL दर्ज करें (जैसे http://example.com:8080/cams/)"
-,"fermi": "बंद करना"
-,"Ne": "नहीं"
-,"Jes": "हां"
-,"Bone": "अच्छी तरह से"
-,"Auto Exposure": "स्वतः एक्सपोजर"
-,"Backlight Compensation": "बैकलाइट मुआवजा"
-,"Brightness": "चमक"
-,"Contrast": "अंतर"
-,"Exposure Absolute": "एक्सपोजर बिल्कुल"
-,"Exposure Auto": "एक्सपोजर ऑटो"
-,"Exposure Auto Priority": "एक्सपोजर स्वत: प्राथमिकता"
-,"Exposure Time Absolute": "एक्सपोज़र समय बिल्कुल"
-,"Focus Absolute": "पूरी तरह से ध्यान केंद्रित करें"
-,"Focus Auto": "फोकस ऑटो"
-,"Gain": "बढ़त"
-,"Gamma": "गामा"
-,"Hue": "रंग"
-,"Led1 Mode": "LED1 मोड"
-,"Led1 Frequency": "एलईडी 1 आवृत्ति"
-,"Pan Absolute": "पूरी तरह से पैन"
-,"Power Line Frequency": "बिजली लाइन आवृत्ति"
-,"Saturation": "परिपूर्णता"
-,"Sharpness": "तीखेपन"
-,"Tilt Absolute": "बिल्कुल झुकाव"
-,"White Balance Temperature": "सफेद संतुलन तापमान"
-,"White Balance Temperature Auto": "सफेद संतुलन तापमान ऑटो"
-,"Zoom Absolute": "ज़ूम बिल्कुल"
+{
+  "": {
+    "language": "hi",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "पासवर्ड में विशेष वर्णों की अनुमति नहीं है",
+  "Ĉi tiu kampo estas deviga": "इस क्षेत्र की आवश्यकता है",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "विशेष पात्रों को कैमरे के नाम पर अनुमति नहीं है",
+  "valoro devas esti multoblo de 8": "मान 8 का एक से अधिक होना चाहिए",
+  "specialaj signoj ne rajtas en radika voja nomo": "मूल पथ नाम में विशेष वर्णों की अनुमति नहीं है",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "फ़ाइलें सीधे आपके सिस्टम की जड़ में नहीं बनाई जा सकतीं",
+  "enigu validan retpoŝtadreson": "एक मान्य ईमेल पता दर्ज करें",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "अल्पविराम द्वारा अलग किए गए मान्य ईमेल पतों की सूची दर्ज करें",
+  "specialaj signoj ne rajtas en dosiernomo": "फ़ाइल नाम में विशेष वर्णों की अनुमति नहीं है",
+  "enigu validan valoron": "एक मान्य मान दर्ज करें",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "यह पुन: क्लाउड फ़ोल्डर में सभी फ़ाइलों को हटा देगा \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", न केवल प्रस्ताव द्वारा अपलोड किए गए!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "यह फ़ोल्डर में सभी पुरानी मीडिया फ़ाइलों को पुन: हटा देगा \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", नहीं बस उन गति द्वारा बनाई गई!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "मान्य कैमरा छवि के बिना मास्क को संपादित नहीं किया जा सकता है!",
+  "Propra": "रिवाज",
+  "Propra dosierindiko": "कस्टम फ़ाइल नाम",
+  "Retan kunlokon": "ऑनलाइन संचार",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "आपका ब्राउज़र इस सुविधा को नहीं ले जाता है!",
+  "Apliki": "लागू",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "सुनिश्चित करें कि सभी कॉन्फ़िगरेशन विकल्प मान्य हैं!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "यह सिस्टम को पुनरारंभ करेगा। रहना चाहते हैं?",
+  "Vere fermiti sistemon?": "सच में सिस्टम बंद?",
+  "Malŝaltita": "विकलांग",
+  "Ĉu vere restartigi ?": "वास्तव में पुनः आरंभ?",
+  "La sistemo rekomencis!": "सिस्टम फिर से शुरू हुआ!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "कृपया संशोधित सेटिंग्स पहले लागू करें!",
+  "Neniu fotilo por forigi!": "हटाने के लिए कोई कैमरा नहीं!",
+  "Ĉu forigi kameraon ": "कैमरा निकाल सकते हैं",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye अपडेट किया गया है (वर्तमान संस्करण:",
+  "Nova versio havebla: ": "नया संस्करण उपलब्ध:",
+  ". Ĝisdatigi?": "। अद्यतन?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye को सफलतापूर्वक अपडेट कर दिया गया है!",
+  "Ĝisdatigo malsukcesis!": "अपडेट विफल!",
+  "La ĝisdatiga procezo malsukcesis!": "अपग्रेड प्रक्रिया विफल रही!",
+  "Rezerva dosiero": "बैकअप फ़ाइल",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "बैकअप फ़ाइल जिसे आपने पहले डाउनलोड किया था।",
+  "Restaŭrigi Agordon": "कॉन्फ़िगरेशन पुनर्स्थापित करें",
+  "Restaŭriganta agordon ...": "कॉन्फ़िगरेशन पुनर्स्थापित कर रहा है ...",
+  "La agordo restaŭrigis!": "कॉन्फ़िगरेशन बहाल कर दिया गया है!",
+  "Malsukcesis restaŭri la agordon!": "कॉन्फ़िगरेशन को पुनर्स्थापित करने में विफल!",
+  "Aliri la alŝutan servon malsukcesis: ": "अपलोड सेवा तक पहुँच विफल रही:",
+  "Aliri la alŝutan servon sukcesis!": "अपलोड सेवा तक पहुँच सफल रही!",
+  "Sciiga retpoŝto fiaskis:": "समाचार ईमेल विफल:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "सुनिश्चित करें कि सभी कॉन्फ़िगरेशन विकल्प मान्य हैं!",
+  "Sciiga Telegramo fiaskis:": "अधिसूचना टेलीग्राम विफल:",
+  "Sciiga Telegramo sukcesis!": "अधिसूचना टेलीग्राम सफल रहा!",
+  "Aliro al retdividado fiaskis: ": "नेटवर्क ट्रांसमिटिंग तक पहुंच विफल:",
+  "Aliro al retdividado sukcesis!": "मंदता तक पहुंच सफल रही है!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "वास्तव में इस फ़ाइल को हटा दें?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "वास्तव में \"%(group)s% (समूह) s\" से सभी छवियां हटाएं?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "वास्तव में सभी फिल्मों को \"%(group)s% (समूह) s\" से हटा दें?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "वास्तव में सभी अनियंत्रित चित्र हटाएं?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "वास्तव में सभी अनियंत्रित फिल्में हटाएं?",
+  "aldonadi kameraon...": "कैमरा जोड़ें ...",
+  "Uzantnomo": "प्रयोक्ता नाम",
+  "Pasvorto": "पासवर्ड",
+  "Memoru min": "मुझे याद करो",
+  "Ensaluti": "लॉग इन करें",
+  "Nuligi": "रद्द करना",
+  "Vi abortis la filmeton.": "आपने वीडियो को निरस्त कर दिया।",
+  "Reto eraro okazis.": "नेटवर्क त्रुटि हुई।",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "डिकोडिंग त्रुटि या गैर-अस्वीकृत फ़ंक्शन।",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "प्लेबैक के लिए प्रारूप समर्थित या दुर्गम / अनुपयुक्त नहीं है।",
+  "Nekonata eraro okazis.": "एक अज्ञात त्रुटि हुई।",
+  "Eraro : ": "त्रुटि:",
+  "antaŭa bildo": "पिछली छवि",
+  "ludi": "खेलने के लिए",
+  "ludi * 5 kaj enĉenigi": "खेल * 5 और श्रृंखला",
+  "sekva bildo": "अगली छवि",
+  "Fermi": "पास",
+  "Elŝuti": "डाउनलोड",
+  "Forigi": "निकालें",
+  "Kamerao tipo": "कैमरा प्रकार",
+  "Loka V4L2-kamerao": "स्थानीय V4L2 कैमरा",
+  "Loka MMAL-kamerao": "स्थानीय MMAL कैमरा",
+  "Reta kamerao": "नेटवर्क कैमरा",
+  "Fora motionEye kamerao": "बाहर गति कैमरा",
+  "Simpla MJPEG-kamerao": "सरल MJPEG कैमरा",
+  "la speco de kamerao, kiun vi volas aldoni": "जिस प्रकार का कैमरा आप जोड़ना चाहते हैं",
+  "URL": "यूआरएल",
+  "http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / cams / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "कैमरा URL (जैसे http://example.com:8080/cam/)",
+  "uzantnomo...": "उपयोगकर्ता नाम ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "यदि आवश्यक हो, तो URL के लिए उपयोगकर्ता नाम (उदाहरण के लिए)",
+  "pasvorto...": "पासवर्ड ...",
+  "la pasvorto por la URL, se bezonata": "जरूरत पड़ने पर URL के लिए पासवर्ड",
+  "Kamerao": "कैमरा",
+  "la kameraon, kiun vi volas aldoni": "कैमरा जिसे आप जोड़ना चाहते हैं",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "एक रिमोट मोशन कैमरा एक कैमरा है जो दूसरे MotionEye सर्वर के पीछे स्थापित होता है। उन्हें यहां जोड़ने से आप उन्हें दूर से देख और प्रबंधित कर पाएंगे।",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "नेटवर्क कैमरा (या आईपी कैमरा) ऐसे उपकरण हैं जो मूल रूप से RTSP / RTMP या MJPEG वीडियो या सरल JPEG छवियों को स्ट्रीम करते हैं। सही RTSP, RTMP, MJPEG या JPEG URL का पता लगाने के लिए अपने डिवाइस के मैनुअल से परामर्श करें।",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "स्थानीय एमएमएएल कैमरे ऐसे उपकरण हैं जो सीधे आपके मोशन सिस्टम से जुड़े होते हैं। ये आमतौर पर कार्ड-विशिष्ट कैमरे होते हैं।",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "वेब कैमरा के बजाय एक साधारण MJPEG कैमरे के रूप में अपने डिवाइस को जोड़ने से फोटोग्राफी में सुधार होगा, लेकिन इसके लिए कोई मोशन डिटेक्शन, इमेज कैप्चर या मूवी रिकॉर्डिंग उपलब्ध नहीं होगी। कैमरा आपके सर्वर और आपके ब्राउज़र के लिए सुलभ होना चाहिए। इस प्रकार का कैमरा इंटरनेट एक्सप्लोरर से मेल नहीं खाता है।",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "स्थानीय V4L2 कैमरे आमतौर पर USB के माध्यम से सीधे आपके मोशन सिस्टम से जुड़े कैमरा डिवाइस होते हैं।",
+  "Aldonadi kameraon...": "कैमरा जोड़ें ...",
+  "Grupo": "समूह",
+  "Inkluzivi foton prenitan ĉiun": "प्रत्येक में शामिल एक तस्वीर शामिल करें",
+  "sekundo": "दूसरा",
+  "5 sekundoj": "5 सेकंड",
+  "10 sekundoj": "10 सेकंड",
+  "30 sekundoj": "30 सेकंड",
+  "minuto": "मिनट",
+  "5 minutoj": "5 मिनट",
+  "10 minutoj": "10 मिनट",
+  "30 minutoj": "30 मिनट",
+  "horo": "एक घंटा",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "दो चयनित छवियों के बीच समय अंतराल का चयन करें।",
+  "Filmo framfrekvenco": "मूवी फ्रेम दर",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "चुनें कि आप कितनी तेजी से त्वरित वीडियो चाहते हैं।",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "बड़ी संख्या में छवियों को ध्यान में रखते हुए, आपके वीडियो को बनाने में कुछ समय लग सकता है!",
+  "Krei akselita video": "एक त्वरित वीडियो बनाएं",
+  "Filmo kreanta en progreso...": "एक फिल्म प्रगति पर है ...",
+  "Zipitaj": "Zipitaj",
+  "Akselita video": "त्वरित वीडियो",
+  "Forigi ĉiujn": "उन सबको हटाओ",
+  "Bildoj prenitaj de ": "द्वारा लिए गए चित्र",
+  "Filmoj registritaj de ": "द्वारा दर्ज की गई फिल्में",
+  "montru ĉi tiun fotilon plenekranan": "इस कैमरे को पूर्णकालिक दिखाएं",
+  "montri ĉiujn fotilojn": "सभी कैमरे दिखाएं",
+  "montru nur ĉi tiun fotilon": "केवल यह कैमरा दिखाएं",
+  "malfermaj bildoj retumilo": "खुले चित्र ब्राउज़र",
+  "malferma videoj retumilo": "खुले वीडियो ब्राउज़र",
+  "agordi ĉi tiun kameraon": "इस कैमरे को सेट करें",
+  "preni instantaron": "एक स्नैपशॉट ले लो",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "आपने अभी तक कोई कैमरा कॉन्फ़िगर नहीं किया है। एक जोड़ने के लिए यहां क्लिक करें ...",
+  "enigu pozitivan nombron": "एक सकारात्मक संख्या दर्ज करें",
+  "enigu pozitivan entjeran nombron": "एक सकारात्मक पूर्णांक दर्ज करें",
+  "enigu nombron": "एक नंबर दर्ज करें",
+  "enigu entjeran nombron": "पूर्णांक दर्ज करें",
+  " inter ": "बीच में",
+  " kaj ": "और",
+  " pli ol ": "से अधिक है",
+  " malpli ol ": "से कम है",
+  "enigu validan tempon en la sekva formato: HH:MM": "निम्न प्रारूप में मान्य समय दर्ज करें: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "एक मान्य URL दर्ज करें (जैसे http://example.com:8080/cams/)",
+  "fermi": "बंद करना",
+  "Ne": "नहीं",
+  "Jes": "हां",
+  "Bone": "अच्छी तरह से",
+  "Auto Exposure": "स्वतः एक्सपोजर",
+  "Backlight Compensation": "बैकलाइट मुआवजा",
+  "Brightness": "चमक",
+  "Contrast": "अंतर",
+  "Exposure Absolute": "एक्सपोजर बिल्कुल",
+  "Exposure Auto": "एक्सपोजर ऑटो",
+  "Exposure Auto Priority": "एक्सपोजर स्वत: प्राथमिकता",
+  "Exposure Time Absolute": "एक्सपोज़र समय बिल्कुल",
+  "Focus Absolute": "पूरी तरह से ध्यान केंद्रित करें",
+  "Focus Auto": "फोकस ऑटो",
+  "Gain": "बढ़त",
+  "Gamma": "गामा",
+  "Hue": "रंग",
+  "Led1 Mode": "LED1 मोड",
+  "Led1 Frequency": "एलईडी 1 आवृत्ति",
+  "Pan Absolute": "पूरी तरह से पैन",
+  "Power Line Frequency": "बिजली लाइन आवृत्ति",
+  "Saturation": "परिपूर्णता",
+  "Sharpness": "तीखेपन",
+  "Tilt Absolute": "बिल्कुल झुकाव",
+  "White Balance Temperature": "सफेद संतुलन तापमान",
+  "White Balance Temperature Auto": "सफेद संतुलन तापमान ऑटो",
+  "Zoom Absolute": "ज़ूम बिल्कुल",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.hu.json
+++ b/motioneye/static/js/motioneye.hu.json
@@ -1,164 +1,176 @@
-{"":{"language":"hu","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "speciális karakterek használata nem engedélyezett a jelszóban"
-,"Ĉi tiu kampo estas deviga": "Kötelező mező"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "speciális karakterek használata nem engedélyezett a kamera nevében"
-,"valoro devas esti multoblo de 8": "az értéknek 8 többszörösének kell lennie"
-,"specialaj signoj ne rajtas en radika voja nomo": "speciális karakterek használata nem engedélyezett a gyökérkönyvtár nevében"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "nem hozhatók létre fájlok a rendszer gyökérkönyvtárában"
-,"enigu validan retpoŝtadreson": "írj be egy valós e-mail címet"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "írj be több valós e-mail címet, vesszővel elválasztva"
-,"specialaj signoj ne rajtas en dosiernomo": "speciális karakterek használata nem engedélyezett a fájlnevekben"
-,"enigu validan valoron": "írj be egy valós értéket"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Ez a művelet minden kapcsolódó, jelenleg a felhőben tárolt fájlt el fog távolítani \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", nem csak azokat, amiket a motionEye hozott létre, vagy töltött fel!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ez a művelet minden kapcsolódó régi fájlt el fog távolítani a mappából \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", nem csak azokat, amiket a motionEye hozott létre!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Kamerakép nélkül nem szerkeszthető a maszk!"
-,"Propra": "Egyéni"
-,"Propra dosierindiko": "Egyéni útvonal"
-,"Retan kunlokon": "Hálózati megosztás"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "A böngésződ nem támogatja a funkciót!"
-,"Apliki": "Alkalmaz"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Győződj meg róla, hogy minden opciót rendben találsz!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "A rendszer újra fog indulni. Folytatod?"
-,"Vere fermiti sistemon?": "Biztosan le akarod állítani?"
-,"Malŝaltita": "Kikapcsolva"
-,"Ĉu vere restartigi ?": "Biztosan újraindítod?"
-,"La sistemo rekomencis!": "A rendszer újraindult!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Előbb alkalmazd a módosított beállításokat!"
-,"Neniu fotilo por forigi!": "Nincs eltávolítható kamera!"
-,"Ĉu forigi kameraon ": "Kamera törlése: "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "A motionEye friss (jelenlegi verzió: "
-,"Nova versio havebla: ": "Új verzió elérhető: "
-,". Ĝisdatigi?": ". Frissíted?"
-,"motionEye estis sukcese ĝisdatigita!": "A motionEye frissítése sikeres volt!"
-,"Ĝisdatigo malsukcesis!": "Frissítési hiba!"
-,"La ĝisdatiga procezo malsukcesis!": "A frissítés nem sikerült!"
-,"Rezerva dosiero": "Biztonsági mentés"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "a korábban letöltött biztonsági fájl."
-,"Restaŭrigi Agordon": "Beállítások visszaállítása"
-,"Restaŭriganta agordon ...": "Beállítások visszaállítása ..."
-,"La agordo restaŭrigis!": "Sikerült a beállítások visszaállítása!"
-,"Malsukcesis restaŭri la agordon!": "Nem sikerült visszaállítani a beállításokat!"
-,"Aliri la alŝutan servon malsukcesis: ": "Nem sikerült elérni a feltöltési szolgáltatást: "
-,"Aliri la alŝutan servon sukcesis!": "Sikerült elérni a feltöltési szolgáltatást!"
-,"Sciiga retpoŝto fiaskis:": ""
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": ""
-,"Sciiga Telegramo fiaskis:": ""
-,"Sciiga Telegramo sukcesis!": ""
-,"Aliro al retdividado fiaskis: ": ""
-,"Aliro al retdividado sukcesis!": ""
-,"Ĉu vere forigi ĉi tiun dosieron?": ""
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": ""
-,"aldonadi kameraon...": ""
-,"Uzantnomo": ""
-,"Pasvorto": "Jelszó"
-,"Memoru min": ""
-,"Ensaluti": ""
-,"Nuligi": ""
-,"Vi abortis la filmeton.": ""
-,"Reto eraro okazis.": ""
-,"Malkodado-eraro aŭ neprogresinta funkcio.": ""
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": ""
-,"Nekonata eraro okazis.": ""
-,"Eraro : ": ""
-,"antaŭa bildo": ""
-,"ludi": ""
-,"ludi * 5 kaj enĉenigi": ""
-,"sekva bildo": ""
-,"Fermi": ""
-,"Elŝuti": ""
-,"Forigi": ""
-,"Kamerao tipo": ""
-,"Loka V4L2-kamerao": ""
-,"Loka MMAL-kamerao": ""
-,"Reta kamerao": ""
-,"Fora motionEye kamerao": ""
-,"Simpla MJPEG-kamerao": ""
-,"la speco de kamerao, kiun vi volas aldoni": ""
-,"URL": ""
-,"http://ekzemplo.com:8765/cams/...": ""
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": ""
-,"uzantnomo...": ""
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": ""
-,"pasvorto...": ""
-,"la pasvorto por la URL, se bezonata": ""
-,"Kamerao": ""
-,"la kameraon, kiun vi volas aldoni": ""
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": ""
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": ""
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": ""
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": ""
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": ""
-,"Aldonadi kameraon...": ""
-,"Grupo": ""
-,"Inkluzivi foton prenitan ĉiun": ""
-,"sekundo": ""
-,"5 sekundoj": ""
-,"10 sekundoj": ""
-,"30 sekundoj": ""
-,"minuto": ""
-,"5 minutoj": ""
-,"10 minutoj": ""
-,"30 minutoj": ""
-,"horo": ""
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": ""
-,"Filmo framfrekvenco": ""
-,"Elektu kiom rapide vi volas ke la akselita video estu.": ""
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": ""
-,"Krei akselita video": ""
-,"Filmo kreanta en progreso...": ""
-,"Zipitaj": ""
-,"Akselita video": ""
-,"Forigi ĉiujn": ""
-,"Bildoj prenitaj de ": ""
-,"Filmoj registritaj de ": ""
-,"montru ĉi tiun fotilon plenekranan": ""
-,"montri ĉiujn fotilojn": ""
-,"montru nur ĉi tiun fotilon": ""
-,"malfermaj bildoj retumilo": ""
-,"malferma videoj retumilo": ""
-,"agordi ĉi tiun kameraon": ""
-,"preni instantaron": ""
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": ""
-,"enigu pozitivan nombron": ""
-,"enigu pozitivan entjeran nombron": ""
-,"enigu nombron": ""
-,"enigu entjeran nombron": ""
-," inter ": ""
-," kaj ": ""
-," pli ol ": ""
-," malpli ol ": ""
-,"enigu validan tempon en la sekva formato: HH:MM": ""
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": ""
-,"fermi": ""
-,"Ne": ""
-,"Jes": ""
-,"Bone": ""
-,"Auto Exposure": ""
-,"Backlight Compensation": ""
-,"Brightness": ""
-,"Contrast": ""
-,"Exposure Absolute": ""
-,"Exposure Auto": ""
-,"Exposure Auto Priority": ""
-,"Exposure Time Absolute": ""
-,"Focus Absolute": ""
-,"Focus Auto": ""
-,"Gain": ""
-,"Gamma": ""
-,"Hue": ""
-,"Led1 Mode": ""
-,"Led1 Frequency": ""
-,"Pan Absolute": ""
-,"Power Line Frequency": ""
-,"Saturation": ""
-,"Sharpness": ""
-,"Tilt Absolute": ""
-,"White Balance Temperature": ""
-,"White Balance Temperature Auto": ""
-,"Zoom Absolute": ""
+{
+  "": {
+    "language": "hu",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "speciális karakterek használata nem engedélyezett a jelszóban",
+  "Ĉi tiu kampo estas deviga": "Kötelező mező",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "speciális karakterek használata nem engedélyezett a kamera nevében",
+  "valoro devas esti multoblo de 8": "az értéknek 8 többszörösének kell lennie",
+  "specialaj signoj ne rajtas en radika voja nomo": "speciális karakterek használata nem engedélyezett a gyökérkönyvtár nevében",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "nem hozhatók létre fájlok a rendszer gyökérkönyvtárában",
+  "enigu validan retpoŝtadreson": "írj be egy valós e-mail címet",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "írj be több valós e-mail címet, vesszővel elválasztva",
+  "specialaj signoj ne rajtas en dosiernomo": "speciális karakterek használata nem engedélyezett a fájlnevekben",
+  "enigu validan valoron": "írj be egy valós értéket",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Ez a művelet minden kapcsolódó, jelenleg a felhőben tárolt fájlt el fog távolítani \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", nem csak azokat, amiket a motionEye hozott létre, vagy töltött fel!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ez a művelet minden kapcsolódó régi fájlt el fog távolítani a mappából \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", nem csak azokat, amiket a motionEye hozott létre!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Kamerakép nélkül nem szerkeszthető a maszk!",
+  "Propra": "Egyéni",
+  "Propra dosierindiko": "Egyéni útvonal",
+  "Retan kunlokon": "Hálózati megosztás",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "A böngésződ nem támogatja a funkciót!",
+  "Apliki": "Alkalmaz",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Győződj meg róla, hogy minden opciót rendben találsz!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "A rendszer újra fog indulni. Folytatod?",
+  "Vere fermiti sistemon?": "Biztosan le akarod állítani?",
+  "Malŝaltita": "Kikapcsolva",
+  "Ĉu vere restartigi ?": "Biztosan újraindítod?",
+  "La sistemo rekomencis!": "A rendszer újraindult!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Előbb alkalmazd a módosított beállításokat!",
+  "Neniu fotilo por forigi!": "Nincs eltávolítható kamera!",
+  "Ĉu forigi kameraon ": "Kamera törlése: ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "A motionEye friss (jelenlegi verzió: ",
+  "Nova versio havebla: ": "Új verzió elérhető: ",
+  ". Ĝisdatigi?": ". Frissíted?",
+  "motionEye estis sukcese ĝisdatigita!": "A motionEye frissítése sikeres volt!",
+  "Ĝisdatigo malsukcesis!": "Frissítési hiba!",
+  "La ĝisdatiga procezo malsukcesis!": "A frissítés nem sikerült!",
+  "Rezerva dosiero": "Biztonsági mentés",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "a korábban letöltött biztonsági fájl.",
+  "Restaŭrigi Agordon": "Beállítások visszaállítása",
+  "Restaŭriganta agordon ...": "Beállítások visszaállítása ...",
+  "La agordo restaŭrigis!": "Sikerült a beállítások visszaállítása!",
+  "Malsukcesis restaŭri la agordon!": "Nem sikerült visszaállítani a beállításokat!",
+  "Aliri la alŝutan servon malsukcesis: ": "Nem sikerült elérni a feltöltési szolgáltatást: ",
+  "Aliri la alŝutan servon sukcesis!": "Sikerült elérni a feltöltési szolgáltatást!",
+  "Sciiga retpoŝto fiaskis:": "",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "",
+  "Sciiga Telegramo fiaskis:": "",
+  "Sciiga Telegramo sukcesis!": "",
+  "Aliro al retdividado fiaskis: ": "",
+  "Aliro al retdividado sukcesis!": "",
+  "Ĉu vere forigi ĉi tiun dosieron?": "",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "",
+  "aldonadi kameraon...": "",
+  "Uzantnomo": "",
+  "Pasvorto": "Jelszó",
+  "Memoru min": "",
+  "Ensaluti": "",
+  "Nuligi": "",
+  "Vi abortis la filmeton.": "",
+  "Reto eraro okazis.": "",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "",
+  "Nekonata eraro okazis.": "",
+  "Eraro : ": "",
+  "antaŭa bildo": "",
+  "ludi": "",
+  "ludi * 5 kaj enĉenigi": "",
+  "sekva bildo": "",
+  "Fermi": "",
+  "Elŝuti": "",
+  "Forigi": "",
+  "Kamerao tipo": "",
+  "Loka V4L2-kamerao": "",
+  "Loka MMAL-kamerao": "",
+  "Reta kamerao": "",
+  "Fora motionEye kamerao": "",
+  "Simpla MJPEG-kamerao": "",
+  "la speco de kamerao, kiun vi volas aldoni": "",
+  "URL": "",
+  "http://ekzemplo.com:8765/cams/...": "",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "",
+  "uzantnomo...": "",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "",
+  "pasvorto...": "",
+  "la pasvorto por la URL, se bezonata": "",
+  "Kamerao": "",
+  "la kameraon, kiun vi volas aldoni": "",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "",
+  "Aldonadi kameraon...": "",
+  "Grupo": "",
+  "Inkluzivi foton prenitan ĉiun": "",
+  "sekundo": "",
+  "5 sekundoj": "",
+  "10 sekundoj": "",
+  "30 sekundoj": "",
+  "minuto": "",
+  "5 minutoj": "",
+  "10 minutoj": "",
+  "30 minutoj": "",
+  "horo": "",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "",
+  "Filmo framfrekvenco": "",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "",
+  "Krei akselita video": "",
+  "Filmo kreanta en progreso...": "",
+  "Zipitaj": "",
+  "Akselita video": "",
+  "Forigi ĉiujn": "",
+  "Bildoj prenitaj de ": "",
+  "Filmoj registritaj de ": "",
+  "montru ĉi tiun fotilon plenekranan": "",
+  "montri ĉiujn fotilojn": "",
+  "montru nur ĉi tiun fotilon": "",
+  "malfermaj bildoj retumilo": "",
+  "malferma videoj retumilo": "",
+  "agordi ĉi tiun kameraon": "",
+  "preni instantaron": "",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "",
+  "enigu pozitivan nombron": "",
+  "enigu pozitivan entjeran nombron": "",
+  "enigu nombron": "",
+  "enigu entjeran nombron": "",
+  " inter ": "",
+  " kaj ": "",
+  " pli ol ": "",
+  " malpli ol ": "",
+  "enigu validan tempon en la sekva formato: HH:MM": "",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "",
+  "fermi": "",
+  "Ne": "",
+  "Jes": "",
+  "Bone": "",
+  "Auto Exposure": "",
+  "Backlight Compensation": "",
+  "Brightness": "",
+  "Contrast": "",
+  "Exposure Absolute": "",
+  "Exposure Auto": "",
+  "Exposure Auto Priority": "",
+  "Exposure Time Absolute": "",
+  "Focus Absolute": "",
+  "Focus Auto": "",
+  "Gain": "",
+  "Gamma": "",
+  "Hue": "",
+  "Led1 Mode": "",
+  "Led1 Frequency": "",
+  "Pan Absolute": "",
+  "Power Line Frequency": "",
+  "Saturation": "",
+  "Sharpness": "",
+  "Tilt Absolute": "",
+  "White Balance Temperature": "",
+  "White Balance Temperature Auto": "",
+  "Zoom Absolute": "",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.it.json
+++ b/motioneye/static/js/motioneye.it.json
@@ -1,164 +1,176 @@
-{"":{"language":"it","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "i caratteri speciali non sono ammessi nella password"
-,"Ĉi tiu kampo estas deviga": "Questo campo è obbligatorio"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "i caratteri speciali non sono ammessi nel nome della videocamera"
-,"valoro devas esti multoblo de 8": "il valore deve essere un multiplo di 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "i caratteri speciali non sono ammessi nel nome della cartella root"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "i file non possono essere creati direttamente nella cartella root"
-,"enigu validan retpoŝtadreson": "inserisci un indirizzo email valido"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "inserisci un elenco di indirizzi email validi separati da virgola"
-,"specialaj signoj ne rajtas en dosiernomo": "i caratteri speciali non sono ammessi nel nome file"
-,"enigu validan valoron": "inserisci un valore valido"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Questa azione eliminerà tutti i file nella cartella cloud in modo ricorsivo\""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", non solo quelli caricati da motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Questa azione eliminerà tutti i vecchi file multimediali nella cartella \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", non solo quelli creati da motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Non è possibile modificare la maschera senza un'immagine della videocamera valida!"
-,"Propra": "Personalizzato"
-,"Propra dosierindiko": "Percorso personalizzato"
-,"Retan kunlokon": "Risorsa di rete"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Il tuo browser non supporta questa funzione!"
-,"Apliki": "Applica"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Assicurati che tutte le opzioni siano valide!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Il sistema verrà riavviato. Continuare?"
-,"Vere fermiti sistemon?": "Spegnere il sistema?"
-,"Malŝaltita": "Spento"
-,"Ĉu vere restartigi ?": "Confermi di voler riavviare?"
-,"La sistemo rekomencis!": "Il sistema è stato riavviato!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Per favore applica le impostazioni modificate prima!"
-,"Neniu fotilo por forigi!": "Nessuna videocamera da rimuovere!"
-,"Ĉu forigi kameraon ": "Rimuovi la videocamera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye è aggiornato (versione corrente: "
-,"Nova versio havebla: ": "Nuova versione disponibile: "
-,". Ĝisdatigi?": ". Aggiornare?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye è stato aggiornato correttamente!"
-,"Ĝisdatigo malsukcesis!": "Aggiornamento fallito!"
-,"La ĝisdatiga procezo malsukcesis!": "Il processo di aggiornamento non è andato a buon fine!"
-,"Rezerva dosiero": "File di backup"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "file di backup scaricato in precedenza."
-,"Restaŭrigi Agordon": "Ripristina configurazione"
-,"Restaŭriganta agordon ...": "Ripristino della configurazione ..."
-,"La agordo restaŭrigis!": "La configurazione è stata ripristinata!"
-,"Malsukcesis restaŭri la agordon!": "Impossibile ripristinare la configurazione!"
-,"Aliri la alŝutan servon malsukcesis: ": "Accesso al servizio di caricamento non riuscito: "
-,"Aliri la alŝutan servon sukcesis!": "L'accesso al servizio di caricamento è andato a buon fine!"
-,"Sciiga retpoŝto fiaskis:": "Notifica per email non riuscita:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assicurati che tutte le opzioni siano valide!"
-,"Sciiga Telegramo fiaskis:": "Notifica Telegram fallita:"
-,"Sciiga Telegramo sukcesis!": "Notifica Telegram inviata!"
-,"Aliro al retdividado fiaskis: ": "Accesso alla risorsa di rete non riuscito: "
-,"Aliro al retdividado sukcesis!": "Accesso alla risorsa di rete avvenuto con successo!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Eliminare il file?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Eliminare tutte le immagini da \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Rimuovere tutte le registrazioni da \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Eliminare tutte le immagini non raggruppate?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Eliminare tutte le registrazioni non raggruppate?"
-,"aldonadi kameraon...": "aggiungi videocamera ..."
-,"Uzantnomo": "Nome utente"
-,"Pasvorto": "Password"
-,"Memoru min": "Ricorda dati di accesso"
-,"Ensaluti": "Accedi"
-,"Nuligi": "Annulla"
-,"Vi abortis la filmeton.": "Hai interrotto il video."
-,"Reto eraro okazis.": "Si è verificato un errore di rete."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Errore di decodifica o funzione media non supportata."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato non supportato o inaccessibile/non adatto alla riproduzione."
-,"Nekonata eraro okazis.": "Si è verificato un errore sconosciuto."
-,"Eraro : ": "Errore: "
-,"antaŭa bildo": "immagine precedente"
-,"ludi": "play"
-,"ludi * 5 kaj enĉenigi": "riproduci * 5 e concatena"
-,"sekva bildo": "immagine successiva"
-,"Fermi": "Chiudi"
-,"Elŝuti": "Download"
-,"Forigi": "Rimuovi"
-,"Kamerao tipo": "Tipo di videocamera"
-,"Loka V4L2-kamerao": "Videocamera V4L2 locale"
-,"Loka MMAL-kamerao": "Videocamera MMAL locale"
-,"Reta kamerao": "Videocamera di rete"
-,"Fora motionEye kamerao": "Videocamera esterna"
-,"Simpla MJPEG-kamerao": "Videocamera MJPEG semplice"
-,"la speco de kamerao, kiun vi volas aldoni": "il tipo di videocamera che si desidera aggiungere"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://esempio.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL della videocamera (ad es. http://esempio.com:8080/cam/)"
-,"uzantnomo...": "nome utente ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "il nome utente per l'URL, se necessario (ad es. admin)"
-,"pasvorto...": "password ..."
-,"la pasvorto por la URL, se bezonata": "la password per l'URL, se necessario"
-,"Kamerao": "Videocamera"
-,"la kameraon, kiun vi volas aldoni": "la videocamera che vuoi aggiungere"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Una videocamera MotionEye remota è una videocamera installata dietro un altro server MotionEye. Aggiungendole qui potrai guardarle e gestirle a distanza."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Le videocamere di rete (o videocamere IP) sono dispositivi che trasmettono in streaming video RTSP/RTMP, MJPEG o semplici immagini JPEG. Consulta il manuale del tuo dispositivo per scoprire l'URL RTSP, RTMP, MJPEG o JPEG corretto."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Le videocamere MMAL locali sono dispositivi collegati direttamente al sistema motionEye. Di solito si tratta di telecamere specifiche della scheda."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "L'aggiunta del dispositivo come una semplice videocamera MJPEG anziché come una videocamera di rete migliorerà il frame rate, ma renderà non disponibile la rilevazione di movimento, l'acquisizione di immagini o registrazione di filmati. La videocamera deve essere accessibile al server e al browser. Questo tipo di videocamera non è compatibile con Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Le videocamere V4L2 locali sono dispositivi collegati direttamente al sistema motionEye, in genere tramite USB."
-,"Aldonadi kameraon...": "Aggiungi videocamera ..."
-,"Grupo": "Gruppo"
-,"Inkluzivi foton prenitan ĉiun": "Includi una foto scattata ogni"
-,"sekundo": "secondo"
-,"5 sekundoj": "5 secondi"
-,"10 sekundoj": "10 secondi"
-,"30 sekundoj": "30 secondi"
-,"minuto": "Minuto"
-,"5 minutoj": "5 minuti"
-,"10 minutoj": "10 minuti"
-,"30 minutoj": "30 minuti"
-,"horo": "Ora"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seleziona l'intervallo di tempo tra due immagini selezionate."
-,"Filmo framfrekvenco": "Frame rate filmato"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "seleziona la velocità di riproduzione del timelapse."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Considerando il gran numero di immagini, la creazione del tuo filmato in timelapse potrebbe richiedere del tempo!"
-,"Krei akselita video": "Crea un filmato in timelapse"
-,"Filmo kreanta en progreso...": "Creazione filmato in timelapse in corso ..."
-,"Zipitaj": "Compresso"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Elimina tutti"
-,"Bildoj prenitaj de ": "Foto scattate da "
-,"Filmoj registritaj de ": "Filmati registrati da "
-,"montru ĉi tiun fotilon plenekranan": "Mostra questa videocamera a tempo pieno"
-,"montri ĉiujn fotilojn": "Mostra tutte le videocamere"
-,"montru nur ĉi tiun fotilon": "Mostra solo questa videocamera"
-,"malfermaj bildoj retumilo": "apri il browser delle immagini"
-,"malferma videoj retumilo": "apri il browser dei filmati"
-,"agordi ĉi tiun kameraon": "imposta questa videocamera"
-,"preni instantaron": "scatta un'istantanea"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Non hai ancora configurato alcuna videocamera. Clicca qui per aggiungerne una ..."
-,"enigu pozitivan nombron": "inserisci un numero positivo"
-,"enigu pozitivan entjeran nombron": "inserisci un numero intero positivo"
-,"enigu nombron": "inserisci un numero"
-,"enigu entjeran nombron": "inserisci un numero intero"
-," inter ": " tra "
-," kaj ": " e "
-," pli ol ": " maggiore di "
-," malpli ol ": " minore di "
-,"enigu validan tempon en la sekva formato: HH:MM": "inserisci un orario valido nel seguente formato: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "inserisci un URL valido (ad es. http://esempio.com:8080/cams/)"
-,"fermi": "chiudi"
-,"Ne": "No"
-,"Jes": "Sì"
-,"Bone": "OK"
-,"Auto Exposure": "Esposizione automatica"
-,"Backlight Compensation": "Compensazione retroilluminazione"
-,"Brightness": "Luminosità"
-,"Contrast": "Contrasto"
-,"Exposure Absolute": "Esposizione assoluta"
-,"Exposure Auto": "Esposizione automatica"
-,"Exposure Auto Priority": "Esposizione priorità automatica"
-,"Exposure Time Absolute": "Tempo di esposizione assoluta"
-,"Focus Absolute": "Focus assoluto"
-,"Focus Auto": "Auto Focus"
-,"Gain": "Guadagno"
-,"Gamma": "Gamma"
-,"Hue": "Tinta"
-,"Led1 Mode": "Modalità LED1"
-,"Led1 Frequency": "Frequenza LED1"
-,"Pan Absolute": "Pan assoluto"
-,"Power Line Frequency": "Frequenza della linea di alimentazione"
-,"Saturation": "Saturazione"
-,"Sharpness": "Nitidezza"
-,"Tilt Absolute": "Inclinazione assoluta"
-,"White Balance Temperature": "Temperatura del bilanciamento del bianco"
-,"White Balance Temperature Auto": "Temperatura di bilanciamento bianco automatico"
-,"Zoom Absolute": "Zoom assoluto"
+{
+  "": {
+    "language": "it",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "i caratteri speciali non sono ammessi nella password",
+  "Ĉi tiu kampo estas deviga": "Questo campo è obbligatorio",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "i caratteri speciali non sono ammessi nel nome della videocamera",
+  "valoro devas esti multoblo de 8": "il valore deve essere un multiplo di 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "i caratteri speciali non sono ammessi nel nome della cartella root",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "i file non possono essere creati direttamente nella cartella root",
+  "enigu validan retpoŝtadreson": "inserisci un indirizzo email valido",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "inserisci un elenco di indirizzi email validi separati da virgola",
+  "specialaj signoj ne rajtas en dosiernomo": "i caratteri speciali non sono ammessi nel nome file",
+  "enigu validan valoron": "inserisci un valore valido",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Questa azione eliminerà tutti i file nella cartella cloud in modo ricorsivo\"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", non solo quelli caricati da motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Questa azione eliminerà tutti i vecchi file multimediali nella cartella \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", non solo quelli creati da motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Non è possibile modificare la maschera senza un'immagine della videocamera valida!",
+  "Propra": "Personalizzato",
+  "Propra dosierindiko": "Percorso personalizzato",
+  "Retan kunlokon": "Risorsa di rete",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Il tuo browser non supporta questa funzione!",
+  "Apliki": "Applica",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Assicurati che tutte le opzioni siano valide!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Il sistema verrà riavviato. Continuare?",
+  "Vere fermiti sistemon?": "Spegnere il sistema?",
+  "Malŝaltita": "Spento",
+  "Ĉu vere restartigi ?": "Confermi di voler riavviare?",
+  "La sistemo rekomencis!": "Il sistema è stato riavviato!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Per favore applica le impostazioni modificate prima!",
+  "Neniu fotilo por forigi!": "Nessuna videocamera da rimuovere!",
+  "Ĉu forigi kameraon ": "Rimuovi la videocamera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye è aggiornato (versione corrente: ",
+  "Nova versio havebla: ": "Nuova versione disponibile: ",
+  ". Ĝisdatigi?": ". Aggiornare?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye è stato aggiornato correttamente!",
+  "Ĝisdatigo malsukcesis!": "Aggiornamento fallito!",
+  "La ĝisdatiga procezo malsukcesis!": "Il processo di aggiornamento non è andato a buon fine!",
+  "Rezerva dosiero": "File di backup",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "file di backup scaricato in precedenza.",
+  "Restaŭrigi Agordon": "Ripristina configurazione",
+  "Restaŭriganta agordon ...": "Ripristino della configurazione ...",
+  "La agordo restaŭrigis!": "La configurazione è stata ripristinata!",
+  "Malsukcesis restaŭri la agordon!": "Impossibile ripristinare la configurazione!",
+  "Aliri la alŝutan servon malsukcesis: ": "Accesso al servizio di caricamento non riuscito: ",
+  "Aliri la alŝutan servon sukcesis!": "L'accesso al servizio di caricamento è andato a buon fine!",
+  "Sciiga retpoŝto fiaskis:": "Notifica per email non riuscita:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Assicurati che tutte le opzioni siano valide!",
+  "Sciiga Telegramo fiaskis:": "Notifica Telegram fallita:",
+  "Sciiga Telegramo sukcesis!": "Notifica Telegram inviata!",
+  "Aliro al retdividado fiaskis: ": "Accesso alla risorsa di rete non riuscito: ",
+  "Aliro al retdividado sukcesis!": "Accesso alla risorsa di rete avvenuto con successo!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Eliminare il file?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Eliminare tutte le immagini da \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Rimuovere tutte le registrazioni da \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Eliminare tutte le immagini non raggruppate?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Eliminare tutte le registrazioni non raggruppate?",
+  "aldonadi kameraon...": "aggiungi videocamera ...",
+  "Uzantnomo": "Nome utente",
+  "Pasvorto": "Password",
+  "Memoru min": "Ricorda dati di accesso",
+  "Ensaluti": "Accedi",
+  "Nuligi": "Annulla",
+  "Vi abortis la filmeton.": "Hai interrotto il video.",
+  "Reto eraro okazis.": "Si è verificato un errore di rete.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Errore di decodifica o funzione media non supportata.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato non supportato o inaccessibile/non adatto alla riproduzione.",
+  "Nekonata eraro okazis.": "Si è verificato un errore sconosciuto.",
+  "Eraro : ": "Errore: ",
+  "antaŭa bildo": "immagine precedente",
+  "ludi": "play",
+  "ludi * 5 kaj enĉenigi": "riproduci * 5 e concatena",
+  "sekva bildo": "immagine successiva",
+  "Fermi": "Chiudi",
+  "Elŝuti": "Download",
+  "Forigi": "Rimuovi",
+  "Kamerao tipo": "Tipo di videocamera",
+  "Loka V4L2-kamerao": "Videocamera V4L2 locale",
+  "Loka MMAL-kamerao": "Videocamera MMAL locale",
+  "Reta kamerao": "Videocamera di rete",
+  "Fora motionEye kamerao": "Videocamera esterna",
+  "Simpla MJPEG-kamerao": "Videocamera MJPEG semplice",
+  "la speco de kamerao, kiun vi volas aldoni": "il tipo di videocamera che si desidera aggiungere",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://esempio.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "l'URL della videocamera (ad es. http://esempio.com:8080/cam/)",
+  "uzantnomo...": "nome utente ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "il nome utente per l'URL, se necessario (ad es. admin)",
+  "pasvorto...": "password ...",
+  "la pasvorto por la URL, se bezonata": "la password per l'URL, se necessario",
+  "Kamerao": "Videocamera",
+  "la kameraon, kiun vi volas aldoni": "la videocamera che vuoi aggiungere",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Una videocamera MotionEye remota è una videocamera installata dietro un altro server MotionEye. Aggiungendole qui potrai guardarle e gestirle a distanza.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Le videocamere di rete (o videocamere IP) sono dispositivi che trasmettono in streaming video RTSP/RTMP, MJPEG o semplici immagini JPEG. Consulta il manuale del tuo dispositivo per scoprire l'URL RTSP, RTMP, MJPEG o JPEG corretto.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Le videocamere MMAL locali sono dispositivi collegati direttamente al sistema motionEye. Di solito si tratta di telecamere specifiche della scheda.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "L'aggiunta del dispositivo come una semplice videocamera MJPEG anziché come una videocamera di rete migliorerà il frame rate, ma renderà non disponibile la rilevazione di movimento, l'acquisizione di immagini o registrazione di filmati. La videocamera deve essere accessibile al server e al browser. Questo tipo di videocamera non è compatibile con Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Le videocamere V4L2 locali sono dispositivi collegati direttamente al sistema motionEye, in genere tramite USB.",
+  "Aldonadi kameraon...": "Aggiungi videocamera ...",
+  "Grupo": "Gruppo",
+  "Inkluzivi foton prenitan ĉiun": "Includi una foto scattata ogni",
+  "sekundo": "secondo",
+  "5 sekundoj": "5 secondi",
+  "10 sekundoj": "10 secondi",
+  "30 sekundoj": "30 secondi",
+  "minuto": "Minuto",
+  "5 minutoj": "5 minuti",
+  "10 minutoj": "10 minuti",
+  "30 minutoj": "30 minuti",
+  "horo": "Ora",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seleziona l'intervallo di tempo tra due immagini selezionate.",
+  "Filmo framfrekvenco": "Frame rate filmato",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "seleziona la velocità di riproduzione del timelapse.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Considerando il gran numero di immagini, la creazione del tuo filmato in timelapse potrebbe richiedere del tempo!",
+  "Krei akselita video": "Crea un filmato in timelapse",
+  "Filmo kreanta en progreso...": "Creazione filmato in timelapse in corso ...",
+  "Zipitaj": "Compresso",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Elimina tutti",
+  "Bildoj prenitaj de ": "Foto scattate da ",
+  "Filmoj registritaj de ": "Filmati registrati da ",
+  "montru ĉi tiun fotilon plenekranan": "Mostra questa videocamera a tempo pieno",
+  "montri ĉiujn fotilojn": "Mostra tutte le videocamere",
+  "montru nur ĉi tiun fotilon": "Mostra solo questa videocamera",
+  "malfermaj bildoj retumilo": "apri il browser delle immagini",
+  "malferma videoj retumilo": "apri il browser dei filmati",
+  "agordi ĉi tiun kameraon": "imposta questa videocamera",
+  "preni instantaron": "scatta un'istantanea",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Non hai ancora configurato alcuna videocamera. Clicca qui per aggiungerne una ...",
+  "enigu pozitivan nombron": "inserisci un numero positivo",
+  "enigu pozitivan entjeran nombron": "inserisci un numero intero positivo",
+  "enigu nombron": "inserisci un numero",
+  "enigu entjeran nombron": "inserisci un numero intero",
+  " inter ": " tra ",
+  " kaj ": " e ",
+  " pli ol ": " maggiore di ",
+  " malpli ol ": " minore di ",
+  "enigu validan tempon en la sekva formato: HH:MM": "inserisci un orario valido nel seguente formato: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "inserisci un URL valido (ad es. http://esempio.com:8080/cams/)",
+  "fermi": "chiudi",
+  "Ne": "No",
+  "Jes": "Sì",
+  "Bone": "OK",
+  "Auto Exposure": "Esposizione automatica",
+  "Backlight Compensation": "Compensazione retroilluminazione",
+  "Brightness": "Luminosità",
+  "Contrast": "Contrasto",
+  "Exposure Absolute": "Esposizione assoluta",
+  "Exposure Auto": "Esposizione automatica",
+  "Exposure Auto Priority": "Esposizione priorità automatica",
+  "Exposure Time Absolute": "Tempo di esposizione assoluta",
+  "Focus Absolute": "Focus assoluto",
+  "Focus Auto": "Auto Focus",
+  "Gain": "Guadagno",
+  "Gamma": "Gamma",
+  "Hue": "Tinta",
+  "Led1 Mode": "Modalità LED1",
+  "Led1 Frequency": "Frequenza LED1",
+  "Pan Absolute": "Pan assoluto",
+  "Power Line Frequency": "Frequenza della linea di alimentazione",
+  "Saturation": "Saturazione",
+  "Sharpness": "Nitidezza",
+  "Tilt Absolute": "Inclinazione assoluta",
+  "White Balance Temperature": "Temperatura del bilanciamento del bianco",
+  "White Balance Temperature Auto": "Temperatura di bilanciamento bianco automatico",
+  "Zoom Absolute": "Zoom assoluto",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ja.json
+++ b/motioneye/static/js/motioneye.ja.json
@@ -1,164 +1,176 @@
-{"":{"language":"ja","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "パスワードに特殊文字は使用できません"
-,"Ĉi tiu kampo estas deviga": "このフィールドは必須です"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "カメラ名に特殊文字は使用できません"
-,"valoro devas esti multoblo de 8": "値は8の倍数でなければなりません"
-,"specialaj signoj ne rajtas en radika voja nomo": "ルートパス名に特殊文字は使用できません"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "システムのルートに直接ファイルを作成することはできません"
-,"enigu validan retpoŝtadreson": "有効なメールアドレスを入力してください"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "カンマ区切りの有効なメールアドレスのリストを入力してください"
-,"specialaj signoj ne rajtas en dosiernomo": "ファイル名に特殊文字は使用できません"
-,"enigu validan valoron": "有効な値を入力してください"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "これにより、クラウドフォルダ内のすべてのファイルが再帰的に削除されます \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\"、motionEyeによってアップロードされたものだけではありません！"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "これにより、フォルダ内のすべての古いメディアファイルが再帰的に削除されます \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\"、motionEyeによって作成されたものだけではありません！"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "有効なカメラ画像がないとマスクを編集できません！"
-,"Propra": "カスタム"
-,"Propra dosierindiko": "カスタムファイル名"
-,"Retan kunlokon": "オンラインコミュニケーション"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "あなたのブラウザはこの機能を実行しません！"
-,"Apliki": "適用"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "すべての構成オプションが有効であることを確認してください！"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "これにより、システムが再起動します。続けますか？"
-,"Vere fermiti sistemon?": "システムを本当にシャットダウンしますか？"
-,"Malŝaltita": "オフ"
-,"Ĉu vere restartigi ?": "本当に再起動しますか？"
-,"La sistemo rekomencis!": "システムが再起動しました！"
-,"Bonvolu apliki unue la modifitajn agordojn!": "最初に変更した設定を適用してください！"
-,"Neniu fotilo por forigi!": "取り外すカメラはありません！"
-,"Ĉu forigi kameraon ": "カメラを取り外し可能"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEyeが更新されました（現在のバージョン："
-,"Nova versio havebla: ": "利用可能な新しいバージョン："
-,". Ĝisdatigi?": "。更新しますか？"
-,"motionEye estis sukcese ĝisdatigita!": "motionEyeが更新されました！"
-,"Ĝisdatigo malsukcesis!": "更新に失敗しました！"
-,"La ĝisdatiga procezo malsukcesis!": "アップグレードプロセスは失敗しました！"
-,"Rezerva dosiero": "バックアップファイル"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "以前にダウンロードしたバックアップファイル。"
-,"Restaŭrigi Agordon": "構成の復元"
-,"Restaŭriganta agordon ...": "設定を復元しています..."
-,"La agordo restaŭrigis!": "設定が復元されました！"
-,"Malsukcesis restaŭri la agordon!": "構成の復元に失敗しました！"
-,"Aliri la alŝutan servon malsukcesis: ": "アップロードサービスへのアクセスに失敗しました："
-,"Aliri la alŝutan servon sukcesis!": "アップロードサービスへのアクセスに成功しました！"
-,"Sciiga retpoŝto fiaskis:": "ニュース電子メールに失敗しました："
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "すべての設定オプションが有効であることを確認してください。"
-,"Sciiga Telegramo fiaskis:": "通知テレグラムに失敗しました。"
-,"Sciiga Telegramo sukcesis!": "通知テレグラムは成功しました！"
-,"Aliro al retdividado fiaskis: ": "ネットワーク送信へのアクセスに失敗しました。"
-,"Aliro al retdividado sukcesis!": "遅延へのアクセスは成功しました！"
-,"Ĉu vere forigi ĉi tiun dosieron?": "このファイルを本当に削除しますか？"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "「%(group)s（グループ）s」から本当にすべての画像を削除しますか？"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "「%(group)s（グループ）s」からすべての映画を本当に削除しますか？"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "グループ化されていないすべての画像を本当に削除しますか？"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "グループ化されていないすべての映画を本当に削除しますか？"
-,"aldonadi kameraon...": "カメラを追加..."
-,"Uzantnomo": "ユーザ名"
-,"Pasvorto": "パスワード"
-,"Memoru min": "覚えて"
-,"Ensaluti": "ログイン"
-,"Nuligi": "キャンセルする"
-,"Vi abortis la filmeton.": "ビデオを中止しました。"
-,"Reto eraro okazis.": "ネットワークエラーが発生しました。"
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "デコードエラーまたは非投影関数。"
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "フォーマットがサポートされていないか、アクセスできない/再生に適していません。"
-,"Nekonata eraro okazis.": "不明なエラーが発生しました。"
-,"Eraro : ": "エラー："
-,"antaŭa bildo": "前の画像"
-,"ludi": "遊ぶ"
-,"ludi * 5 kaj enĉenigi": "再生* 5とチェーン"
-,"sekva bildo": "次の画像"
-,"Fermi": "閉じる"
-,"Elŝuti": "ダウンロードする"
-,"Forigi": "取り除く"
-,"Kamerao tipo": "カメラタイプ"
-,"Loka V4L2-kamerao": "ローカルV4L2カメラ"
-,"Loka MMAL-kamerao": "ローカルMMALカメラ"
-,"Reta kamerao": "ウェブカメラ"
-,"Fora motionEye kamerao": "外のモーションアイカメラ"
-,"Simpla MJPEG-kamerao": "シンプルなMJPEGカメラ"
-,"la speco de kamerao, kiun vi volas aldoni": "追加するカメラのタイプ"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http：//example.com：8765 / cams / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "カメラのURL（例：http://example.com:8080/cam/）"
-,"uzantnomo...": "ユーザー名..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "必要に応じて、URLのユーザー名（例：admin）"
-,"pasvorto...": "パスワード..."
-,"la pasvorto por la URL, se bezonata": "必要に応じて、URLのパスワード"
-,"Kamerao": "カメラ"
-,"la kameraon, kiun vi volas aldoni": "追加するカメラ"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "リモートmotionEyeカメラは、別のMotionEyeサーバーの背後に設置されたカメラです。ここに追加すると、離れた場所から監視および管理できます。"
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "ネットワークカメラ（またはIPカメラ）は、RTSP / RTMPまたはMJPEGビデオまたは単純なJPEG画像をネイティブにストリーミングするデバイスです。デバイスのマニュアルを参照して、正しいRTSP、RTMP、MJPEG、またはJPEG URLを確認してください。"
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "ローカルMMALカメラは、motionEyeシステムに直接接続されているデバイスです。これらは通常、カード固有のカメラです。"
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "デバイスをWebカメラとしてではなく、単純なMJPEGカメラとして追加すると、写真が改善されますが、動きの検出、画像のキャプチャ、または動画の記録は利用できません。カメラは、サーバーとブラウザーにアクセスできる必要があります。このタイプのカメラはInternet Explorerと一致しません。"
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "ローカルV4L2カメラは、通常USBを介してモーションアイシステムに直接接続されたカメラデバイスです。"
-,"Aldonadi kameraon...": "カメラを追加..."
-,"Grupo": "団体"
-,"Inkluzivi foton prenitan ĉiun": "それぞれ撮影した写真を含める"
-,"sekundo": "秒"
-,"5 sekundoj": "5秒"
-,"10 sekundoj": "10秒"
-,"30 sekundoj": "30秒"
-,"minuto": "分"
-,"5 minutoj": "5分"
-,"10 minutoj": "10分"
-,"30 minutoj": "30分"
-,"horo": "時"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "選択した2つの画像間の時間間隔を選択します。"
-,"Filmo framfrekvenco": "映画のフレームレート"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "アクセラレーションビデオの速度を選択します。"
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "画像の数が多いため、動画の作成には時間がかかる場合があります。"
-,"Krei akselita video": "加速したビデオを作成する"
-,"Filmo kreanta en progreso...": "進行中の映画..."
-,"Zipitaj": "ジッパー付き"
-,"Akselita video": "加速ビデオ"
-,"Forigi ĉiujn": "それらをすべて削除します"
-,"Bildoj prenitaj de ": "撮影した写真"
-,"Filmoj registritaj de ": "によって記録された映画"
-,"montru ĉi tiun fotilon plenekranan": "このカメラをフルタイムに見せる"
-,"montri ĉiujn fotilojn": "すべてのカメラを表示"
-,"montru nur ĉi tiun fotilon": "このカメラだけを表示します"
-,"malfermaj bildoj retumilo": "画像ブラウザを開く"
-,"malferma videoj retumilo": "動画ブラウザを開く"
-,"agordi ĉi tiun kameraon": "このカメラをセット"
-,"preni instantaron": "スナップショットを撮る"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "あなたはまだカメラを設定していません。 1つを追加するにはここをクリック..."
-,"enigu pozitivan nombron": "正の数を入力してください"
-,"enigu pozitivan entjeran nombron": "正の整数を入力してください"
-,"enigu nombron": "数字を入力してください"
-,"enigu entjeran nombron": "整数を入力してください"
-," inter ": "間に"
-," kaj ": "と"
-," pli ol ": "以上"
-," malpli ol ": "より少ない"
-,"enigu validan tempon en la sekva formato: HH:MM": "有効な時刻を次の形式で入力してください：HH：MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "有効なURLを入力してください（例：http://example.com:8080/cams/）"
-,"fermi": "閉じる"
-,"Ne": "いいえ"
-,"Jes": "はい"
-,"Bone": "よし"
-,"Auto Exposure": "自動露出"
-,"Backlight Compensation": "バックライト補償"
-,"Brightness": "輝度"
-,"Contrast": "対比"
-,"Exposure Absolute": "絶対に露出"
-,"Exposure Auto": "露出自動"
-,"Exposure Auto Priority": "露出自動優先度"
-,"Exposure Time Absolute": "絶対に露出時間"
-,"Focus Absolute": "絶対に集中してください"
-,"Focus Auto": "フォーカスオート"
-,"Gain": "利得"
-,"Gamma": "ガンマ"
-,"Hue": "色相"
-,"Led1 Mode": "LED1モード"
-,"Led1 Frequency": "LED1周波数"
-,"Pan Absolute": "絶対にパン"
-,"Power Line Frequency": "電力線周波数"
-,"Saturation": "飽和"
-,"Sharpness": "シャープネス"
-,"Tilt Absolute": "絶対に傾けます"
-,"White Balance Temperature": "ホワイトバランス温度"
-,"White Balance Temperature Auto": "ホワイトバランス温度自動"
-,"Zoom Absolute": "絶対にズームします"
+{
+  "": {
+    "language": "ja",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "パスワードに特殊文字は使用できません",
+  "Ĉi tiu kampo estas deviga": "このフィールドは必須です",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "カメラ名に特殊文字は使用できません",
+  "valoro devas esti multoblo de 8": "値は8の倍数でなければなりません",
+  "specialaj signoj ne rajtas en radika voja nomo": "ルートパス名に特殊文字は使用できません",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "システムのルートに直接ファイルを作成することはできません",
+  "enigu validan retpoŝtadreson": "有効なメールアドレスを入力してください",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "カンマ区切りの有効なメールアドレスのリストを入力してください",
+  "specialaj signoj ne rajtas en dosiernomo": "ファイル名に特殊文字は使用できません",
+  "enigu validan valoron": "有効な値を入力してください",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "これにより、クラウドフォルダ内のすべてのファイルが再帰的に削除されます \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\"、motionEyeによってアップロードされたものだけではありません！",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "これにより、フォルダ内のすべての古いメディアファイルが再帰的に削除されます \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\"、motionEyeによって作成されたものだけではありません！",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "有効なカメラ画像がないとマスクを編集できません！",
+  "Propra": "カスタム",
+  "Propra dosierindiko": "カスタムファイル名",
+  "Retan kunlokon": "オンラインコミュニケーション",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "あなたのブラウザはこの機能を実行しません！",
+  "Apliki": "適用",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "すべての構成オプションが有効であることを確認してください！",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "これにより、システムが再起動します。続けますか？",
+  "Vere fermiti sistemon?": "システムを本当にシャットダウンしますか？",
+  "Malŝaltita": "オフ",
+  "Ĉu vere restartigi ?": "本当に再起動しますか？",
+  "La sistemo rekomencis!": "システムが再起動しました！",
+  "Bonvolu apliki unue la modifitajn agordojn!": "最初に変更した設定を適用してください！",
+  "Neniu fotilo por forigi!": "取り外すカメラはありません！",
+  "Ĉu forigi kameraon ": "カメラを取り外し可能",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEyeが更新されました（現在のバージョン：",
+  "Nova versio havebla: ": "利用可能な新しいバージョン：",
+  ". Ĝisdatigi?": "。更新しますか？",
+  "motionEye estis sukcese ĝisdatigita!": "motionEyeが更新されました！",
+  "Ĝisdatigo malsukcesis!": "更新に失敗しました！",
+  "La ĝisdatiga procezo malsukcesis!": "アップグレードプロセスは失敗しました！",
+  "Rezerva dosiero": "バックアップファイル",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "以前にダウンロードしたバックアップファイル。",
+  "Restaŭrigi Agordon": "構成の復元",
+  "Restaŭriganta agordon ...": "設定を復元しています...",
+  "La agordo restaŭrigis!": "設定が復元されました！",
+  "Malsukcesis restaŭri la agordon!": "構成の復元に失敗しました！",
+  "Aliri la alŝutan servon malsukcesis: ": "アップロードサービスへのアクセスに失敗しました：",
+  "Aliri la alŝutan servon sukcesis!": "アップロードサービスへのアクセスに成功しました！",
+  "Sciiga retpoŝto fiaskis:": "ニュース電子メールに失敗しました：",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "すべての設定オプションが有効であることを確認してください。",
+  "Sciiga Telegramo fiaskis:": "通知テレグラムに失敗しました。",
+  "Sciiga Telegramo sukcesis!": "通知テレグラムは成功しました！",
+  "Aliro al retdividado fiaskis: ": "ネットワーク送信へのアクセスに失敗しました。",
+  "Aliro al retdividado sukcesis!": "遅延へのアクセスは成功しました！",
+  "Ĉu vere forigi ĉi tiun dosieron?": "このファイルを本当に削除しますか？",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "「%(group)s（グループ）s」から本当にすべての画像を削除しますか？",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "「%(group)s（グループ）s」からすべての映画を本当に削除しますか？",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "グループ化されていないすべての画像を本当に削除しますか？",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "グループ化されていないすべての映画を本当に削除しますか？",
+  "aldonadi kameraon...": "カメラを追加...",
+  "Uzantnomo": "ユーザ名",
+  "Pasvorto": "パスワード",
+  "Memoru min": "覚えて",
+  "Ensaluti": "ログイン",
+  "Nuligi": "キャンセルする",
+  "Vi abortis la filmeton.": "ビデオを中止しました。",
+  "Reto eraro okazis.": "ネットワークエラーが発生しました。",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "デコードエラーまたは非投影関数。",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "フォーマットがサポートされていないか、アクセスできない/再生に適していません。",
+  "Nekonata eraro okazis.": "不明なエラーが発生しました。",
+  "Eraro : ": "エラー：",
+  "antaŭa bildo": "前の画像",
+  "ludi": "遊ぶ",
+  "ludi * 5 kaj enĉenigi": "再生* 5とチェーン",
+  "sekva bildo": "次の画像",
+  "Fermi": "閉じる",
+  "Elŝuti": "ダウンロードする",
+  "Forigi": "取り除く",
+  "Kamerao tipo": "カメラタイプ",
+  "Loka V4L2-kamerao": "ローカルV4L2カメラ",
+  "Loka MMAL-kamerao": "ローカルMMALカメラ",
+  "Reta kamerao": "ウェブカメラ",
+  "Fora motionEye kamerao": "外のモーションアイカメラ",
+  "Simpla MJPEG-kamerao": "シンプルなMJPEGカメラ",
+  "la speco de kamerao, kiun vi volas aldoni": "追加するカメラのタイプ",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http：//example.com：8765 / cams / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "カメラのURL（例：http://example.com:8080/cam/）",
+  "uzantnomo...": "ユーザー名...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "必要に応じて、URLのユーザー名（例：admin）",
+  "pasvorto...": "パスワード...",
+  "la pasvorto por la URL, se bezonata": "必要に応じて、URLのパスワード",
+  "Kamerao": "カメラ",
+  "la kameraon, kiun vi volas aldoni": "追加するカメラ",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "リモートmotionEyeカメラは、別のMotionEyeサーバーの背後に設置されたカメラです。ここに追加すると、離れた場所から監視および管理できます。",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "ネットワークカメラ（またはIPカメラ）は、RTSP / RTMPまたはMJPEGビデオまたは単純なJPEG画像をネイティブにストリーミングするデバイスです。デバイスのマニュアルを参照して、正しいRTSP、RTMP、MJPEG、またはJPEG URLを確認してください。",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "ローカルMMALカメラは、motionEyeシステムに直接接続されているデバイスです。これらは通常、カード固有のカメラです。",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "デバイスをWebカメラとしてではなく、単純なMJPEGカメラとして追加すると、写真が改善されますが、動きの検出、画像のキャプチャ、または動画の記録は利用できません。カメラは、サーバーとブラウザーにアクセスできる必要があります。このタイプのカメラはInternet Explorerと一致しません。",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "ローカルV4L2カメラは、通常USBを介してモーションアイシステムに直接接続されたカメラデバイスです。",
+  "Aldonadi kameraon...": "カメラを追加...",
+  "Grupo": "団体",
+  "Inkluzivi foton prenitan ĉiun": "それぞれ撮影した写真を含める",
+  "sekundo": "秒",
+  "5 sekundoj": "5秒",
+  "10 sekundoj": "10秒",
+  "30 sekundoj": "30秒",
+  "minuto": "分",
+  "5 minutoj": "5分",
+  "10 minutoj": "10分",
+  "30 minutoj": "30分",
+  "horo": "時",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "選択した2つの画像間の時間間隔を選択します。",
+  "Filmo framfrekvenco": "映画のフレームレート",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "アクセラレーションビデオの速度を選択します。",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "画像の数が多いため、動画の作成には時間がかかる場合があります。",
+  "Krei akselita video": "加速したビデオを作成する",
+  "Filmo kreanta en progreso...": "進行中の映画...",
+  "Zipitaj": "ジッパー付き",
+  "Akselita video": "加速ビデオ",
+  "Forigi ĉiujn": "それらをすべて削除します",
+  "Bildoj prenitaj de ": "撮影した写真",
+  "Filmoj registritaj de ": "によって記録された映画",
+  "montru ĉi tiun fotilon plenekranan": "このカメラをフルタイムに見せる",
+  "montri ĉiujn fotilojn": "すべてのカメラを表示",
+  "montru nur ĉi tiun fotilon": "このカメラだけを表示します",
+  "malfermaj bildoj retumilo": "画像ブラウザを開く",
+  "malferma videoj retumilo": "動画ブラウザを開く",
+  "agordi ĉi tiun kameraon": "このカメラをセット",
+  "preni instantaron": "スナップショットを撮る",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "あなたはまだカメラを設定していません。 1つを追加するにはここをクリック...",
+  "enigu pozitivan nombron": "正の数を入力してください",
+  "enigu pozitivan entjeran nombron": "正の整数を入力してください",
+  "enigu nombron": "数字を入力してください",
+  "enigu entjeran nombron": "整数を入力してください",
+  " inter ": "間に",
+  " kaj ": "と",
+  " pli ol ": "以上",
+  " malpli ol ": "より少ない",
+  "enigu validan tempon en la sekva formato: HH:MM": "有効な時刻を次の形式で入力してください：HH：MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "有効なURLを入力してください（例：http://example.com:8080/cams/）",
+  "fermi": "閉じる",
+  "Ne": "いいえ",
+  "Jes": "はい",
+  "Bone": "よし",
+  "Auto Exposure": "自動露出",
+  "Backlight Compensation": "バックライト補償",
+  "Brightness": "輝度",
+  "Contrast": "対比",
+  "Exposure Absolute": "絶対に露出",
+  "Exposure Auto": "露出自動",
+  "Exposure Auto Priority": "露出自動優先度",
+  "Exposure Time Absolute": "絶対に露出時間",
+  "Focus Absolute": "絶対に集中してください",
+  "Focus Auto": "フォーカスオート",
+  "Gain": "利得",
+  "Gamma": "ガンマ",
+  "Hue": "色相",
+  "Led1 Mode": "LED1モード",
+  "Led1 Frequency": "LED1周波数",
+  "Pan Absolute": "絶対にパン",
+  "Power Line Frequency": "電力線周波数",
+  "Saturation": "飽和",
+  "Sharpness": "シャープネス",
+  "Tilt Absolute": "絶対に傾けます",
+  "White Balance Temperature": "ホワイトバランス温度",
+  "White Balance Temperature Auto": "ホワイトバランス温度自動",
+  "Zoom Absolute": "絶対にズームします",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ko.json
+++ b/motioneye/static/js/motioneye.ko.json
@@ -1,164 +1,176 @@
-{"":{"language":"ko","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "암호에 특수문자는 사용할 수 없습니다"
-,"Ĉi tiu kampo estas deviga": "필수 항목입니다"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "카메라 이름에 특수문자는 사용할 수 없습니다"
-,"valoro devas esti multoblo de 8": "값은 8의 배수여야 합니다"
-,"specialaj signoj ne rajtas en radika voja nomo": "root 디렉토리 이름에 특수문자를 사용할 수 없습니다"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "시스템의 root에 바로 파일을 생성할 수 없습니다"
-,"enigu validan retpoŝtadreson": "유효한 이메일 주소를 입력하세요"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "쉼표로 구분된 유효한 이메일 주소 목록을 입력하세요"
-,"specialaj signoj ne rajtas en dosiernomo": "파일명에 특수문자를 사용할 수 없습니다"
-,"enigu validan valoron": "유효한 값을 입력하세요"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "다음 클라우드 폴더 내의 모든 파일을 지우게 됩니다: \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\" motionEye에서 업로드된 것이 아니어도 말이죠!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "다음 폴더 내의 모든 오래된 미디어 파일을 지울 것입니다: \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\" motionEye에서 생성된 것이 아니어도 말이죠!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "유효한 카메라 이미지 없이는 마스크를 수정할 수 없습니다!"
-,"Propra": "커스텀"
-,"Propra dosierindiko": "커스텀 경로"
-,"Retan kunlokon": "네트워크 공유"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "이 브라우저는 이 기능을 지원하지 않습니다!"
-,"Apliki": "적용"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "모든 옵션이 유효한지 확실히 해주세요!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "시스템을 재시작하게 됩니다. 계속할까요?"
-,"Vere fermiti sistemon?": "정말 종료할까요?"
-,"Malŝaltita": "전원 꺼짐"
-,"Ĉu vere restartigi ?": "정말 재시작할까요?"
-,"La sistemo rekomencis!": "시스템이 다시 시작됐습니다!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "우선 수정된 설정을 적용해주세요!"
-,"Neniu fotilo por forigi!": "제거할 카메라가 없습니다!"
-,"Ĉu forigi kameraon ": "카메라 제거 "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye가 최신 버전입니다 (현재 버전: "
-,"Nova versio havebla: ": "새 버전을 사용할 수 있습니다: "
-,". Ĝisdatigi?": ". 업데이트할까요?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye가 성공적으로 업데이트되었습니다!"
-,"Ĝisdatigo malsukcesis!": "업데이트에 실패했습니다!"
-,"La ĝisdatiga procezo malsukcesis!": "업데이트 처리에 실패했습니다!"
-,"Rezerva dosiero": "백업 파일"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "이전에 다운로드한 백업 파일입니다."
-,"Restaŭrigi Agordon": "설정 복원"
-,"Restaŭriganta agordon ...": "설정 복원 중..."
-,"La agordo restaŭrigis!": "설정이 복원되었습니다!"
-,"Malsukcesis restaŭri la agordon!": "설정 복원에 실패했습니다!"
-,"Aliri la alŝutan servon malsukcesis: ": "업로드 서비스 접근에 실패했습니다: "
-,"Aliri la alŝutan servon sukcesis!": "업로드 서비스 연결에 성공했습니다!"
-,"Sciiga retpoŝto fiaskis:": "알림 이메일 전송에 실패했습니다:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "모든 설정 값이 유효한지 확실히 해주세요!"
-,"Sciiga Telegramo fiaskis:": "텔레그램 알림 실패:"
-,"Sciiga Telegramo sukcesis!": "텔레그램 알림 성공!"
-,"Aliro al retdividado fiaskis: ": "네트워크 공유 접근에 실패했습니다: "
-,"Aliro al retdividado sukcesis!": "네트워크 공유 접근에 성공했습니다!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "이 파일을 정말 삭제할까요?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "정말 \"%(group)\"의 모든 사진을 삭제할까요?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "정말 \"%(group)\"의 모든 영상을 삭제할까요?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "정말 그룹에 속하지 않은 모든 사진을 삭제할까요?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "정말 그룹에 속하지 않은 모든 영상을 삭제할까요?"
-,"aldonadi kameraon...": "카메라 추가..."
-,"Uzantnomo": "사용자 이름"
-,"Pasvorto": "암호"
-,"Memoru min": "기억하기"
-,"Ensaluti": "로그인"
-,"Nuligi": "취소"
-,"Vi abortis la filmeton.": "영상을 취소했습니다."
-,"Reto eraro okazis.": "네트워크 오류가 발생했습니다."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "미디어를 디코딩 중 오류가 발생했거나 지원되지 않는 미디어입니다."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "지원되지 않는 형식이거나, 재생에 적합하지 않거나, 접근이 불가능합니다."
-,"Nekonata eraro okazis.": "알 수 없는 오류가 발생했습니다."
-,"Eraro : ": "오류: "
-,"antaŭa bildo": "이전 사진"
-,"ludi": "재생"
-,"ludi * 5 kaj enĉenigi": "5개 재생 및 연속"
-,"sekva bildo": "다음 사진"
-,"Fermi": "닫기"
-,"Elŝuti": "다운로드"
-,"Forigi": "제거"
-,"Kamerao tipo": "카메라 종류"
-,"Loka V4L2-kamerao": "로컬 V4L2 카메라"
-,"Loka MMAL-kamerao": "로컬 MMAL 카메라"
-,"Reta kamerao": "네트워크 카메라"
-,"Fora motionEye kamerao": "원격 motionEye 카메라"
-,"Simpla MJPEG-kamerao": "단순 MJPEG 카메라"
-,"la speco de kamerao, kiun vi volas aldoni": "추가할 카메라의 종류"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "카메라 URL (예: http://example.com:8080/cams/)"
-,"uzantnomo...": "사용자 이름..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "필요할 경우, URL에 사용할 사용자 이름 (예: admin)"
-,"pasvorto...": "암호..."
-,"la pasvorto por la URL, se bezonata": "필요할 경우, URL을 위한 암호"
-,"Kamerao": "카메라"
-,"la kameraon, kiun vi volas aldoni": "추가하려는 카메라"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "원격 motionEye카메라는 다른 motionEye 서버에 연결된 카메라로, 이 곳에 추가하여 멀리 떨어진 곳에 있는 카메라도 보고 관리할 수 있습니다."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "네트워크 카메라(또는 IP카메라)는 RTSP/RTMP 또는 MJPEG형식의 영상이나 JPEG 이미지를 자체적으로 송출합니다. 정확한 RTSP, RTMP, MJPEG 또는 JPEG URL은 각 장치의 설명서를 참조하십시오."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "로컬 MMAL 카메라는 이 motionEye 시스템에 직결된 장치로, 대개 특정 보드 전용 카메라입니다."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "네트워크 카메라 대신 MJPEG 카메라로 장치를 추가할 경우 초당 프레임 수는 증가하지만 움직임 감지, 사진 캡쳐와 영상 녹화는 사용할 수 없게 됩니다. 카메라는 서버와 브라우저에서 볼 수 있습니다. 이 형식의 카메라는 Internet Explorer에서 사용할 수 없습니다."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "로컬 V4L2 카메라는 motionEye 시스템에 직결된 카메라로, 대개 USB로 연결됩니다."
-,"Aldonadi kameraon...": "카메라 추가..."
-,"Grupo": "그룹"
-,"Inkluzivi foton prenitan ĉiun": "매 X마다 찍힌 사진 포함"
-,"sekundo": "초"
-,"5 sekundoj": "5초"
-,"10 sekundoj": "10초"
-,"30 sekundoj": "30초"
-,"minuto": "1분"
-,"5 minutoj": "5분"
-,"10 minutoj": "10분"
-,"30 minutoj": "30분"
-,"horo": "1시간"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "선택된 두 사진 사이의 시간 간격을 선택하세요."
-,"Filmo framfrekvenco": "영상 초당 프레임 수"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "타임랩스 재생 속도를 선택하세요."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "선택된 사진 수가 많으면 타임랩스 생성에 시간이 좀 걸릴 수 있습니다!"
-,"Krei akselita video": "타임랩스 영상 만들기"
-,"Filmo kreanta en progreso...": "타임랩스 영상 만드는 중..."
-,"Zipitaj": "압축됨"
-,"Akselita video": "타임랩스"
-,"Forigi ĉiujn": "전체 삭제"
-,"Bildoj prenitaj de ": "사진 촬영자: "
-,"Filmoj registritaj de ": "영상 촬영자: "
-,"montru ĉi tiun fotilon plenekranan": "카메라 전체화면으로 보기"
-,"montri ĉiujn fotilojn": "전체 카메라 보기"
-,"montru nur ĉi tiun fotilon": "이 카메라만 보기"
-,"malfermaj bildoj retumilo": "사진 탐색기 열기"
-,"malferma videoj retumilo": "영상 탐색기 보기"
-,"agordi ĉi tiun kameraon": "이 카메라 설정"
-,"preni instantaron": "스냅샷 촬영"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "설정된 카메라가 없습니다. 여기를 클릭해서 생성하세요."
-,"enigu pozitivan nombron": "0보다 큰 수 입력"
-,"enigu pozitivan entjeran nombron": "0보다 큰 정수 입력"
-,"enigu nombron": "수 입력"
-,"enigu entjeran nombron": "정수 입력"
-," inter ": " 사이 "
-," kaj ": " 와(과) "
-," pli ol ": " 초과 "
-," malpli ol ": " 미만 "
-,"enigu validan tempon en la sekva formato: HH:MM": "MM 형식으로 유효한 시간 입력"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "유효한 URL 입력 (예: http://example.com:8080/cams/)"
-,"fermi": "닫기"
-,"Ne": "아니오"
-,"Jes": "예"
-,"Bone": "확인"
-,"Auto Exposure": "자동 노출"
-,"Backlight Compensation": "후광 보정"
-,"Brightness": "밝기"
-,"Contrast": "대비"
-,"Exposure Absolute": "절대 노출"
-,"Exposure Auto": "노출 자동"
-,"Exposure Auto Priority": "자동 노출 우선순위"
-,"Exposure Time Absolute": "절대 노출 시간"
-,"Focus Absolute": "절대 초점"
-,"Focus Auto": "자동 초점"
-,"Gain": "얻다"
-,"Gamma": "감마"
-,"Hue": "색조"
-,"Led1 Mode": "LED1 모드"
-,"Led1 Frequency": "LED1 빈도"
-,"Pan Absolute": "절대 팬(Pan)"
-,"Power Line Frequency": "전원 주파수"
-,"Saturation": "채도"
-,"Sharpness": "선명도"
-,"Tilt Absolute": "절대 기울기"
-,"White Balance Temperature": "화이트밸런스 온도"
-,"White Balance Temperature Auto": "자동 화이트밸런스 온도"
-,"Zoom Absolute": "절대 확대"
+{
+  "": {
+    "language": "ko",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "암호에 특수문자는 사용할 수 없습니다",
+  "Ĉi tiu kampo estas deviga": "필수 항목입니다",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "카메라 이름에 특수문자는 사용할 수 없습니다",
+  "valoro devas esti multoblo de 8": "값은 8의 배수여야 합니다",
+  "specialaj signoj ne rajtas en radika voja nomo": "root 디렉토리 이름에 특수문자를 사용할 수 없습니다",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "시스템의 root에 바로 파일을 생성할 수 없습니다",
+  "enigu validan retpoŝtadreson": "유효한 이메일 주소를 입력하세요",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "쉼표로 구분된 유효한 이메일 주소 목록을 입력하세요",
+  "specialaj signoj ne rajtas en dosiernomo": "파일명에 특수문자를 사용할 수 없습니다",
+  "enigu validan valoron": "유효한 값을 입력하세요",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "다음 클라우드 폴더 내의 모든 파일을 지우게 됩니다: \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\" motionEye에서 업로드된 것이 아니어도 말이죠!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "다음 폴더 내의 모든 오래된 미디어 파일을 지울 것입니다: \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\" motionEye에서 생성된 것이 아니어도 말이죠!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "유효한 카메라 이미지 없이는 마스크를 수정할 수 없습니다!",
+  "Propra": "커스텀",
+  "Propra dosierindiko": "커스텀 경로",
+  "Retan kunlokon": "네트워크 공유",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "이 브라우저는 이 기능을 지원하지 않습니다!",
+  "Apliki": "적용",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "모든 옵션이 유효한지 확실히 해주세요!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "시스템을 재시작하게 됩니다. 계속할까요?",
+  "Vere fermiti sistemon?": "정말 종료할까요?",
+  "Malŝaltita": "전원 꺼짐",
+  "Ĉu vere restartigi ?": "정말 재시작할까요?",
+  "La sistemo rekomencis!": "시스템이 다시 시작됐습니다!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "우선 수정된 설정을 적용해주세요!",
+  "Neniu fotilo por forigi!": "제거할 카메라가 없습니다!",
+  "Ĉu forigi kameraon ": "카메라 제거 ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye가 최신 버전입니다 (현재 버전: ",
+  "Nova versio havebla: ": "새 버전을 사용할 수 있습니다: ",
+  ". Ĝisdatigi?": ". 업데이트할까요?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye가 성공적으로 업데이트되었습니다!",
+  "Ĝisdatigo malsukcesis!": "업데이트에 실패했습니다!",
+  "La ĝisdatiga procezo malsukcesis!": "업데이트 처리에 실패했습니다!",
+  "Rezerva dosiero": "백업 파일",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "이전에 다운로드한 백업 파일입니다.",
+  "Restaŭrigi Agordon": "설정 복원",
+  "Restaŭriganta agordon ...": "설정 복원 중...",
+  "La agordo restaŭrigis!": "설정이 복원되었습니다!",
+  "Malsukcesis restaŭri la agordon!": "설정 복원에 실패했습니다!",
+  "Aliri la alŝutan servon malsukcesis: ": "업로드 서비스 접근에 실패했습니다: ",
+  "Aliri la alŝutan servon sukcesis!": "업로드 서비스 연결에 성공했습니다!",
+  "Sciiga retpoŝto fiaskis:": "알림 이메일 전송에 실패했습니다:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "모든 설정 값이 유효한지 확실히 해주세요!",
+  "Sciiga Telegramo fiaskis:": "텔레그램 알림 실패:",
+  "Sciiga Telegramo sukcesis!": "텔레그램 알림 성공!",
+  "Aliro al retdividado fiaskis: ": "네트워크 공유 접근에 실패했습니다: ",
+  "Aliro al retdividado sukcesis!": "네트워크 공유 접근에 성공했습니다!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "이 파일을 정말 삭제할까요?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "정말 \"%(group)\"의 모든 사진을 삭제할까요?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "정말 \"%(group)\"의 모든 영상을 삭제할까요?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "정말 그룹에 속하지 않은 모든 사진을 삭제할까요?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "정말 그룹에 속하지 않은 모든 영상을 삭제할까요?",
+  "aldonadi kameraon...": "카메라 추가...",
+  "Uzantnomo": "사용자 이름",
+  "Pasvorto": "암호",
+  "Memoru min": "기억하기",
+  "Ensaluti": "로그인",
+  "Nuligi": "취소",
+  "Vi abortis la filmeton.": "영상을 취소했습니다.",
+  "Reto eraro okazis.": "네트워크 오류가 발생했습니다.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "미디어를 디코딩 중 오류가 발생했거나 지원되지 않는 미디어입니다.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "지원되지 않는 형식이거나, 재생에 적합하지 않거나, 접근이 불가능합니다.",
+  "Nekonata eraro okazis.": "알 수 없는 오류가 발생했습니다.",
+  "Eraro : ": "오류: ",
+  "antaŭa bildo": "이전 사진",
+  "ludi": "재생",
+  "ludi * 5 kaj enĉenigi": "5개 재생 및 연속",
+  "sekva bildo": "다음 사진",
+  "Fermi": "닫기",
+  "Elŝuti": "다운로드",
+  "Forigi": "제거",
+  "Kamerao tipo": "카메라 종류",
+  "Loka V4L2-kamerao": "로컬 V4L2 카메라",
+  "Loka MMAL-kamerao": "로컬 MMAL 카메라",
+  "Reta kamerao": "네트워크 카메라",
+  "Fora motionEye kamerao": "원격 motionEye 카메라",
+  "Simpla MJPEG-kamerao": "단순 MJPEG 카메라",
+  "la speco de kamerao, kiun vi volas aldoni": "추가할 카메라의 종류",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "카메라 URL (예: http://example.com:8080/cams/)",
+  "uzantnomo...": "사용자 이름...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "필요할 경우, URL에 사용할 사용자 이름 (예: admin)",
+  "pasvorto...": "암호...",
+  "la pasvorto por la URL, se bezonata": "필요할 경우, URL을 위한 암호",
+  "Kamerao": "카메라",
+  "la kameraon, kiun vi volas aldoni": "추가하려는 카메라",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "원격 motionEye카메라는 다른 motionEye 서버에 연결된 카메라로, 이 곳에 추가하여 멀리 떨어진 곳에 있는 카메라도 보고 관리할 수 있습니다.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "네트워크 카메라(또는 IP카메라)는 RTSP/RTMP 또는 MJPEG형식의 영상이나 JPEG 이미지를 자체적으로 송출합니다. 정확한 RTSP, RTMP, MJPEG 또는 JPEG URL은 각 장치의 설명서를 참조하십시오.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "로컬 MMAL 카메라는 이 motionEye 시스템에 직결된 장치로, 대개 특정 보드 전용 카메라입니다.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "네트워크 카메라 대신 MJPEG 카메라로 장치를 추가할 경우 초당 프레임 수는 증가하지만 움직임 감지, 사진 캡쳐와 영상 녹화는 사용할 수 없게 됩니다. 카메라는 서버와 브라우저에서 볼 수 있습니다. 이 형식의 카메라는 Internet Explorer에서 사용할 수 없습니다.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "로컬 V4L2 카메라는 motionEye 시스템에 직결된 카메라로, 대개 USB로 연결됩니다.",
+  "Aldonadi kameraon...": "카메라 추가...",
+  "Grupo": "그룹",
+  "Inkluzivi foton prenitan ĉiun": "매 X마다 찍힌 사진 포함",
+  "sekundo": "초",
+  "5 sekundoj": "5초",
+  "10 sekundoj": "10초",
+  "30 sekundoj": "30초",
+  "minuto": "1분",
+  "5 minutoj": "5분",
+  "10 minutoj": "10분",
+  "30 minutoj": "30분",
+  "horo": "1시간",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "선택된 두 사진 사이의 시간 간격을 선택하세요.",
+  "Filmo framfrekvenco": "영상 초당 프레임 수",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "타임랩스 재생 속도를 선택하세요.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "선택된 사진 수가 많으면 타임랩스 생성에 시간이 좀 걸릴 수 있습니다!",
+  "Krei akselita video": "타임랩스 영상 만들기",
+  "Filmo kreanta en progreso...": "타임랩스 영상 만드는 중...",
+  "Zipitaj": "압축됨",
+  "Akselita video": "타임랩스",
+  "Forigi ĉiujn": "전체 삭제",
+  "Bildoj prenitaj de ": "사진 촬영자: ",
+  "Filmoj registritaj de ": "영상 촬영자: ",
+  "montru ĉi tiun fotilon plenekranan": "카메라 전체화면으로 보기",
+  "montri ĉiujn fotilojn": "전체 카메라 보기",
+  "montru nur ĉi tiun fotilon": "이 카메라만 보기",
+  "malfermaj bildoj retumilo": "사진 탐색기 열기",
+  "malferma videoj retumilo": "영상 탐색기 보기",
+  "agordi ĉi tiun kameraon": "이 카메라 설정",
+  "preni instantaron": "스냅샷 촬영",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "설정된 카메라가 없습니다. 여기를 클릭해서 생성하세요.",
+  "enigu pozitivan nombron": "0보다 큰 수 입력",
+  "enigu pozitivan entjeran nombron": "0보다 큰 정수 입력",
+  "enigu nombron": "수 입력",
+  "enigu entjeran nombron": "정수 입력",
+  " inter ": " 사이 ",
+  " kaj ": " 와(과) ",
+  " pli ol ": " 초과 ",
+  " malpli ol ": " 미만 ",
+  "enigu validan tempon en la sekva formato: HH:MM": "MM 형식으로 유효한 시간 입력",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "유효한 URL 입력 (예: http://example.com:8080/cams/)",
+  "fermi": "닫기",
+  "Ne": "아니오",
+  "Jes": "예",
+  "Bone": "확인",
+  "Auto Exposure": "자동 노출",
+  "Backlight Compensation": "후광 보정",
+  "Brightness": "밝기",
+  "Contrast": "대비",
+  "Exposure Absolute": "절대 노출",
+  "Exposure Auto": "노출 자동",
+  "Exposure Auto Priority": "자동 노출 우선순위",
+  "Exposure Time Absolute": "절대 노출 시간",
+  "Focus Absolute": "절대 초점",
+  "Focus Auto": "자동 초점",
+  "Gain": "얻다",
+  "Gamma": "감마",
+  "Hue": "색조",
+  "Led1 Mode": "LED1 모드",
+  "Led1 Frequency": "LED1 빈도",
+  "Pan Absolute": "절대 팬(Pan)",
+  "Power Line Frequency": "전원 주파수",
+  "Saturation": "채도",
+  "Sharpness": "선명도",
+  "Tilt Absolute": "절대 기울기",
+  "White Balance Temperature": "화이트밸런스 온도",
+  "White Balance Temperature Auto": "자동 화이트밸런스 온도",
+  "Zoom Absolute": "절대 확대",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ms.json
+++ b/motioneye/static/js/motioneye.ms.json
@@ -1,164 +1,176 @@
-{"":{"language":"ms","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "watak khas tidak dibenarkan dalam kata laluan"
-,"Ĉi tiu kampo estas deviga": "Bidang ini diperlukan"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "watak khas tidak dibenarkan dalam nama kamera"
-,"valoro devas esti multoblo de 8": "nilai mestilah gandaan 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "watak khas tidak dibenarkan dalam nama jalan root"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "fail tidak dapat dibuat secara langsung di root sistem anda"
-,"enigu validan retpoŝtadreson": "masukkan alamat e-mel yang sah"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "masukkan senarai alamat e-mel sah yang dipisahkan dengan koma"
-,"specialaj signoj ne rajtas en dosiernomo": "watak khas tidak dibenarkan dalam nama fail"
-,"enigu validan valoron": "masukkan nilai yang sah"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Ini secara berulang akan menghapus semua fail dalam folder awan \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", bukan hanya yang dimuat naik oleh motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ini secara berulang akan menghapus semua fail media lama dalam folder \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", bukan hanya yang dicipta oleh motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Tidak dapat mengedit topeng tanpa gambar kamera yang sah!"
-,"Propra": "Milik"
-,"Propra dosierindiko": "Nama fail tersuai"
-,"Retan kunlokon": "Komunikasi dalam talian"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Penyemak imbas anda tidak menjalankan ciri ini!"
-,"Apliki": "Memohon"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Pastikan semua pilihan konfigurasi adalah sah!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Ini akan memulakan semula sistem. Terus?"
-,"Vere fermiti sistemon?": "Betulkah sistem mati?"
-,"Malŝaltita": "Mati"
-,"Ĉu vere restartigi ?": "Benarkah mulakan semula?"
-,"La sistemo rekomencis!": "Sistem dimulakan semula!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Sila gunakan tetapan yang diubah suai terlebih dahulu!"
-,"Neniu fotilo por forigi!": "Tiada kamera untuk dikeluarkan!"
-,"Ĉu forigi kameraon ": "Boleh mengeluarkan kamera"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye dikemas kini (versi semasa:"
-,"Nova versio havebla: ": "Versi baru tersedia:"
-,". Ĝisdatigi?": ". Kemas kini?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye telah berjaya dikemas kini!"
-,"Ĝisdatigo malsukcesis!": "Kemas kini gagal!"
-,"La ĝisdatiga procezo malsukcesis!": "Proses peningkatan gagal!"
-,"Rezerva dosiero": "Fail sandaran"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Fail sandaran yang anda muat turun lebih awal."
-,"Restaŭrigi Agordon": "Pulihkan Konfigurasi"
-,"Restaŭriganta agordon ...": "Memulihkan konfigurasi ..."
-,"La agordo restaŭrigis!": "Konfigurasi telah dipulihkan!"
-,"Malsukcesis restaŭri la agordon!": "Gagal memulihkan konfigurasi!"
-,"Aliri la alŝutan servon malsukcesis: ": "Gagal mengakses perkhidmatan muat naik:"
-,"Aliri la alŝutan servon sukcesis!": "Mengakses perkhidmatan muat naik berjaya!"
-,"Sciiga retpoŝto fiaskis:": "E-mel berita gagal:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Pastikan semua pilihan konfigurasi adalah sah!"
-,"Sciiga Telegramo fiaskis:": "Telegram Pemberitahuan Gagal:"
-,"Sciiga Telegramo sukcesis!": "Telegram Pemberitahuan berjaya!"
-,"Aliro al retdividado fiaskis: ": "Akses kepada penghantaran rangkaian gagal:"
-,"Aliro al retdividado sukcesis!": "Akses kepada retardasi telah berjaya!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Benarkah memadam fail ini?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Benarkah memadam semua gambar dari \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Benarkah membuang semua filem dari \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Benarkah memadam semua gambar yang tidak dikumpulkan?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Benarkah memadam semua filem yang tidak dikumpulkan?"
-,"aldonadi kameraon...": "tambah kamera ..."
-,"Uzantnomo": "Nama pengguna"
-,"Pasvorto": "Kata laluan"
-,"Memoru min": "Ingat saya"
-,"Ensaluti": "Log masuk"
-,"Nuligi": "Batalkan"
-,"Vi abortis la filmeton.": "Anda membatalkan video."
-,"Reto eraro okazis.": "Ralat rangkaian berlaku."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Kesalahan penyahkodan atau fungsi bukan projek."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format tidak disokong atau tidak dapat diakses / tidak sesuai untuk main balik."
-,"Nekonata eraro okazis.": "Ralat tidak diketahui berlaku."
-,"Eraro : ": "Ralat:"
-,"antaŭa bildo": "gambar sebelumnya"
-,"ludi": "untuk bermain"
-,"ludi * 5 kaj enĉenigi": "bermain * 5 dan rantai"
-,"sekva bildo": "gambar seterusnya"
-,"Fermi": "Tutup"
-,"Elŝuti": "Muat turun"
-,"Forigi": "Keluarkan"
-,"Kamerao tipo": "Jenis kamera"
-,"Loka V4L2-kamerao": "Kamera V4L2 tempatan"
-,"Loka MMAL-kamerao": "Kamera MMAL tempatan"
-,"Reta kamerao": "Kamera Web"
-,"Fora motionEye kamerao": "Kamera mata gerak luar"
-,"Simpla MJPEG-kamerao": "Kamera MJPEG ringkas"
-,"la speco de kamerao, kiun vi volas aldoni": "jenis kamera yang ingin anda tambahkan"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http: //contoh.com: 8765 / kamera / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL kamera (mis. http://example.com:8080/cam/)"
-,"uzantnomo...": "nama pengguna ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "nama pengguna untuk URL, jika diperlukan (mis. admin)"
-,"pasvorto...": "kata laluan ..."
-,"la pasvorto por la URL, se bezonata": "kata laluan untuk URL, jika diperlukan"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kamera yang ingin anda tambah"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Kamera motionEye jarak jauh adalah kamera yang dipasang di belakang pelayan MotionEye yang lain. Menambahnya di sini akan membolehkan anda menonton dan menguruskannya dari jauh."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Kamera rangkaian (atau kamera IP) adalah peranti yang menstrimkan video RTSP / RTMP atau MJPEG secara asli atau gambar JPEG sederhana. Rujuk manual peranti anda untuk mengetahui URL RTSP, RTMP, MJPEG atau JPEG yang betul."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Kamera MMAL tempatan adalah peranti yang disambungkan secara langsung ke sistem motionEye anda. Ini biasanya kamera khusus kad."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Menambah peranti anda sebagai kamera MJPEG sederhana dan bukan sebagai kamera web akan meningkatkan fotografi, tetapi tidak ada pengesanan gerakan, pengambilan gambar atau rakaman filem yang tersedia untuknya. Kamera mesti dapat diakses oleh pelayan dan penyemak imbas anda. Jenis kamera ini tidak sepadan dengan Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Kamera V4L2 tempatan adalah peranti kamera yang disambungkan terus ke sistem motionEye anda, biasanya melalui USB."
-,"Aldonadi kameraon...": "Tambahkan kamera ..."
-,"Grupo": "Kumpulan"
-,"Inkluzivi foton prenitan ĉiun": "Sertakan gambar yang diambil masing-masing"
-,"sekundo": "kedua"
-,"5 sekundoj": "5 saat"
-,"10 sekundoj": "10 saat"
-,"30 sekundoj": "30 saat"
-,"minuto": "minit"
-,"5 minutoj": "5 minit"
-,"10 minutoj": "10 minit"
-,"30 minutoj": "30 minit"
-,"horo": "sejam"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Pilih selang waktu antara dua gambar yang dipilih."
-,"Filmo framfrekvenco": "Kadar bingkai filem"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Pilih seberapa pantas anda mahu video dipercepat."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Memandangkan sejumlah besar gambar, membuat video anda memerlukan sedikit masa!"
-,"Krei akselita video": "Buat video dipercepat"
-,"Filmo kreanta en progreso...": "Filem sedang berlangsung ..."
-,"Zipitaj": "Berzip"
-,"Akselita video": "Video dipercepat"
-,"Forigi ĉiujn": "Keluarkan semuanya"
-,"Bildoj prenitaj de ": "Gambar diambil oleh"
-,"Filmoj registritaj de ": "Filem yang dirakam oleh"
-,"montru ĉi tiun fotilon plenekranan": "Tunjukkan kamera ini sepenuh masa"
-,"montri ĉiujn fotilojn": "Tunjukkan semua kamera"
-,"montru nur ĉi tiun fotilon": "Tunjukkan hanya kamera ini"
-,"malfermaj bildoj retumilo": "buka penyemak imbas gambar"
-,"malferma videoj retumilo": "buka penyemak imbas video"
-,"agordi ĉi tiun kameraon": "tetapkan kamera ini"
-,"preni instantaron": "ambil gambar"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Anda belum mengkonfigurasi mana-mana kamera. Klik di sini untuk menambah ..."
-,"enigu pozitivan nombron": "masukkan nombor positif"
-,"enigu pozitivan entjeran nombron": "masukkan bilangan bulat positif"
-,"enigu nombron": "masukkan nombor"
-,"enigu entjeran nombron": "masukkan nombor bulat"
-," inter ": "di antara"
-," kaj ": "dan"
-," pli ol ": "lebih daripada"
-," malpli ol ": "kurang daripada"
-,"enigu validan tempon en la sekva formato: HH:MM": "masukkan masa yang sah dalam format berikut: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "masukkan URL yang sah (mis. http://example.com:8080/cams/)"
-,"fermi": "untuk menutup"
-,"Ne": "Tidak"
-,"Jes": "Ya"
-,"Bone": "Baiklah"
-,"Auto Exposure": "Pendedahan auto"
-,"Backlight Compensation": "Pampasan latar belakang"
-,"Brightness": "Kecerahan"
-,"Contrast": "Kontras"
-,"Exposure Absolute": "Pendedahan benar -benar"
-,"Exposure Auto": "Pendedahan Auto"
-,"Exposure Auto Priority": "Prioriti auto pendedahan"
-,"Exposure Time Absolute": "Waktu pendedahan benar -benar"
-,"Focus Absolute": "Fokus benar -benar"
-,"Focus Auto": "Fokus Auto"
-,"Gain": "Keuntungan"
-,"Gamma": "Gamma"
-,"Hue": "Hue"
-,"Led1 Mode": "Mod LED1"
-,"Led1 Frequency": "Kekerapan LED1"
-,"Pan Absolute": "Pan benar -benar"
-,"Power Line Frequency": "Kekerapan talian kuasa"
-,"Saturation": "Ketepuan"
-,"Sharpness": "Ketajaman"
-,"Tilt Absolute": "Tilt benar -benar"
-,"White Balance Temperature": "Suhu keseimbangan putih"
-,"White Balance Temperature Auto": "Auto suhu keseimbangan putih"
-,"Zoom Absolute": "Zoom benar -benar"
+{
+  "": {
+    "language": "ms",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "watak khas tidak dibenarkan dalam kata laluan",
+  "Ĉi tiu kampo estas deviga": "Bidang ini diperlukan",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "watak khas tidak dibenarkan dalam nama kamera",
+  "valoro devas esti multoblo de 8": "nilai mestilah gandaan 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "watak khas tidak dibenarkan dalam nama jalan root",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "fail tidak dapat dibuat secara langsung di root sistem anda",
+  "enigu validan retpoŝtadreson": "masukkan alamat e-mel yang sah",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "masukkan senarai alamat e-mel sah yang dipisahkan dengan koma",
+  "specialaj signoj ne rajtas en dosiernomo": "watak khas tidak dibenarkan dalam nama fail",
+  "enigu validan valoron": "masukkan nilai yang sah",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Ini secara berulang akan menghapus semua fail dalam folder awan \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", bukan hanya yang dimuat naik oleh motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ini secara berulang akan menghapus semua fail media lama dalam folder \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", bukan hanya yang dicipta oleh motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Tidak dapat mengedit topeng tanpa gambar kamera yang sah!",
+  "Propra": "Milik",
+  "Propra dosierindiko": "Nama fail tersuai",
+  "Retan kunlokon": "Komunikasi dalam talian",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Penyemak imbas anda tidak menjalankan ciri ini!",
+  "Apliki": "Memohon",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Pastikan semua pilihan konfigurasi adalah sah!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Ini akan memulakan semula sistem. Terus?",
+  "Vere fermiti sistemon?": "Betulkah sistem mati?",
+  "Malŝaltita": "Mati",
+  "Ĉu vere restartigi ?": "Benarkah mulakan semula?",
+  "La sistemo rekomencis!": "Sistem dimulakan semula!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Sila gunakan tetapan yang diubah suai terlebih dahulu!",
+  "Neniu fotilo por forigi!": "Tiada kamera untuk dikeluarkan!",
+  "Ĉu forigi kameraon ": "Boleh mengeluarkan kamera",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye dikemas kini (versi semasa:",
+  "Nova versio havebla: ": "Versi baru tersedia:",
+  ". Ĝisdatigi?": ". Kemas kini?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye telah berjaya dikemas kini!",
+  "Ĝisdatigo malsukcesis!": "Kemas kini gagal!",
+  "La ĝisdatiga procezo malsukcesis!": "Proses peningkatan gagal!",
+  "Rezerva dosiero": "Fail sandaran",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Fail sandaran yang anda muat turun lebih awal.",
+  "Restaŭrigi Agordon": "Pulihkan Konfigurasi",
+  "Restaŭriganta agordon ...": "Memulihkan konfigurasi ...",
+  "La agordo restaŭrigis!": "Konfigurasi telah dipulihkan!",
+  "Malsukcesis restaŭri la agordon!": "Gagal memulihkan konfigurasi!",
+  "Aliri la alŝutan servon malsukcesis: ": "Gagal mengakses perkhidmatan muat naik:",
+  "Aliri la alŝutan servon sukcesis!": "Mengakses perkhidmatan muat naik berjaya!",
+  "Sciiga retpoŝto fiaskis:": "E-mel berita gagal:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Pastikan semua pilihan konfigurasi adalah sah!",
+  "Sciiga Telegramo fiaskis:": "Telegram Pemberitahuan Gagal:",
+  "Sciiga Telegramo sukcesis!": "Telegram Pemberitahuan berjaya!",
+  "Aliro al retdividado fiaskis: ": "Akses kepada penghantaran rangkaian gagal:",
+  "Aliro al retdividado sukcesis!": "Akses kepada retardasi telah berjaya!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Benarkah memadam fail ini?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Benarkah memadam semua gambar dari \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Benarkah membuang semua filem dari \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Benarkah memadam semua gambar yang tidak dikumpulkan?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Benarkah memadam semua filem yang tidak dikumpulkan?",
+  "aldonadi kameraon...": "tambah kamera ...",
+  "Uzantnomo": "Nama pengguna",
+  "Pasvorto": "Kata laluan",
+  "Memoru min": "Ingat saya",
+  "Ensaluti": "Log masuk",
+  "Nuligi": "Batalkan",
+  "Vi abortis la filmeton.": "Anda membatalkan video.",
+  "Reto eraro okazis.": "Ralat rangkaian berlaku.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Kesalahan penyahkodan atau fungsi bukan projek.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format tidak disokong atau tidak dapat diakses / tidak sesuai untuk main balik.",
+  "Nekonata eraro okazis.": "Ralat tidak diketahui berlaku.",
+  "Eraro : ": "Ralat:",
+  "antaŭa bildo": "gambar sebelumnya",
+  "ludi": "untuk bermain",
+  "ludi * 5 kaj enĉenigi": "bermain * 5 dan rantai",
+  "sekva bildo": "gambar seterusnya",
+  "Fermi": "Tutup",
+  "Elŝuti": "Muat turun",
+  "Forigi": "Keluarkan",
+  "Kamerao tipo": "Jenis kamera",
+  "Loka V4L2-kamerao": "Kamera V4L2 tempatan",
+  "Loka MMAL-kamerao": "Kamera MMAL tempatan",
+  "Reta kamerao": "Kamera Web",
+  "Fora motionEye kamerao": "Kamera mata gerak luar",
+  "Simpla MJPEG-kamerao": "Kamera MJPEG ringkas",
+  "la speco de kamerao, kiun vi volas aldoni": "jenis kamera yang ingin anda tambahkan",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http: //contoh.com: 8765 / kamera / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL kamera (mis. http://example.com:8080/cam/)",
+  "uzantnomo...": "nama pengguna ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "nama pengguna untuk URL, jika diperlukan (mis. admin)",
+  "pasvorto...": "kata laluan ...",
+  "la pasvorto por la URL, se bezonata": "kata laluan untuk URL, jika diperlukan",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kamera yang ingin anda tambah",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Kamera motionEye jarak jauh adalah kamera yang dipasang di belakang pelayan MotionEye yang lain. Menambahnya di sini akan membolehkan anda menonton dan menguruskannya dari jauh.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Kamera rangkaian (atau kamera IP) adalah peranti yang menstrimkan video RTSP / RTMP atau MJPEG secara asli atau gambar JPEG sederhana. Rujuk manual peranti anda untuk mengetahui URL RTSP, RTMP, MJPEG atau JPEG yang betul.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Kamera MMAL tempatan adalah peranti yang disambungkan secara langsung ke sistem motionEye anda. Ini biasanya kamera khusus kad.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Menambah peranti anda sebagai kamera MJPEG sederhana dan bukan sebagai kamera web akan meningkatkan fotografi, tetapi tidak ada pengesanan gerakan, pengambilan gambar atau rakaman filem yang tersedia untuknya. Kamera mesti dapat diakses oleh pelayan dan penyemak imbas anda. Jenis kamera ini tidak sepadan dengan Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Kamera V4L2 tempatan adalah peranti kamera yang disambungkan terus ke sistem motionEye anda, biasanya melalui USB.",
+  "Aldonadi kameraon...": "Tambahkan kamera ...",
+  "Grupo": "Kumpulan",
+  "Inkluzivi foton prenitan ĉiun": "Sertakan gambar yang diambil masing-masing",
+  "sekundo": "kedua",
+  "5 sekundoj": "5 saat",
+  "10 sekundoj": "10 saat",
+  "30 sekundoj": "30 saat",
+  "minuto": "minit",
+  "5 minutoj": "5 minit",
+  "10 minutoj": "10 minit",
+  "30 minutoj": "30 minit",
+  "horo": "sejam",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Pilih selang waktu antara dua gambar yang dipilih.",
+  "Filmo framfrekvenco": "Kadar bingkai filem",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Pilih seberapa pantas anda mahu video dipercepat.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Memandangkan sejumlah besar gambar, membuat video anda memerlukan sedikit masa!",
+  "Krei akselita video": "Buat video dipercepat",
+  "Filmo kreanta en progreso...": "Filem sedang berlangsung ...",
+  "Zipitaj": "Berzip",
+  "Akselita video": "Video dipercepat",
+  "Forigi ĉiujn": "Keluarkan semuanya",
+  "Bildoj prenitaj de ": "Gambar diambil oleh",
+  "Filmoj registritaj de ": "Filem yang dirakam oleh",
+  "montru ĉi tiun fotilon plenekranan": "Tunjukkan kamera ini sepenuh masa",
+  "montri ĉiujn fotilojn": "Tunjukkan semua kamera",
+  "montru nur ĉi tiun fotilon": "Tunjukkan hanya kamera ini",
+  "malfermaj bildoj retumilo": "buka penyemak imbas gambar",
+  "malferma videoj retumilo": "buka penyemak imbas video",
+  "agordi ĉi tiun kameraon": "tetapkan kamera ini",
+  "preni instantaron": "ambil gambar",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Anda belum mengkonfigurasi mana-mana kamera. Klik di sini untuk menambah ...",
+  "enigu pozitivan nombron": "masukkan nombor positif",
+  "enigu pozitivan entjeran nombron": "masukkan bilangan bulat positif",
+  "enigu nombron": "masukkan nombor",
+  "enigu entjeran nombron": "masukkan nombor bulat",
+  " inter ": "di antara",
+  " kaj ": "dan",
+  " pli ol ": "lebih daripada",
+  " malpli ol ": "kurang daripada",
+  "enigu validan tempon en la sekva formato: HH:MM": "masukkan masa yang sah dalam format berikut: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "masukkan URL yang sah (mis. http://example.com:8080/cams/)",
+  "fermi": "untuk menutup",
+  "Ne": "Tidak",
+  "Jes": "Ya",
+  "Bone": "Baiklah",
+  "Auto Exposure": "Pendedahan auto",
+  "Backlight Compensation": "Pampasan latar belakang",
+  "Brightness": "Kecerahan",
+  "Contrast": "Kontras",
+  "Exposure Absolute": "Pendedahan benar -benar",
+  "Exposure Auto": "Pendedahan Auto",
+  "Exposure Auto Priority": "Prioriti auto pendedahan",
+  "Exposure Time Absolute": "Waktu pendedahan benar -benar",
+  "Focus Absolute": "Fokus benar -benar",
+  "Focus Auto": "Fokus Auto",
+  "Gain": "Keuntungan",
+  "Gamma": "Gamma",
+  "Hue": "Hue",
+  "Led1 Mode": "Mod LED1",
+  "Led1 Frequency": "Kekerapan LED1",
+  "Pan Absolute": "Pan benar -benar",
+  "Power Line Frequency": "Kekerapan talian kuasa",
+  "Saturation": "Ketepuan",
+  "Sharpness": "Ketajaman",
+  "Tilt Absolute": "Tilt benar -benar",
+  "White Balance Temperature": "Suhu keseimbangan putih",
+  "White Balance Temperature Auto": "Auto suhu keseimbangan putih",
+  "Zoom Absolute": "Zoom benar -benar",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.nb_NO.json
+++ b/motioneye/static/js/motioneye.nb_NO.json
@@ -1,164 +1,176 @@
-{"":{"language":"nb","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "spesielle tegn er ikke tillatt i passordet"
-,"Ĉi tiu kampo estas deviga": "Dette feltet er obligatorisk"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "spesielle tegn er ikke tillatt i navnet på et kamera"
-,"valoro devas esti multoblo de 8": "Verdien må være et multiplum på 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "spesielle tegn er ikke tillatt i rotmappenavn"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "filer kan ikke opprettes direkte i roten til systemet ditt"
-,"enigu validan retpoŝtadreson": "oppgi en gyldig e-post-adresse"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "skriv inn en komma-separert liste med gyldige e -postadresser"
-,"specialaj signoj ne rajtas en dosiernomo": "spesielle tegn er ikke tillatt i filnavnet"
-,"enigu validan valoron": "angi en gyldig verdi"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Dette vil rekursivt slette alle filer som er til stede i sky-mappen ”"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", ikke bare de som er lastet opp av motioneye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Dette vil rekursivt slette alle gamle mediefiler i katalogen \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", ikke bare de som er skapt av Motioneye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Kan ikke redigere masken uten et gyldig kamerabilde!"
-,"Propra": "Egendefinert"
-,"Propra dosierindiko": "Egendefinert sti"
-,"Retan kunlokon": "Nettverkdeling"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Nettleseren din implementerer ikke denne funksjonen!"
-,"Apliki": "Bruk"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Forsikre deg om at alle konfigurasjonsalternativer er gyldige!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Dette vil restarte systemet. Vil du fortsette?"
-,"Vere fermiti sistemon?": "Vil du virkelig skru av systemet?"
-,"Malŝaltita": "Slått av"
-,"Ĉu vere restartigi ?": "Vil du virkelig starte på nytt?"
-,"La sistemo rekomencis!": "Systemet har blitt restartet!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Vennligst ta i bruk de endrede innstillingene først!"
-,"Neniu fotilo por forigi!": "Ingen kameraer å fjerne!"
-,"Ĉu forigi kameraon ": "Fjern kamera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye er oppdatert (gjeldende versjon: "
-,"Nova versio havebla: ": "Ny versjon tilgjengelig: "
-,". Ĝisdatigi?": ". Oppdatere?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye har blitt oppdatert!"
-,"Ĝisdatigo malsukcesis!": "Oppdatering mislyktes!"
-,"La ĝisdatiga procezo malsukcesis!": "Oppdateringsprosessen mislyktes!"
-,"Rezerva dosiero": "Sikkerhetskopiert fil"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "sikkerhetskopierte filen du tidligere har lastet ned."
-,"Restaŭrigi Agordon": "Gjenopprett konfigurasjon"
-,"Restaŭriganta agordon ...": "Gjenoppretter konfigurasjonen ..."
-,"La agordo restaŭrigis!": "Konfigurasjonen er gjenopprettet!"
-,"Malsukcesis restaŭri la agordon!": "Kunne ikke gjenopprette konfigurasjonen!"
-,"Aliri la alŝutan servon malsukcesis: ": "Tilgang til opplastingstjenesten mislyktes: "
-,"Aliri la alŝutan servon sukcesis!": "Tilgang til opplastingstjenesten har vært vellykket!"
-,"Sciiga retpoŝto fiaskis:": "E-post varsel mislyktes:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Forsikre deg om at alle konfigurasjonsalternativer er gyldige!"
-,"Sciiga Telegramo fiaskis:": "Telegram varsel mislyktes:"
-,"Sciiga Telegramo sukcesis!": "Telegram varsel har vært vellykket!"
-,"Aliro al retdividado fiaskis: ": "Tilgang til nettverksdeling mislyktes: "
-,"Aliro al retdividado sukcesis!": "Tilgang til nettverksdeling var vellykket!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Vil du virkelig slette denne filen?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Vil du virkelig slette alle bilder fra \"%(gruppe) s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Vil du virkelig slette alle filmer fra \"%(gruppe) s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Vil du virkelig slette alle ikke grupperte bilder?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Vil du virkelig slette alle de ikke grupperte filmene?"
-,"aldonadi kameraon...": "legg til et kamera ..."
-,"Uzantnomo": "Brukernavn"
-,"Pasvorto": "Passord"
-,"Memoru min": "Husk meg"
-,"Ensaluti": "Logg inn"
-,"Nuligi": "Avbryt"
-,"Vi abortis la filmeton.": "Du avbrøt videoen."
-,"Reto eraro okazis.": "En nettverksfeil oppstod."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Dekodingfeil av media eller ikke-støttet funksjon."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format ikke støttet eller utilgjengelig/upassende for avspilling."
-,"Nekonata eraro okazis.": "En ukjent feil oppstod."
-,"Eraro : ": "Feil: "
-,"antaŭa bildo": "forrige bilde"
-,"ludi": "spill av"
-,"ludi * 5 kaj enĉenigi": "spill av * 5 og sett sammen"
-,"sekva bildo": "neste bilde"
-,"Fermi": "Lukk"
-,"Elŝuti": "Last ned"
-,"Forigi": "Fjern"
-,"Kamerao tipo": "Kameratype"
-,"Loka V4L2-kamerao": "Lokalt V4L2 kamera"
-,"Loka MMAL-kamerao": "Lokalt MMAL kamera"
-,"Reta kamerao": "Nettverk-kamera"
-,"Fora motionEye kamerao": "Eksternt motionEye kamera"
-,"Simpla MJPEG-kamerao": "Enkelt MJPEG kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "typen kamera du vil legge til"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kameraets addresse (eg http://example.com:8080/cam/)"
-,"uzantnomo...": "brukernavn ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "brukernavnet for nettadressen, om nødvendig (f.eks. admin)"
-,"pasvorto...": "passord ..."
-,"la pasvorto por la URL, se bezonata": "passordet for nettadressen, om nødvendig"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kameraet du vil legge til"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Eksterne motionEye kameraer er kameraer installert bak en annen motionEye -server. Å legge dem til her vil tillate deg å se og administrere dem eksternt."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Nettverk-kameraer (eller IP -kameraer) er enheter som støtter strømming av RTSP/RTMP eller MJPEG videoer eller enkle JPEG bilder. Kontakt håndboken for enheten din for å finne ut riktig URL RTSP, RTMP, MJPEG eller JPEG addresse."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL kameraer er enheter koblet direkte til motionEye-systemet ditt. Dette er vanligvis kortspesifikke kameraer."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Legge til enheten din som et enkelt MJPEG -kamera i stedet for som ett nettverks-kamera vil forbedre oppdateringshastigheten, men ingen bevegelsesdeteksjon, bildefangst eller innspilling av filmer vil være tilgjengelig for det. Kameraet må være tilgjengelig for serveren din og nettleseren din. Denne typen kamera støttes ikke med Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2 kameraer er kameraenheter som er koblet direkte til motioneye-systemet ditt, vanligvis via USB."
-,"Aldonadi kameraon...": "Legg til et kamera ..."
-,"Grupo": "Gruppe"
-,"Inkluzivi foton prenitan ĉiun": "Inkluder et bilde tatt hvert"
-,"sekundo": "sekund"
-,"5 sekundoj": "5 sekunder"
-,"10 sekundoj": "10 sekunder"
-,"30 sekundoj": "30 sekunder"
-,"minuto": "minutt"
-,"5 minutoj": "5 minutter"
-,"10 minutoj": "10 minutter"
-,"30 minutoj": "30 minutter"
-,"horo": "time"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "velg tidsintervallen mellom to utvalgte bilder."
-,"Filmo framfrekvenco": "Film oppdateringshastighet"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "velg hvor raskt du vil timelapse avspillingen skal være."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Gitt det store antallet bilder, kan det ta litt tid å lage timelapse videoen!"
-,"Krei akselita video": "Lag Timelapse Video"
-,"Filmo kreanta en progreso...": "Lager Timelapse Video ..."
-,"Zipitaj": "Kompremert (ZIP)"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Slett alle"
-,"Bildoj prenitaj de ": "Bilder tatt av "
-,"Filmoj registritaj de ": "Filmer spilt inn av "
-,"montru ĉi tiun fotilon plenekranan": "Vis dette kameraet i fullskjerm"
-,"montri ĉiujn fotilojn": "Vis alle kameraer"
-,"montru nur ĉi tiun fotilon": "Vis bare dette kameraet"
-,"malfermaj bildoj retumilo": "åpne bilder utforsker"
-,"malferma videoj retumilo": "åpne videoer utforsker"
-,"agordi ĉi tiun kameraon": "konfigurer dette kameraet"
-,"preni instantaron": "å ta et kjapt bilde"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Du har ikke satt opp noen kamera ennå. Klikk her for å legge til ett ..."
-,"enigu pozitivan nombron": "skriv inn et positivt tall"
-,"enigu pozitivan entjeran nombron": "skriv inn et positivt heltallnummer"
-,"enigu nombron": "skriv inn et tall"
-,"enigu entjeran nombron": "skriv inn et heltallnummer"
-," inter ": " mellom "
-," kaj ": " og "
-," pli ol ": " mer enn "
-," malpli ol ": " mindre enn "
-,"enigu validan tempon en la sekva formato: HH:MM": "skriv inn en gyldig tid i følgende format: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "skriv inn en gyldig addresse (f.eks. Http://ekzemplo.com:8080/cams/)"
-,"fermi": "lukk"
-,"Ne": "Nei"
-,"Jes": "Ja"
-,"Bone": "Ok"
-,"Auto Exposure": "Autoeksponering"
-,"Backlight Compensation": "Baklys-kompensasjon"
-,"Brightness": "Lysstyrke"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Eksponering Absolutt"
-,"Exposure Auto": "Eksponering Auto"
-,"Exposure Auto Priority": "Eksponering Auto Prioritet"
-,"Exposure Time Absolute": "Eksponeringstid Absolutt"
-,"Focus Absolute": "Fokus Absolutt"
-,"Focus Auto": "Fokus Auto"
-,"Gain": "Gain"
-,"Gamma": "Gamma"
-,"Hue": "Fargetone"
-,"Led1 Mode": "LED1 modus"
-,"Led1 Frequency": "LED1 frekvens"
-,"Pan Absolute": "Panorering absolutt"
-,"Power Line Frequency": "Strømnett frekvens"
-,"Saturation": "Metning"
-,"Sharpness": "Skarphet"
-,"Tilt Absolute": "Tilt Absolutt"
-,"White Balance Temperature": "Hvitbalansetemperatur"
-,"White Balance Temperature Auto": "Hvitbalansetemperatur Auto"
-,"Zoom Absolute": "Zoom Absolutt"
+{
+  "": {
+    "language": "nb",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "spesielle tegn er ikke tillatt i passordet",
+  "Ĉi tiu kampo estas deviga": "Dette feltet er obligatorisk",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "spesielle tegn er ikke tillatt i navnet på et kamera",
+  "valoro devas esti multoblo de 8": "Verdien må være et multiplum på 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "spesielle tegn er ikke tillatt i rotmappenavn",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "filer kan ikke opprettes direkte i roten til systemet ditt",
+  "enigu validan retpoŝtadreson": "oppgi en gyldig e-post-adresse",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "skriv inn en komma-separert liste med gyldige e -postadresser",
+  "specialaj signoj ne rajtas en dosiernomo": "spesielle tegn er ikke tillatt i filnavnet",
+  "enigu validan valoron": "angi en gyldig verdi",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Dette vil rekursivt slette alle filer som er til stede i sky-mappen ”",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", ikke bare de som er lastet opp av motioneye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Dette vil rekursivt slette alle gamle mediefiler i katalogen \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", ikke bare de som er skapt av Motioneye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Kan ikke redigere masken uten et gyldig kamerabilde!",
+  "Propra": "Egendefinert",
+  "Propra dosierindiko": "Egendefinert sti",
+  "Retan kunlokon": "Nettverkdeling",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Nettleseren din implementerer ikke denne funksjonen!",
+  "Apliki": "Bruk",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Forsikre deg om at alle konfigurasjonsalternativer er gyldige!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Dette vil restarte systemet. Vil du fortsette?",
+  "Vere fermiti sistemon?": "Vil du virkelig skru av systemet?",
+  "Malŝaltita": "Slått av",
+  "Ĉu vere restartigi ?": "Vil du virkelig starte på nytt?",
+  "La sistemo rekomencis!": "Systemet har blitt restartet!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Vennligst ta i bruk de endrede innstillingene først!",
+  "Neniu fotilo por forigi!": "Ingen kameraer å fjerne!",
+  "Ĉu forigi kameraon ": "Fjern kamera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye er oppdatert (gjeldende versjon: ",
+  "Nova versio havebla: ": "Ny versjon tilgjengelig: ",
+  ". Ĝisdatigi?": ". Oppdatere?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye har blitt oppdatert!",
+  "Ĝisdatigo malsukcesis!": "Oppdatering mislyktes!",
+  "La ĝisdatiga procezo malsukcesis!": "Oppdateringsprosessen mislyktes!",
+  "Rezerva dosiero": "Sikkerhetskopiert fil",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "sikkerhetskopierte filen du tidligere har lastet ned.",
+  "Restaŭrigi Agordon": "Gjenopprett konfigurasjon",
+  "Restaŭriganta agordon ...": "Gjenoppretter konfigurasjonen ...",
+  "La agordo restaŭrigis!": "Konfigurasjonen er gjenopprettet!",
+  "Malsukcesis restaŭri la agordon!": "Kunne ikke gjenopprette konfigurasjonen!",
+  "Aliri la alŝutan servon malsukcesis: ": "Tilgang til opplastingstjenesten mislyktes: ",
+  "Aliri la alŝutan servon sukcesis!": "Tilgang til opplastingstjenesten har vært vellykket!",
+  "Sciiga retpoŝto fiaskis:": "E-post varsel mislyktes:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Forsikre deg om at alle konfigurasjonsalternativer er gyldige!",
+  "Sciiga Telegramo fiaskis:": "Telegram varsel mislyktes:",
+  "Sciiga Telegramo sukcesis!": "Telegram varsel har vært vellykket!",
+  "Aliro al retdividado fiaskis: ": "Tilgang til nettverksdeling mislyktes: ",
+  "Aliro al retdividado sukcesis!": "Tilgang til nettverksdeling var vellykket!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Vil du virkelig slette denne filen?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Vil du virkelig slette alle bilder fra \"%(gruppe) s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Vil du virkelig slette alle filmer fra \"%(gruppe) s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Vil du virkelig slette alle ikke grupperte bilder?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Vil du virkelig slette alle de ikke grupperte filmene?",
+  "aldonadi kameraon...": "legg til et kamera ...",
+  "Uzantnomo": "Brukernavn",
+  "Pasvorto": "Passord",
+  "Memoru min": "Husk meg",
+  "Ensaluti": "Logg inn",
+  "Nuligi": "Avbryt",
+  "Vi abortis la filmeton.": "Du avbrøt videoen.",
+  "Reto eraro okazis.": "En nettverksfeil oppstod.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Dekodingfeil av media eller ikke-støttet funksjon.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format ikke støttet eller utilgjengelig/upassende for avspilling.",
+  "Nekonata eraro okazis.": "En ukjent feil oppstod.",
+  "Eraro : ": "Feil: ",
+  "antaŭa bildo": "forrige bilde",
+  "ludi": "spill av",
+  "ludi * 5 kaj enĉenigi": "spill av * 5 og sett sammen",
+  "sekva bildo": "neste bilde",
+  "Fermi": "Lukk",
+  "Elŝuti": "Last ned",
+  "Forigi": "Fjern",
+  "Kamerao tipo": "Kameratype",
+  "Loka V4L2-kamerao": "Lokalt V4L2 kamera",
+  "Loka MMAL-kamerao": "Lokalt MMAL kamera",
+  "Reta kamerao": "Nettverk-kamera",
+  "Fora motionEye kamerao": "Eksternt motionEye kamera",
+  "Simpla MJPEG-kamerao": "Enkelt MJPEG kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "typen kamera du vil legge til",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kameraets addresse (eg http://example.com:8080/cam/)",
+  "uzantnomo...": "brukernavn ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "brukernavnet for nettadressen, om nødvendig (f.eks. admin)",
+  "pasvorto...": "passord ...",
+  "la pasvorto por la URL, se bezonata": "passordet for nettadressen, om nødvendig",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kameraet du vil legge til",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Eksterne motionEye kameraer er kameraer installert bak en annen motionEye -server. Å legge dem til her vil tillate deg å se og administrere dem eksternt.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Nettverk-kameraer (eller IP -kameraer) er enheter som støtter strømming av RTSP/RTMP eller MJPEG videoer eller enkle JPEG bilder. Kontakt håndboken for enheten din for å finne ut riktig URL RTSP, RTMP, MJPEG eller JPEG addresse.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL kameraer er enheter koblet direkte til motionEye-systemet ditt. Dette er vanligvis kortspesifikke kameraer.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Legge til enheten din som et enkelt MJPEG -kamera i stedet for som ett nettverks-kamera vil forbedre oppdateringshastigheten, men ingen bevegelsesdeteksjon, bildefangst eller innspilling av filmer vil være tilgjengelig for det. Kameraet må være tilgjengelig for serveren din og nettleseren din. Denne typen kamera støttes ikke med Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2 kameraer er kameraenheter som er koblet direkte til motioneye-systemet ditt, vanligvis via USB.",
+  "Aldonadi kameraon...": "Legg til et kamera ...",
+  "Grupo": "Gruppe",
+  "Inkluzivi foton prenitan ĉiun": "Inkluder et bilde tatt hvert",
+  "sekundo": "sekund",
+  "5 sekundoj": "5 sekunder",
+  "10 sekundoj": "10 sekunder",
+  "30 sekundoj": "30 sekunder",
+  "minuto": "minutt",
+  "5 minutoj": "5 minutter",
+  "10 minutoj": "10 minutter",
+  "30 minutoj": "30 minutter",
+  "horo": "time",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "velg tidsintervallen mellom to utvalgte bilder.",
+  "Filmo framfrekvenco": "Film oppdateringshastighet",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "velg hvor raskt du vil timelapse avspillingen skal være.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Gitt det store antallet bilder, kan det ta litt tid å lage timelapse videoen!",
+  "Krei akselita video": "Lag Timelapse Video",
+  "Filmo kreanta en progreso...": "Lager Timelapse Video ...",
+  "Zipitaj": "Kompremert (ZIP)",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Slett alle",
+  "Bildoj prenitaj de ": "Bilder tatt av ",
+  "Filmoj registritaj de ": "Filmer spilt inn av ",
+  "montru ĉi tiun fotilon plenekranan": "Vis dette kameraet i fullskjerm",
+  "montri ĉiujn fotilojn": "Vis alle kameraer",
+  "montru nur ĉi tiun fotilon": "Vis bare dette kameraet",
+  "malfermaj bildoj retumilo": "åpne bilder utforsker",
+  "malferma videoj retumilo": "åpne videoer utforsker",
+  "agordi ĉi tiun kameraon": "konfigurer dette kameraet",
+  "preni instantaron": "å ta et kjapt bilde",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Du har ikke satt opp noen kamera ennå. Klikk her for å legge til ett ...",
+  "enigu pozitivan nombron": "skriv inn et positivt tall",
+  "enigu pozitivan entjeran nombron": "skriv inn et positivt heltallnummer",
+  "enigu nombron": "skriv inn et tall",
+  "enigu entjeran nombron": "skriv inn et heltallnummer",
+  " inter ": " mellom ",
+  " kaj ": " og ",
+  " pli ol ": " mer enn ",
+  " malpli ol ": " mindre enn ",
+  "enigu validan tempon en la sekva formato: HH:MM": "skriv inn en gyldig tid i følgende format: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "skriv inn en gyldig addresse (f.eks. Http://ekzemplo.com:8080/cams/)",
+  "fermi": "lukk",
+  "Ne": "Nei",
+  "Jes": "Ja",
+  "Bone": "Ok",
+  "Auto Exposure": "Autoeksponering",
+  "Backlight Compensation": "Baklys-kompensasjon",
+  "Brightness": "Lysstyrke",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Eksponering Absolutt",
+  "Exposure Auto": "Eksponering Auto",
+  "Exposure Auto Priority": "Eksponering Auto Prioritet",
+  "Exposure Time Absolute": "Eksponeringstid Absolutt",
+  "Focus Absolute": "Fokus Absolutt",
+  "Focus Auto": "Fokus Auto",
+  "Gain": "Gain",
+  "Gamma": "Gamma",
+  "Hue": "Fargetone",
+  "Led1 Mode": "LED1 modus",
+  "Led1 Frequency": "LED1 frekvens",
+  "Pan Absolute": "Panorering absolutt",
+  "Power Line Frequency": "Strømnett frekvens",
+  "Saturation": "Metning",
+  "Sharpness": "Skarphet",
+  "Tilt Absolute": "Tilt Absolutt",
+  "White Balance Temperature": "Hvitbalansetemperatur",
+  "White Balance Temperature Auto": "Hvitbalansetemperatur Auto",
+  "Zoom Absolute": "Zoom Absolutt",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.nl.json
+++ b/motioneye/static/js/motioneye.nl.json
@@ -1,164 +1,176 @@
-{"":{"language":"nl","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "het wachtwoord mag geen speciale tekens bevatten"
-,"Ĉi tiu kampo estas deviga": "Dit veld is verplicht"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "de naam van de camera mag geen speciale tekens bevatten"
-,"valoro devas esti multoblo de 8": "waarde moet een veelvoud zijn van 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "het hoofdpad mag geen speciale tekens bevatten"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "bestanden kunnen niet rechtstreeks aangemaakt worden in de hoofdmap van uw systeem"
-,"enigu validan retpoŝtadreson": "voer een geldig e-mailadres in"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "voer een door komma's gescheiden lijst van geldige e-mailadressen in"
-,"specialaj signoj ne rajtas en dosiernomo": "de bestandsnaam mag geen speciale tekens bevatten"
-,"enigu validan valoron": "voer een geldige waarde in"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Hiermee worden alle bestanden in de cloud map recursief verwijderd \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", ook diegene die niet zijn weggeschreven door motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Hiermee worden alle oude mediabestanden in de map recursief verwijderd \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", ook diegene die niet zijn aangemaakt door motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Het masker kan niet zonder een geldig camerabeeld worden bewerkt!"
-,"Propra": "Aangepast"
-,"Propra dosierindiko": "Aangepaste map"
-,"Retan kunlokon": "Netwerk locatie"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Uw browser ondersteund niet deze functie!"
-,"Apliki": "Toepassen"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Zorg ervoor dat alle configuratie-instellingen geldig zijn!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Hiermee wordt het systeem opnieuw gestart. Doorgaan?"
-,"Vere fermiti sistemon?": "Systeem echt afsluiten?"
-,"Malŝaltita": "Afsluiten"
-,"Ĉu vere restartigi ?": "Echt opnieuw starten?"
-,"La sistemo rekomencis!": "Het systeem is opnieuw gestart!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Pas eerst de gewijzigde instellingen toe!"
-,"Neniu fotilo por forigi!": "Geen camera aanwezig om te verwijderen!"
-,"Ĉu forigi kameraon ": "Verwijder camera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye is bijgewerkt tot de laatste versie (huidige versie: "
-,"Nova versio havebla: ": "Nieuwe versie beschikbaar: "
-,". Ĝisdatigi?": ". Bijwerken?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye is succesvol bijgewerkt!"
-,"Ĝisdatigo malsukcesis!": "Het bijwerken is mislukt!"
-,"La ĝisdatiga procezo malsukcesis!": "Het bijwerkproces is mislukt!"
-,"Rezerva dosiero": "Backup bestand"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Het eerder gedownloade back-upbestand."
-,"Restaŭrigi Agordon": "Configuratie terugzetten"
-,"Restaŭriganta agordon ...": "Configuratie wordt teruggezet ..."
-,"La agordo restaŭrigis!": "De instellingen zijn teruggezet!"
-,"Malsukcesis restaŭri la agordon!": "De instellingen kunnen niet worden teruggezet!"
-,"Aliri la alŝutan servon malsukcesis: ": "Toegang tot de uploadservice is mislukt: "
-,"Aliri la alŝutan servon sukcesis!": "Toegang tot de uploadservice is gelukt!"
-,"Sciiga retpoŝto fiaskis:": "Verzenden notificatie mail is mislukt:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Zorg ervoor dat alle configuratie-instellingen geldig zijn!"
-,"Sciiga Telegramo fiaskis:": "Notificatie melding mislukt:"
-,"Sciiga Telegramo sukcesis!": "Notificatie melding succesvol!"
-,"Aliro al retdividado fiaskis: ": "Toegang tot netwerk locatie mislukt: "
-,"Aliro al retdividado sukcesis!": "Toegang tot netwerk locatie succesvol!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Wil je dit bestand echt verwijderen?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Werkelijk alle afbeeldingen uit \"%(group)s\" verwijderen?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Werkelijk alle films uit \"%(group)s\" verwijderen?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Werkelijk alle niet gegroepeerde afbeeldingen verwijderen?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Werkelijk alle niet gegroepeerde films verwijderen?"
-,"aldonadi kameraon...": "Camera toevoegen..."
-,"Uzantnomo": "Gebruikersnaam"
-,"Pasvorto": "Wachtwoord"
-,"Memoru min": "Mij onthouden"
-,"Ensaluti": "Aanmelden"
-,"Nuligi": "Afbreken"
-,"Vi abortis la filmeton.": "Je hebt de video afgebroken."
-,"Reto eraro okazis.": "Er is een netwerkfout opgetreden."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Media decoderingsfout of niet ondersteunde media functionaliteit."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formaat wordt niet ondersteund of is niet beschikbaar/ongeschikt om af te spelen."
-,"Nekonata eraro okazis.": "Onbekende fout opgetreden."
-,"Eraro : ": "Fout : "
-,"antaŭa bildo": "vorige afbeelding"
-,"ludi": "afspelen"
-,"ludi * 5 kaj enĉenigi": "speel 5 keer sneller af"
-,"sekva bildo": "volgende foto"
-,"Fermi": "Sluiten"
-,"Elŝuti": "Ophalen"
-,"Forigi": "Verwijderen"
-,"Kamerao tipo": "Cameratype"
-,"Loka V4L2-kamerao": "Lokale V4L2-camera"
-,"Loka MMAL-kamerao": "Lokale MMAL-camera"
-,"Reta kamerao": "Netwerkcamera"
-,"Fora motionEye kamerao": "Externe MotionEye camera"
-,"Simpla MJPEG-kamerao": "Eenvoudige MJPEG-camera"
-,"la speco de kamerao, kiun vi volas aldoni": "het type camera dat u wilt toevoegen"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://voorbeeld.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "de camera URL (bijv. http://voorbeeld.com:8080/cam/)"
-,"uzantnomo...": "gebruikersnaam..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "de gebruikersnaam voor de URL, indien nodig (bijv. admin)"
-,"pasvorto...": "wachtwoord..."
-,"la pasvorto por la URL, se bezonata": "het wachtwoord voor de URL, indien nodig"
-,"Kamerao": "Camera"
-,"la kameraon, kiun vi volas aldoni": "de camera die u wilt toevoegen"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "MotionEye camera's op afstand zijn camera's die op een andere MotionEye server zijn geïnstalleerd. Door ze hier toe te voegen, kunt u ze op afstand bekijken en beheren."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Netwerkcamera's (of IP-camera's) zijn apparaten die standaard RTSP/RTMP-, MJPEG-video's of gewone JPEG-afbeeldingen kunnen streamen. Raadpleeg de handleiding van uw apparaat om de juiste RTSP-, RTMP-, MJPEG- of JPEG-URL te vinden."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL-camera's zijn apparaten die rechtstreeks op uw motionEye-systeem zijn aangesloten. Dit zijn meestal kaartspecifieke camera's."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Als u uw apparaat toevoegt als een eenvoudige MJPEG-camera in plaats van een netwerkcamera, dan zal de beeldkwaliteit verbeteren, maar er is dan geen bewegingsdetectie, beeldopname of video-opname mogelijk. De camera moet toegankelijk zijn voor uw server en browser. Dit type camera is niet compatibel met Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2-camera's zijn camera-apparaten die rechtstreeks op uw MotionEye-systeem zijn aangesloten, meestal via USB."
-,"Aldonadi kameraon...": "Camera toevoegen..."
-,"Grupo": "Groep"
-,"Inkluzivi foton prenitan ĉiun": "Voeg elk een foto toe die is gemaakt"
-,"sekundo": "1 seconde"
-,"5 sekundoj": "5 seconden"
-,"10 sekundoj": "10 seconden"
-,"30 sekundoj": "30 seconden"
-,"minuto": "1 minuut"
-,"5 minutoj": "5 minuten"
-,"10 minutoj": "10 minuten"
-,"30 minutoj": "30 minuten"
-,"horo": "1 uur"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Selecteer het tijdsinterval tussen twee geselecteerde afbeeldingen."
-,"Filmo framfrekvenco": "Framesnelheid video"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Kies hoe snel de Timelapse afgespeeld moet worden."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Gezien het grote aantal afbeeldingen kan het maken van uw video enige tijd in beslag nemen!"
-,"Krei akselita video": "Maak een Timelapse film"
-,"Filmo kreanta en progreso...": "Bezig met het maken van de video..."
-,"Zipitaj": "Gezipt"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Alles verwijderen"
-,"Bildoj prenitaj de ": "Foto's genomen op "
-,"Filmoj registritaj de ": "Films opgenomen door "
-,"montru ĉi tiun fotilon plenekranan": "deze camera weergeven op volledig scherm"
-,"montri ĉiujn fotilojn": "toon alle camera's"
-,"montru nur ĉi tiun fotilon": "toon alleen deze camera"
-,"malfermaj bildoj retumilo": "Afbeeldingen openen"
-,"malferma videoj retumilo": "Video's openen"
-,"agordi ĉi tiun kameraon": "deze camera configureren"
-,"preni instantaron": "maak een momentopname"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "U heeft nog geen camera geconfigureerd. Klik hier om er een toe te voegen ..."
-,"enigu pozitivan nombron": "voer een positief getal in"
-,"enigu pozitivan entjeran nombron": "voer een positief geheel getal in"
-,"enigu nombron": "voer een nummer in"
-,"enigu entjeran nombron": "voer een geheel getal in"
-," inter ": " tussen "
-," kaj ": " en "
-," pli ol ": " groter dan "
-," malpli ol ": " kleiner dan "
-,"enigu validan tempon en la sekva formato: HH:MM": "voer een geldige tijd in het volgende formaat: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "voer een geldige URL in (bijv. http://voorbeeld.com:8080/cams/)"
-,"fermi": "sluiten"
-,"Ne": "Nee"
-,"Jes": "Ja"
-,"Bone": "OK"
-,"Auto Exposure": "Automatische belichting"
-,"Backlight Compensation": "Tegenlichtcompensatie"
-,"Brightness": "Helderheid"
-,"Contrast": "Contrast"
-,"Exposure Absolute": "Absolute belichting"
-,"Exposure Auto": "Automatische belichting"
-,"Exposure Auto Priority": "Automatische belichtingsprioriteit"
-,"Exposure Time Absolute": "Absolute belichtingstijd"
-,"Focus Absolute": "Absoluut focussen"
-,"Focus Auto": "Autofocus"
-,"Gain": "Versterking"
-,"Gamma": "Gamma"
-,"Hue": "Kleurtoon"
-,"Led1 Mode": "LED1 modus"
-,"Led1 Frequency": "LED1 frequentie"
-,"Pan Absolute": "Pan absoluut"
-,"Power Line Frequency": "Net frequentie"
-,"Saturation": "Saturatie"
-,"Sharpness": "Scherpte"
-,"Tilt Absolute": "Absoluut kantelen"
-,"White Balance Temperature": "Temperatuur witbalans"
-,"White Balance Temperature Auto": "Auto temperatuur witbalans"
-,"Zoom Absolute": "Absolute zoom"
+{
+  "": {
+    "language": "nl",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "het wachtwoord mag geen speciale tekens bevatten",
+  "Ĉi tiu kampo estas deviga": "Dit veld is verplicht",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "de naam van de camera mag geen speciale tekens bevatten",
+  "valoro devas esti multoblo de 8": "waarde moet een veelvoud zijn van 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "het hoofdpad mag geen speciale tekens bevatten",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "bestanden kunnen niet rechtstreeks aangemaakt worden in de hoofdmap van uw systeem",
+  "enigu validan retpoŝtadreson": "voer een geldig e-mailadres in",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "voer een door komma's gescheiden lijst van geldige e-mailadressen in",
+  "specialaj signoj ne rajtas en dosiernomo": "de bestandsnaam mag geen speciale tekens bevatten",
+  "enigu validan valoron": "voer een geldige waarde in",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Hiermee worden alle bestanden in de cloud map recursief verwijderd \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", ook diegene die niet zijn weggeschreven door motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Hiermee worden alle oude mediabestanden in de map recursief verwijderd \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", ook diegene die niet zijn aangemaakt door motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Het masker kan niet zonder een geldig camerabeeld worden bewerkt!",
+  "Propra": "Aangepast",
+  "Propra dosierindiko": "Aangepaste map",
+  "Retan kunlokon": "Netwerk locatie",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Uw browser ondersteund niet deze functie!",
+  "Apliki": "Toepassen",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Zorg ervoor dat alle configuratie-instellingen geldig zijn!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Hiermee wordt het systeem opnieuw gestart. Doorgaan?",
+  "Vere fermiti sistemon?": "Systeem echt afsluiten?",
+  "Malŝaltita": "Afsluiten",
+  "Ĉu vere restartigi ?": "Echt opnieuw starten?",
+  "La sistemo rekomencis!": "Het systeem is opnieuw gestart!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Pas eerst de gewijzigde instellingen toe!",
+  "Neniu fotilo por forigi!": "Geen camera aanwezig om te verwijderen!",
+  "Ĉu forigi kameraon ": "Verwijder camera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye is bijgewerkt tot de laatste versie (huidige versie: ",
+  "Nova versio havebla: ": "Nieuwe versie beschikbaar: ",
+  ". Ĝisdatigi?": ". Bijwerken?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye is succesvol bijgewerkt!",
+  "Ĝisdatigo malsukcesis!": "Het bijwerken is mislukt!",
+  "La ĝisdatiga procezo malsukcesis!": "Het bijwerkproces is mislukt!",
+  "Rezerva dosiero": "Backup bestand",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Het eerder gedownloade back-upbestand.",
+  "Restaŭrigi Agordon": "Configuratie terugzetten",
+  "Restaŭriganta agordon ...": "Configuratie wordt teruggezet ...",
+  "La agordo restaŭrigis!": "De instellingen zijn teruggezet!",
+  "Malsukcesis restaŭri la agordon!": "De instellingen kunnen niet worden teruggezet!",
+  "Aliri la alŝutan servon malsukcesis: ": "Toegang tot de uploadservice is mislukt: ",
+  "Aliri la alŝutan servon sukcesis!": "Toegang tot de uploadservice is gelukt!",
+  "Sciiga retpoŝto fiaskis:": "Verzenden notificatie mail is mislukt:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Zorg ervoor dat alle configuratie-instellingen geldig zijn!",
+  "Sciiga Telegramo fiaskis:": "Notificatie melding mislukt:",
+  "Sciiga Telegramo sukcesis!": "Notificatie melding succesvol!",
+  "Aliro al retdividado fiaskis: ": "Toegang tot netwerk locatie mislukt: ",
+  "Aliro al retdividado sukcesis!": "Toegang tot netwerk locatie succesvol!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Wil je dit bestand echt verwijderen?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Werkelijk alle afbeeldingen uit \"%(group)s\" verwijderen?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Werkelijk alle films uit \"%(group)s\" verwijderen?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Werkelijk alle niet gegroepeerde afbeeldingen verwijderen?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Werkelijk alle niet gegroepeerde films verwijderen?",
+  "aldonadi kameraon...": "Camera toevoegen...",
+  "Uzantnomo": "Gebruikersnaam",
+  "Pasvorto": "Wachtwoord",
+  "Memoru min": "Mij onthouden",
+  "Ensaluti": "Aanmelden",
+  "Nuligi": "Afbreken",
+  "Vi abortis la filmeton.": "Je hebt de video afgebroken.",
+  "Reto eraro okazis.": "Er is een netwerkfout opgetreden.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Media decoderingsfout of niet ondersteunde media functionaliteit.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formaat wordt niet ondersteund of is niet beschikbaar/ongeschikt om af te spelen.",
+  "Nekonata eraro okazis.": "Onbekende fout opgetreden.",
+  "Eraro : ": "Fout : ",
+  "antaŭa bildo": "vorige afbeelding",
+  "ludi": "afspelen",
+  "ludi * 5 kaj enĉenigi": "speel 5 keer sneller af",
+  "sekva bildo": "volgende foto",
+  "Fermi": "Sluiten",
+  "Elŝuti": "Ophalen",
+  "Forigi": "Verwijderen",
+  "Kamerao tipo": "Cameratype",
+  "Loka V4L2-kamerao": "Lokale V4L2-camera",
+  "Loka MMAL-kamerao": "Lokale MMAL-camera",
+  "Reta kamerao": "Netwerkcamera",
+  "Fora motionEye kamerao": "Externe MotionEye camera",
+  "Simpla MJPEG-kamerao": "Eenvoudige MJPEG-camera",
+  "la speco de kamerao, kiun vi volas aldoni": "het type camera dat u wilt toevoegen",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://voorbeeld.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "de camera URL (bijv. http://voorbeeld.com:8080/cam/)",
+  "uzantnomo...": "gebruikersnaam...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "de gebruikersnaam voor de URL, indien nodig (bijv. admin)",
+  "pasvorto...": "wachtwoord...",
+  "la pasvorto por la URL, se bezonata": "het wachtwoord voor de URL, indien nodig",
+  "Kamerao": "Camera",
+  "la kameraon, kiun vi volas aldoni": "de camera die u wilt toevoegen",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "MotionEye camera's op afstand zijn camera's die op een andere MotionEye server zijn geïnstalleerd. Door ze hier toe te voegen, kunt u ze op afstand bekijken en beheren.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Netwerkcamera's (of IP-camera's) zijn apparaten die standaard RTSP/RTMP-, MJPEG-video's of gewone JPEG-afbeeldingen kunnen streamen. Raadpleeg de handleiding van uw apparaat om de juiste RTSP-, RTMP-, MJPEG- of JPEG-URL te vinden.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokale MMAL-camera's zijn apparaten die rechtstreeks op uw motionEye-systeem zijn aangesloten. Dit zijn meestal kaartspecifieke camera's.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Als u uw apparaat toevoegt als een eenvoudige MJPEG-camera in plaats van een netwerkcamera, dan zal de beeldkwaliteit verbeteren, maar er is dan geen bewegingsdetectie, beeldopname of video-opname mogelijk. De camera moet toegankelijk zijn voor uw server en browser. Dit type camera is niet compatibel met Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokale V4L2-camera's zijn camera-apparaten die rechtstreeks op uw MotionEye-systeem zijn aangesloten, meestal via USB.",
+  "Aldonadi kameraon...": "Camera toevoegen...",
+  "Grupo": "Groep",
+  "Inkluzivi foton prenitan ĉiun": "Voeg elk een foto toe die is gemaakt",
+  "sekundo": "1 seconde",
+  "5 sekundoj": "5 seconden",
+  "10 sekundoj": "10 seconden",
+  "30 sekundoj": "30 seconden",
+  "minuto": "1 minuut",
+  "5 minutoj": "5 minuten",
+  "10 minutoj": "10 minuten",
+  "30 minutoj": "30 minuten",
+  "horo": "1 uur",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Selecteer het tijdsinterval tussen twee geselecteerde afbeeldingen.",
+  "Filmo framfrekvenco": "Framesnelheid video",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Kies hoe snel de Timelapse afgespeeld moet worden.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Gezien het grote aantal afbeeldingen kan het maken van uw video enige tijd in beslag nemen!",
+  "Krei akselita video": "Maak een Timelapse film",
+  "Filmo kreanta en progreso...": "Bezig met het maken van de video...",
+  "Zipitaj": "Gezipt",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Alles verwijderen",
+  "Bildoj prenitaj de ": "Foto's genomen op ",
+  "Filmoj registritaj de ": "Films opgenomen door ",
+  "montru ĉi tiun fotilon plenekranan": "deze camera weergeven op volledig scherm",
+  "montri ĉiujn fotilojn": "toon alle camera's",
+  "montru nur ĉi tiun fotilon": "toon alleen deze camera",
+  "malfermaj bildoj retumilo": "Afbeeldingen openen",
+  "malferma videoj retumilo": "Video's openen",
+  "agordi ĉi tiun kameraon": "deze camera configureren",
+  "preni instantaron": "maak een momentopname",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "U heeft nog geen camera geconfigureerd. Klik hier om er een toe te voegen ...",
+  "enigu pozitivan nombron": "voer een positief getal in",
+  "enigu pozitivan entjeran nombron": "voer een positief geheel getal in",
+  "enigu nombron": "voer een nummer in",
+  "enigu entjeran nombron": "voer een geheel getal in",
+  " inter ": " tussen ",
+  " kaj ": " en ",
+  " pli ol ": " groter dan ",
+  " malpli ol ": " kleiner dan ",
+  "enigu validan tempon en la sekva formato: HH:MM": "voer een geldige tijd in het volgende formaat: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "voer een geldige URL in (bijv. http://voorbeeld.com:8080/cams/)",
+  "fermi": "sluiten",
+  "Ne": "Nee",
+  "Jes": "Ja",
+  "Bone": "OK",
+  "Auto Exposure": "Automatische belichting",
+  "Backlight Compensation": "Tegenlichtcompensatie",
+  "Brightness": "Helderheid",
+  "Contrast": "Contrast",
+  "Exposure Absolute": "Absolute belichting",
+  "Exposure Auto": "Automatische belichting",
+  "Exposure Auto Priority": "Automatische belichtingsprioriteit",
+  "Exposure Time Absolute": "Absolute belichtingstijd",
+  "Focus Absolute": "Absoluut focussen",
+  "Focus Auto": "Autofocus",
+  "Gain": "Versterking",
+  "Gamma": "Gamma",
+  "Hue": "Kleurtoon",
+  "Led1 Mode": "LED1 modus",
+  "Led1 Frequency": "LED1 frequentie",
+  "Pan Absolute": "Pan absoluut",
+  "Power Line Frequency": "Net frequentie",
+  "Saturation": "Saturatie",
+  "Sharpness": "Scherpte",
+  "Tilt Absolute": "Absoluut kantelen",
+  "White Balance Temperature": "Temperatuur witbalans",
+  "White Balance Temperature Auto": "Auto temperatuur witbalans",
+  "Zoom Absolute": "Absolute zoom",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.pa.json
+++ b/motioneye/static/js/motioneye.pa.json
@@ -1,164 +1,176 @@
-{"":{"language":"pa","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "ਪਾਸਵਰਡ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ"
-,"Ĉi tiu kampo estas deviga": "ਇਹ ਖੇਤਰ ਲੋੜੀਂਦਾ ਹੈ"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "ਕੈਮਰੇ ਦੇ ਨਾਮ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ"
-,"valoro devas esti multoblo de 8": "ਮੁੱਲ 8 ਦਾ ਗੁਣਕ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-,"specialaj signoj ne rajtas en radika voja nomo": "ਰੂਟ ਮਾਰਗ ਨਾਮ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "ਫਾਈਲਾਂ ਸਿੱਧੇ ਤੁਹਾਡੇ ਸਿਸਟਮ ਦੇ ਰੂਟ ਵਿੱਚ ਨਹੀਂ ਬਣੀਆਂ"
-,"enigu validan retpoŝtadreson": "ਇੱਕ ਵੈਧ ਈਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "ਕਾਮੇ ਨਾਲ ਵੱਖ ਕੀਤੇ ਵੈਧ ਈਮੇਲ ਪਤਿਆਂ ਦੀ ਸੂਚੀ ਦਰਜ ਕਰੋ"
-,"specialaj signoj ne rajtas en dosiernomo": "ਫਾਇਲ ਅੱਖਰ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ"
-,"enigu validan valoron": "ਇੱਕ ਯੋਗ ਮੁੱਲ ਦਾਖਲ ਕਰੋ"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "ਇਹ ਲਗਾਤਾਰ ਕਲਾਉਡ ਫੋਲਡਰ ਦੀਆਂ ਸਾਰੀਆਂ ਫਾਈਲਾਂ ਨੂੰ ਮਿਟਾ ਦੇਵੇਗਾ \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", ਮੋਸ਼ਨ ਈ ਦੁਆਰਾ ਅਪਲੋਡ ਕੀਤੇ ਸਿਰਫ ਉਨ੍ਹਾਂ ਨੂੰ ਹੀ ਨਹੀਂ!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "ਇਹ ਲਗਾਤਾਰ ਫੋਲਡਰ ਵਿਚਲੀਆਂ ਪੁਰਾਣੀਆਂ ਮੀਡੀਆ ਫਾਈਲਾਂ ਨੂੰ ਮਿਟਾ ਦੇਵੇਗਾ \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", ਸਿਰਫ ਮੋਸ਼ਨ ਈ ਦੁਆਰਾ ਬਣਾਏ ਉਨ੍ਹਾਂ ਨੂੰ ਨਹੀਂ!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "ਇੱਕ ਯੋਗ ਕੈਮਰਾ ਚਿੱਤਰ ਤੋਂ ਬਿਨਾਂ ਮਾਸਕ ਨੂੰ ਸੋਧ ਨਹੀਂ ਸਕਦਾ!"
-,"Propra": "ਆਪਣੇ"
-,"Propra dosierindiko": "ਕਸਟਮ ਫਾਈਲ ਨਾਮ"
-,"Retan kunlokon": "Communicationਨਲਾਈਨ ਸੰਚਾਰ"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "ਤੁਹਾਡਾ ਬ੍ਰਾ .ਜ਼ਰ ਇਸ ਵਿਸ਼ੇਸ਼ਤਾ ਨੂੰ ਪੂਰਾ ਨਹੀਂ ਕਰਦਾ!"
-,"Apliki": "ਲਾਗੂ ਕਰੋ"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "ਇਹ ਸੁਨਿਸ਼ਚਿਤ ਕਰੋ ਕਿ ਸਾਰੀਆਂ ਕੌਂਫਿਗਰੇਸ਼ਨ ਵਿਕਲਪ ਯੋਗ ਹਨ!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "ਇਹ ਸਿਸਟਮ ਨੂੰ ਮੁੜ ਚਾਲੂ ਕਰੇਗਾ. ਜਾਰੀ ਰੱਖਣਾ ਹੈ?"
-,"Vere fermiti sistemon?": "ਕੀ ਸਿਸਟਮ ਬੰਦ ਹੋ ਰਿਹਾ ਹੈ?"
-,"Malŝaltita": "ਬੰਦ"
-,"Ĉu vere restartigi ?": "ਅਸਲ ਵਿੱਚ ਮੁੜ ਚਾਲੂ ਹੋ?"
-,"La sistemo rekomencis!": "ਸਿਸਟਮ ਦੁਬਾਰਾ ਚਾਲੂ ਹੋਇਆ!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "ਕਿਰਪਾ ਕਰਕੇ ਪਹਿਲਾਂ ਸੋਧੀ ਹੋਈ ਸੈਟਿੰਗ ਲਾਗੂ ਕਰੋ!"
-,"Neniu fotilo por forigi!": "ਹਟਾਉਣ ਲਈ ਕੋਈ ਕੈਮਰਾ ਨਹੀਂ!"
-,"Ĉu forigi kameraon ": "ਕੈਮਰਾ ਹਟਾ ਸਕਦਾ ਹੈ"
-,"motionEye estas ĝisdatigita (aktuala versio: ": "ਮੋਸ਼ਨ ਈ ਅਪਡੇਟ ਹੋਇਆ ਹੈ (ਮੌਜੂਦਾ ਸੰਸਕਰਣ:"
-,"Nova versio havebla: ": "ਨਵਾਂ ਸੰਸਕਰਣ ਉਪਲਬਧ:"
-,". Ĝisdatigi?": ". ਅਪਡੇਟ?"
-,"motionEye estis sukcese ĝisdatigita!": "ਮੋਸ਼ਨ ਈ ਨੂੰ ਸਫਲਤਾਪੂਰਵਕ ਅਪਡੇਟ ਕੀਤਾ ਗਿਆ ਹੈ!"
-,"Ĝisdatigo malsukcesis!": "ਅਪਡੇਟ ਫੇਲ੍ਹ ਹੋਇਆ!"
-,"La ĝisdatiga procezo malsukcesis!": "ਅਪਗ੍ਰੇਡ ਪ੍ਰਕਿਰਿਆ ਅਸਫਲ!"
-,"Rezerva dosiero": "ਬੈਕਅਪ ਫਾਈਲ"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "ਬੈਕਅਪ ਫਾਈਲ ਜੋ ਤੁਸੀਂ ਪਹਿਲਾਂ ਡਾedਨਲੋਡ ਕੀਤੀ ਹੈ."
-,"Restaŭrigi Agordon": "ਮੁੜ - ਪ੍ਰਾਪਤ ਕਰੋ"
-,"Restaŭriganta agordon ...": "ਕੌਂਫਿਗਰੇਸ਼ਨ ਰੀਸਟੋਰ ਕਰ ਰਿਹਾ ਹੈ ..."
-,"La agordo restaŭrigis!": "ਕੌਨਫਿਗਰੇਸ਼ਨ ਨੂੰ ਬਹਾਲ ਕਰ ਦਿੱਤਾ ਗਿਆ ਹੈ!"
-,"Malsukcesis restaŭri la agordon!": "ਕੌਂਫਿਗਰੇਸ਼ਨ ਨੂੰ ਰੀਸਟੋਰ ਕਰਨ ਵਿੱਚ ਅਸਫਲ!"
-,"Aliri la alŝutan servon malsukcesis: ": "ਅਪਲੋਡ ਸੇਵਾ ਤੱਕ ਪਹੁੰਚ ਅਸਫਲ:"
-,"Aliri la alŝutan servon sukcesis!": "ਅਪਲੋਡ ਸੇਵਾ ਤੱਕ ਪਹੁੰਚ ਸਫਲ ਰਹੀ!"
-,"Sciiga retpoŝto fiaskis:": "ਨਿ News ਜ਼ ਈਮੇਲ ਅਸਫਲ:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "ਇਹ ਸੁਨਿਸ਼ਚਿਤ ਕਰੋ ਕਿ ਸਾਰੀਆਂ ਕੌਂਫਿਗਰੇਸ਼ਨ ਯੋਗ ਹਨ!"
-,"Sciiga Telegramo fiaskis:": "ਨੋਟੀਫਿਕੇਸ਼ਨ ਤਾਰ ਅਸਫਲ:"
-,"Sciiga Telegramo sukcesis!": "ਨੋਟੀਫਿਕੇਸ਼ਨ ਤਾਰਾਂ ਸਫਲ ਰਿਹਾ!"
-,"Aliro al retdividado fiaskis: ": "ਨੈੱਟਵਰਕ ਟ੍ਰਾਂਸਮੇਟਿੰਗ ਤੱਕ ਪਹੁੰਚ ਅਸਫਲ:"
-,"Aliro al retdividado sukcesis!": "ਪ੍ਰਤਿਭਾ ਤੱਕ ਪਹੁੰਚ ਸਫਲ ਰਹੀ ਹੈ!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "ਸੱਚਮੁੱਚ ਇਸ ਫਾਈਲ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "ਕੀ ਸੱਚਮੁੱਚ \"%(group)s% (ਸਮੂਹ) s\" ਤੋਂ ਸਾਰੇ ਚਿੱਤਰ ਮਿਟਾਉਣੇ ਹਨ?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੀਆਂ ਫਿਲਮਾਂ ਨੂੰ \"%(group)s% (ਸਮੂਹ) s\" ਤੋਂ ਹਟਾਉਣਾ ਹੈ?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੇ ਸਮੂਹ ਰਹਿਤ ਚਿੱਤਰਾਂ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੀਆਂ ਗੈਰ-ਸਮੂਹਿਤ ਫਿਲਮਾਂ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?"
-,"aldonadi kameraon...": "ਕੈਮਰਾ ਸ਼ਾਮਲ ਕਰੋ ..."
-,"Uzantnomo": "ਉਪਯੋਗਕਰਤਾ ਨਾਮ"
-,"Pasvorto": "ਪਾਸਵਰਡ"
-,"Memoru min": "ਮੈਨੂੰ ਯਾਦ ਕਰੋ"
-,"Ensaluti": "ਲਾਗ ਇਨ"
-,"Nuligi": "ਰੱਦ ਕਰੋ"
-,"Vi abortis la filmeton.": "ਤੁਸੀਂ ਵੀਡੀਓ ਨੂੰ ਅਧੂਰਾ ਛੱਡ ਦਿੱਤਾ ਹੈ."
-,"Reto eraro okazis.": "ਨੈੱਟਵਰਕ ਗਲਤੀ ਆਈ ਹੈ."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "ਡੀਕੋਡਿੰਗ ਗਲਤੀ ਜਾਂ ਨਾਨ-ਪ੍ਰੋਜੈਕਟਿਡ ਫੰਕਸ਼ਨ."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "ਫਾਰਮੈਟ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ ਜਾਂ ਪਲੇਬੈਕ ਲਈ ਅਸਮਰੱਥ / ਅਣਉਚਿਤ ਹੈ."
-,"Nekonata eraro okazis.": "ਇੱਕ ਅਣਜਾਣ ਗਲਤੀ ਆਈ ਹੈ."
-,"Eraro : ": "ਗਲਤੀ:"
-,"antaŭa bildo": "ਪਿਛਲੀ ਤਸਵੀਰ"
-,"ludi": "ਖੇਡਣ ਲਈ"
-,"ludi * 5 kaj enĉenigi": "* 5 ਅਤੇ ਚੇਨ ਖੇਡੋ"
-,"sekva bildo": "ਅਗਲਾ ਚਿੱਤਰ"
-,"Fermi": "ਬੰਦ ਕਰੋ"
-,"Elŝuti": "ਡਾ .ਨਲੋਡ"
-,"Forigi": "ਹਟਾਓ"
-,"Kamerao tipo": "ਕੈਮਰਾ ਕਿਸਮ"
-,"Loka V4L2-kamerao": "ਸਥਾਨਕ ਵੀ 4 ਐਲ 2 ਕੈਮਰਾ"
-,"Loka MMAL-kamerao": "ਸਥਾਨਕ ਐਮ ਐਮ ਐਲ ਕੈਮਰਾ"
-,"Reta kamerao": "ਵੈਬਕੈਮ"
-,"Fora motionEye kamerao": "ਬਾਹਰ ਮੋਸ਼ਨਈ ਕੈਮਰਾ"
-,"Simpla MJPEG-kamerao": "ਸਧਾਰਨ ਐਮਜੇਪੀਈਜੀ ਕੈਮਰਾ"
-,"la speco de kamerao, kiun vi volas aldoni": "ਕੈਮਰਾ ਦੀ ਕਿਸਮ ਜੋ ਤੁਸੀਂ ਸ਼ਾਮਲ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ"
-,"URL": "ਯੂਆਰਐਲ"
-,"http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / ਕੈਮਜ਼ / ..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "ਕੈਮਰਾ ਯੂਆਰਐਲ (ਉਦਾਹਰਣ ਲਈ http://example.com:8080/cam/)"
-,"uzantnomo...": "ਉਪਭੋਗਤਾ ਨਾਮ ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "ਯੂਆਰਐਲ ਲਈ ਯੂਜ਼ਰ-ਨਾਂ, ਜੇ ਜਰੂਰੀ ਹੋਵੇ (ਜਿਵੇਂ ਐਡਮਿਨ)"
-,"pasvorto...": "ਪਾਸਵਰਡ ..."
-,"la pasvorto por la URL, se bezonata": "ਯੂਆਰਐਲ ਲਈ ਪਾਸਵਰਡ, ਜੇ ਜਰੂਰੀ ਹੈ"
-,"Kamerao": "ਕੈਮਰਾ"
-,"la kameraon, kiun vi volas aldoni": "ਕੈਮਰਾ ਜੋ ਤੁਸੀਂ ਜੋੜਨਾ ਚਾਹੁੰਦੇ ਹੋ"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "ਇੱਕ ਰਿਮੋਟ ਮੋਸ਼ਨਈ ਕੈਮਰਾ ਇੱਕ ਕੈਮਰਾ ਹੈ ਜੋ ਇੱਕ ਹੋਰ ਮੋਸ਼ਨ ਈ ਸਰਵਰ ਦੇ ਪਿੱਛੇ ਸਥਾਪਤ ਕੀਤਾ ਗਿਆ ਹੈ. ਉਨ੍ਹਾਂ ਨੂੰ ਇੱਥੇ ਜੋੜਨ ਨਾਲ ਤੁਸੀਂ ਉਨ੍ਹਾਂ ਨੂੰ ਦੂਰੋਂ ਵੇਖਣ ਅਤੇ ਪ੍ਰਬੰਧਿਤ ਕਰ ਸਕੋਗੇ."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "ਨੈਟਵਰਕ ਕੈਮਰੇ (ਜਾਂ ਆਈਪੀ ਕੈਮਰੇ) ਉਹ ਉਪਕਰਣ ਹਨ ਜੋ ਆਰਟੀਐਸਪੀ / ਆਰਟੀਐਮਪੀ ਜਾਂ ਐਮਜੇਪੀਈਜੀ ਵੀਡਿਓਜ ਜਾਂ ਸਧਾਰਣ ਜੇਪੀਈਜੀ ਚਿੱਤਰਾਂ ਦਾ ਮੂਲ ਰੂਪ ਵਿਚ ਸਟ੍ਰੀਮ ਕਰਦੇ ਹਨ. ਸਹੀ RTSP, RTMP, MJPEG ਜਾਂ JPEG URL ਨੂੰ ਲੱਭਣ ਲਈ ਆਪਣੀ ਡਿਵਾਈਸ ਦੇ ਮੈਨੂਅਲ ਤੋਂ ਸਲਾਹ ਲਓ."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "ਸਥਾਨਕ ਐਮ ਐਮ ਐਲ ਕੈਮਰਾ ਉਹ ਉਪਕਰਣ ਹਨ ਜੋ ਸਿੱਧੇ ਤੁਹਾਡੇ ਮੋਸ਼ਨਇ ਸਿਸਟਮ ਨਾਲ ਜੁੜੇ ਹੋਏ ਹਨ. ਇਹ ਆਮ ਤੌਰ ਤੇ ਕਾਰਡ ਸੰਬੰਧੀ ਕੈਮਰੇ ਹੁੰਦੇ ਹਨ."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ਆਪਣੀ ਡਿਵਾਈਸ ਨੂੰ ਵੈੱਬ ਕੈਮਰੇ ਦੀ ਬਜਾਏ ਇੱਕ ਸਧਾਰਣ ਐਮਜੇਪੀਈਜੀ ਕੈਮਰੇ ਵਜੋਂ ਸ਼ਾਮਲ ਕਰਨ ਨਾਲ ਫੋਟੋਗ੍ਰਾਫੀ ਵਿੱਚ ਸੁਧਾਰ ਹੋਵੇਗਾ, ਪਰ ਇਸ ਦੇ ਲਈ ਕੋਈ ਗਤੀ ਖੋਜ, ਚਿੱਤਰ ਕੈਪਚਰ ਜਾਂ ਫਿਲਮ ਰਿਕਾਰਡਿੰਗ ਉਪਲਬਧ ਨਹੀਂ ਹੋਏਗੀ. ਕੈਮਰਾ ਤੁਹਾਡੇ ਸਰਵਰ ਅਤੇ ਤੁਹਾਡੇ ਬ੍ਰਾ .ਜ਼ਰ ਲਈ ਪਹੁੰਚਯੋਗ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ. ਇਸ ਕਿਸਮ ਦਾ ਕੈਮਰਾ ਇੰਟਰਨੈੱਟ ਐਕਸਪਲੋਰਰ ਨਾਲ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "ਸਥਾਨਕ ਵੀ 4 ਐਲ 2 ਕੈਮਰੇ ਕੈਮਰਾ ਉਪਕਰਣ ਹਨ ਜੋ ਸਿੱਧੇ ਤੁਹਾਡੇ ਮੋਸ਼ਨਇ ਸਿਸਟਮ ਨਾਲ ਜੁੜੇ ਹੁੰਦੇ ਹਨ, ਆਮ ਤੌਰ ਤੇ ਯੂ ਐਸ ਬੀ ਦੁਆਰਾ."
-,"Aldonadi kameraon...": "ਕੈਮਰਾ ਸ਼ਾਮਲ ਕਰੋ ..."
-,"Grupo": "ਸਮੂਹ"
-,"Inkluzivi foton prenitan ĉiun": "ਹਰ ਇੱਕ ਲਈ ਗਈ ਇੱਕ ਫੋਟੋ ਸ਼ਾਮਲ ਕਰੋ"
-,"sekundo": "ਦੂਜਾ"
-,"5 sekundoj": "5 ਸਕਿੰਟ"
-,"10 sekundoj": "10 ਸਕਿੰਟ"
-,"30 sekundoj": "30 ਸਕਿੰਟ"
-,"minuto": "ਮਿੰਟ"
-,"5 minutoj": "5 ਮਿੰਟ"
-,"10 minutoj": "10 ਮਿੰਟ"
-,"30 minutoj": "30 ਮਿੰਟ"
-,"horo": "ਇਕ ਘੰਟਾ"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "ਦੋ ਚੁਣੇ ਚਿੱਤਰਾਂ ਵਿਚਕਾਰ ਸਮਾਂ ਅੰਤਰਾਲ ਦੀ ਚੋਣ ਕਰੋ."
-,"Filmo framfrekvenco": "ਫਿਲਮ ਫਰੇਮ ਰੇਟ"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "ਚੁਣੋ ਕਿ ਤੁਸੀਂ ਕਿੰਨੀ ਤੇਜ਼ੀ ਨਾਲ ਐਕਸਲੇਟਿਡ ਵੀਡੀਓ ਚਾਹੁੰਦੇ ਹੋ."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "ਵੱਡੀ ਗਿਣਤੀ ਵਿੱਚ ਤਸਵੀਰਾਂ ਨੂੰ ਧਿਆਨ ਵਿੱਚ ਰੱਖਦਿਆਂ, ਤੁਹਾਡੇ ਵੀਡੀਓ ਨੂੰ ਬਣਾਉਣ ਵਿੱਚ ਕੁਝ ਸਮਾਂ ਲੱਗ ਸਕਦਾ ਹੈ!"
-,"Krei akselita video": "ਇੱਕ ਪ੍ਰਵੇਗਿਤ ਵੀਡੀਓ ਬਣਾਓ"
-,"Filmo kreanta en progreso...": "ਇੱਕ ਫਿਲਮ ਪ੍ਰਗਤੀ ਵਿੱਚ ਹੈ ..."
-,"Zipitaj": "ਜ਼ਿੱਪਰਡ"
-,"Akselita video": "ਤੇਜ਼ ਵੀਡੀਓ"
-,"Forigi ĉiujn": "ਸਭ ਨੂੰ ਹਟਾਓ"
-,"Bildoj prenitaj de ": "ਦੁਆਰਾ ਖਿੱਚੀਆਂ ਤਸਵੀਰਾਂ"
-,"Filmoj registritaj de ": "ਦੁਆਰਾ ਰਿਕਾਰਡ ਕੀਤੀਆਂ ਫਿਲਮਾਂ"
-,"montru ĉi tiun fotilon plenekranan": "ਇਸ ਕੈਮਰਾ ਨੂੰ ਪੂਰਾ ਸਮਾਂ ਦਿਖਾਓ"
-,"montri ĉiujn fotilojn": "ਸਾਰੇ ਕੈਮਰੇ ਦਿਖਾਓ"
-,"montru nur ĉi tiun fotilon": "ਸਿਰਫ ਇਹ ਕੈਮਰਾ ਦਿਖਾਓ"
-,"malfermaj bildoj retumilo": "ਚਿੱਤਰ ਬਰਾ browserਜ਼ਰ ਖੋਲ੍ਹੋ"
-,"malferma videoj retumilo": "ਵੀਡੀਓ ਬਰਾ browserਜ਼ਰ ਖੋਲ੍ਹੋ"
-,"agordi ĉi tiun kameraon": "ਇਸ ਕੈਮਰਾ ਸੈੱਟ ਕਰੋ"
-,"preni instantaron": "ਇੱਕ ਸਨੈਪਸ਼ਾਟ ਲਓ"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "ਤੁਸੀਂ ਅਜੇ ਤੱਕ ਕਿਸੇ ਵੀ ਕੈਮਰੇ ਨੂੰ ਕੌਂਫਿਗਰ ਨਹੀਂ ਕੀਤਾ ਹੈ. % ਨੂੰ ਜੋਡ਼ਨ ਲਈ ਇੱਥੇ ਕਲਿਕ ਕਰੋਂ ..."
-,"enigu pozitivan nombron": "ਸਕਾਰਾਤਮਕ ਨੰਬਰ ਦਾਖਲ ਕਰੋ"
-,"enigu pozitivan entjeran nombron": "ਇੱਕ ਸਕਾਰਾਤਮਕ ਪੂਰਨ ਅੰਕ ਦਾਖਲ ਕਰੋ"
-,"enigu nombron": "ਇੱਕ ਨੰਬਰ ਦਰਜ ਕਰੋ"
-,"enigu entjeran nombron": "ਇੱਕ ਪੂਰਨ ਅੰਕ ਦਾਖਲ ਕਰੋ"
-," inter ": "ਵਿਚਕਾਰ"
-," kaj ": "ਅਤੇ"
-," pli ol ": "ਵੱਧ ਹੋਰ"
-," malpli ol ": "ਤੋਂ ਘੱਟ"
-,"enigu validan tempon en la sekva formato: HH:MM": "ਹੇਠ ਦਿੱਤੇ ਫਾਰਮੈਟ ਵਿੱਚ ਯੋਗ ਸਮਾਂ ਦਾਖਲ ਕਰੋ: ਐਚਐਚ: ਐਮਐਮ"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ਇੱਕ ਵੈਧ URL ਦਾਖਲ ਕਰੋ (ਉਦਾਹਰਣ ਲਈ http://example.com:8080/cams/)"
-,"fermi": "ਬੰਦ ਕਰਨ ਲਈ"
-,"Ne": "ਨਹੀਂ"
-,"Jes": "ਹਾਂ"
-,"Bone": "ਠੀਕ ਹੈ"
-,"Auto Exposure": "ਆਟੋ ਐਕਸਪੋਜਰ"
-,"Backlight Compensation": "ਬੈਕਲਾਈਟ ਮੁਆਵਜ਼ਾ"
-,"Brightness": "ਚਮਕ"
-,"Contrast": "ਇਸ ਦੇ ਉਲਟ"
-,"Exposure Absolute": "ਐਕਸਪੋਜਰ ਬਿਲਕੁਲ"
-,"Exposure Auto": "ਐਕਸਪੋਜਰ ਆਟੋ"
-,"Exposure Auto Priority": "ਐਕਸਪੋਜਰ ਆਟੋ ਪ੍ਰਾਥਮਿਕਤਾ"
-,"Exposure Time Absolute": "ਐਕਸਪੋਜਰ ਟਾਈਮ ਬਿਲਕੁਲ"
-,"Focus Absolute": "ਬਿਲਕੁਲ ਧਿਆਨ ਦਿਓ"
-,"Focus Auto": "ਫੋਕਸ ਆਟੋ"
-,"Gain": "ਲਾਭ"
-,"Gamma": "ਗਾਮਾ"
-,"Hue": "ਹੂ"
-,"Led1 Mode": "LED1 ਮੋਡ"
-,"Led1 Frequency": "LED1 ਬਾਰੰਬਾਰਤਾ"
-,"Pan Absolute": "ਹਿੰਮਤ"
-,"Power Line Frequency": "ਪਾਵਰ ਲਾਈਨ ਬਾਰੰਬਾਰਤਾ"
-,"Saturation": "ਸੰਤ੍ਰਿਪਤਾ"
-,"Sharpness": "ਤਿੱਖਾਪਨ"
-,"Tilt Absolute": "ਥੋੜਾ ਜਿਹਾ ਝੁਕੋ"
-,"White Balance Temperature": "ਚਿੱਟਾ ਸੰਤੁਲਨ ਦਾ ਤਾਪਮਾਨ"
-,"White Balance Temperature Auto": "ਚਿੱਟਾ ਸੰਤੁਲਨ ਦਾ ਤਾਪਮਾਨ ਆਟੋ"
-,"Zoom Absolute": "ਜ਼ੂਮ ਬਿਲਕੁਲ"
+{
+  "": {
+    "language": "pa",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "ਪਾਸਵਰਡ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ",
+  "Ĉi tiu kampo estas deviga": "ਇਹ ਖੇਤਰ ਲੋੜੀਂਦਾ ਹੈ",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "ਕੈਮਰੇ ਦੇ ਨਾਮ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ",
+  "valoro devas esti multoblo de 8": "ਮੁੱਲ 8 ਦਾ ਗੁਣਕ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ",
+  "specialaj signoj ne rajtas en radika voja nomo": "ਰੂਟ ਮਾਰਗ ਨਾਮ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "ਫਾਈਲਾਂ ਸਿੱਧੇ ਤੁਹਾਡੇ ਸਿਸਟਮ ਦੇ ਰੂਟ ਵਿੱਚ ਨਹੀਂ ਬਣੀਆਂ",
+  "enigu validan retpoŝtadreson": "ਇੱਕ ਵੈਧ ਈਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "ਕਾਮੇ ਨਾਲ ਵੱਖ ਕੀਤੇ ਵੈਧ ਈਮੇਲ ਪਤਿਆਂ ਦੀ ਸੂਚੀ ਦਰਜ ਕਰੋ",
+  "specialaj signoj ne rajtas en dosiernomo": "ਫਾਇਲ ਅੱਖਰ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਅੱਖਰਾਂ ਦੀ ਆਗਿਆ ਨਹੀਂ ਹੈ",
+  "enigu validan valoron": "ਇੱਕ ਯੋਗ ਮੁੱਲ ਦਾਖਲ ਕਰੋ",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "ਇਹ ਲਗਾਤਾਰ ਕਲਾਉਡ ਫੋਲਡਰ ਦੀਆਂ ਸਾਰੀਆਂ ਫਾਈਲਾਂ ਨੂੰ ਮਿਟਾ ਦੇਵੇਗਾ \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", ਮੋਸ਼ਨ ਈ ਦੁਆਰਾ ਅਪਲੋਡ ਕੀਤੇ ਸਿਰਫ ਉਨ੍ਹਾਂ ਨੂੰ ਹੀ ਨਹੀਂ!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "ਇਹ ਲਗਾਤਾਰ ਫੋਲਡਰ ਵਿਚਲੀਆਂ ਪੁਰਾਣੀਆਂ ਮੀਡੀਆ ਫਾਈਲਾਂ ਨੂੰ ਮਿਟਾ ਦੇਵੇਗਾ \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", ਸਿਰਫ ਮੋਸ਼ਨ ਈ ਦੁਆਰਾ ਬਣਾਏ ਉਨ੍ਹਾਂ ਨੂੰ ਨਹੀਂ!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "ਇੱਕ ਯੋਗ ਕੈਮਰਾ ਚਿੱਤਰ ਤੋਂ ਬਿਨਾਂ ਮਾਸਕ ਨੂੰ ਸੋਧ ਨਹੀਂ ਸਕਦਾ!",
+  "Propra": "ਆਪਣੇ",
+  "Propra dosierindiko": "ਕਸਟਮ ਫਾਈਲ ਨਾਮ",
+  "Retan kunlokon": "Communicationਨਲਾਈਨ ਸੰਚਾਰ",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "ਤੁਹਾਡਾ ਬ੍ਰਾ .ਜ਼ਰ ਇਸ ਵਿਸ਼ੇਸ਼ਤਾ ਨੂੰ ਪੂਰਾ ਨਹੀਂ ਕਰਦਾ!",
+  "Apliki": "ਲਾਗੂ ਕਰੋ",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "ਇਹ ਸੁਨਿਸ਼ਚਿਤ ਕਰੋ ਕਿ ਸਾਰੀਆਂ ਕੌਂਫਿਗਰੇਸ਼ਨ ਵਿਕਲਪ ਯੋਗ ਹਨ!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "ਇਹ ਸਿਸਟਮ ਨੂੰ ਮੁੜ ਚਾਲੂ ਕਰੇਗਾ. ਜਾਰੀ ਰੱਖਣਾ ਹੈ?",
+  "Vere fermiti sistemon?": "ਕੀ ਸਿਸਟਮ ਬੰਦ ਹੋ ਰਿਹਾ ਹੈ?",
+  "Malŝaltita": "ਬੰਦ",
+  "Ĉu vere restartigi ?": "ਅਸਲ ਵਿੱਚ ਮੁੜ ਚਾਲੂ ਹੋ?",
+  "La sistemo rekomencis!": "ਸਿਸਟਮ ਦੁਬਾਰਾ ਚਾਲੂ ਹੋਇਆ!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "ਕਿਰਪਾ ਕਰਕੇ ਪਹਿਲਾਂ ਸੋਧੀ ਹੋਈ ਸੈਟਿੰਗ ਲਾਗੂ ਕਰੋ!",
+  "Neniu fotilo por forigi!": "ਹਟਾਉਣ ਲਈ ਕੋਈ ਕੈਮਰਾ ਨਹੀਂ!",
+  "Ĉu forigi kameraon ": "ਕੈਮਰਾ ਹਟਾ ਸਕਦਾ ਹੈ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "ਮੋਸ਼ਨ ਈ ਅਪਡੇਟ ਹੋਇਆ ਹੈ (ਮੌਜੂਦਾ ਸੰਸਕਰਣ:",
+  "Nova versio havebla: ": "ਨਵਾਂ ਸੰਸਕਰਣ ਉਪਲਬਧ:",
+  ". Ĝisdatigi?": ". ਅਪਡੇਟ?",
+  "motionEye estis sukcese ĝisdatigita!": "ਮੋਸ਼ਨ ਈ ਨੂੰ ਸਫਲਤਾਪੂਰਵਕ ਅਪਡੇਟ ਕੀਤਾ ਗਿਆ ਹੈ!",
+  "Ĝisdatigo malsukcesis!": "ਅਪਡੇਟ ਫੇਲ੍ਹ ਹੋਇਆ!",
+  "La ĝisdatiga procezo malsukcesis!": "ਅਪਗ੍ਰੇਡ ਪ੍ਰਕਿਰਿਆ ਅਸਫਲ!",
+  "Rezerva dosiero": "ਬੈਕਅਪ ਫਾਈਲ",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "ਬੈਕਅਪ ਫਾਈਲ ਜੋ ਤੁਸੀਂ ਪਹਿਲਾਂ ਡਾedਨਲੋਡ ਕੀਤੀ ਹੈ.",
+  "Restaŭrigi Agordon": "ਮੁੜ - ਪ੍ਰਾਪਤ ਕਰੋ",
+  "Restaŭriganta agordon ...": "ਕੌਂਫਿਗਰੇਸ਼ਨ ਰੀਸਟੋਰ ਕਰ ਰਿਹਾ ਹੈ ...",
+  "La agordo restaŭrigis!": "ਕੌਨਫਿਗਰੇਸ਼ਨ ਨੂੰ ਬਹਾਲ ਕਰ ਦਿੱਤਾ ਗਿਆ ਹੈ!",
+  "Malsukcesis restaŭri la agordon!": "ਕੌਂਫਿਗਰੇਸ਼ਨ ਨੂੰ ਰੀਸਟੋਰ ਕਰਨ ਵਿੱਚ ਅਸਫਲ!",
+  "Aliri la alŝutan servon malsukcesis: ": "ਅਪਲੋਡ ਸੇਵਾ ਤੱਕ ਪਹੁੰਚ ਅਸਫਲ:",
+  "Aliri la alŝutan servon sukcesis!": "ਅਪਲੋਡ ਸੇਵਾ ਤੱਕ ਪਹੁੰਚ ਸਫਲ ਰਹੀ!",
+  "Sciiga retpoŝto fiaskis:": "ਨਿ News ਜ਼ ਈਮੇਲ ਅਸਫਲ:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "ਇਹ ਸੁਨਿਸ਼ਚਿਤ ਕਰੋ ਕਿ ਸਾਰੀਆਂ ਕੌਂਫਿਗਰੇਸ਼ਨ ਯੋਗ ਹਨ!",
+  "Sciiga Telegramo fiaskis:": "ਨੋਟੀਫਿਕੇਸ਼ਨ ਤਾਰ ਅਸਫਲ:",
+  "Sciiga Telegramo sukcesis!": "ਨੋਟੀਫਿਕੇਸ਼ਨ ਤਾਰਾਂ ਸਫਲ ਰਿਹਾ!",
+  "Aliro al retdividado fiaskis: ": "ਨੈੱਟਵਰਕ ਟ੍ਰਾਂਸਮੇਟਿੰਗ ਤੱਕ ਪਹੁੰਚ ਅਸਫਲ:",
+  "Aliro al retdividado sukcesis!": "ਪ੍ਰਤਿਭਾ ਤੱਕ ਪਹੁੰਚ ਸਫਲ ਰਹੀ ਹੈ!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "ਸੱਚਮੁੱਚ ਇਸ ਫਾਈਲ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "ਕੀ ਸੱਚਮੁੱਚ \"%(group)s% (ਸਮੂਹ) s\" ਤੋਂ ਸਾਰੇ ਚਿੱਤਰ ਮਿਟਾਉਣੇ ਹਨ?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੀਆਂ ਫਿਲਮਾਂ ਨੂੰ \"%(group)s% (ਸਮੂਹ) s\" ਤੋਂ ਹਟਾਉਣਾ ਹੈ?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੇ ਸਮੂਹ ਰਹਿਤ ਚਿੱਤਰਾਂ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "ਕੀ ਸੱਚਮੁੱਚ ਸਾਰੀਆਂ ਗੈਰ-ਸਮੂਹਿਤ ਫਿਲਮਾਂ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ?",
+  "aldonadi kameraon...": "ਕੈਮਰਾ ਸ਼ਾਮਲ ਕਰੋ ...",
+  "Uzantnomo": "ਉਪਯੋਗਕਰਤਾ ਨਾਮ",
+  "Pasvorto": "ਪਾਸਵਰਡ",
+  "Memoru min": "ਮੈਨੂੰ ਯਾਦ ਕਰੋ",
+  "Ensaluti": "ਲਾਗ ਇਨ",
+  "Nuligi": "ਰੱਦ ਕਰੋ",
+  "Vi abortis la filmeton.": "ਤੁਸੀਂ ਵੀਡੀਓ ਨੂੰ ਅਧੂਰਾ ਛੱਡ ਦਿੱਤਾ ਹੈ.",
+  "Reto eraro okazis.": "ਨੈੱਟਵਰਕ ਗਲਤੀ ਆਈ ਹੈ.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "ਡੀਕੋਡਿੰਗ ਗਲਤੀ ਜਾਂ ਨਾਨ-ਪ੍ਰੋਜੈਕਟਿਡ ਫੰਕਸ਼ਨ.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "ਫਾਰਮੈਟ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ ਜਾਂ ਪਲੇਬੈਕ ਲਈ ਅਸਮਰੱਥ / ਅਣਉਚਿਤ ਹੈ.",
+  "Nekonata eraro okazis.": "ਇੱਕ ਅਣਜਾਣ ਗਲਤੀ ਆਈ ਹੈ.",
+  "Eraro : ": "ਗਲਤੀ:",
+  "antaŭa bildo": "ਪਿਛਲੀ ਤਸਵੀਰ",
+  "ludi": "ਖੇਡਣ ਲਈ",
+  "ludi * 5 kaj enĉenigi": "* 5 ਅਤੇ ਚੇਨ ਖੇਡੋ",
+  "sekva bildo": "ਅਗਲਾ ਚਿੱਤਰ",
+  "Fermi": "ਬੰਦ ਕਰੋ",
+  "Elŝuti": "ਡਾ .ਨਲੋਡ",
+  "Forigi": "ਹਟਾਓ",
+  "Kamerao tipo": "ਕੈਮਰਾ ਕਿਸਮ",
+  "Loka V4L2-kamerao": "ਸਥਾਨਕ ਵੀ 4 ਐਲ 2 ਕੈਮਰਾ",
+  "Loka MMAL-kamerao": "ਸਥਾਨਕ ਐਮ ਐਮ ਐਲ ਕੈਮਰਾ",
+  "Reta kamerao": "ਵੈਬਕੈਮ",
+  "Fora motionEye kamerao": "ਬਾਹਰ ਮੋਸ਼ਨਈ ਕੈਮਰਾ",
+  "Simpla MJPEG-kamerao": "ਸਧਾਰਨ ਐਮਜੇਪੀਈਜੀ ਕੈਮਰਾ",
+  "la speco de kamerao, kiun vi volas aldoni": "ਕੈਮਰਾ ਦੀ ਕਿਸਮ ਜੋ ਤੁਸੀਂ ਸ਼ਾਮਲ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ",
+  "URL": "ਯੂਆਰਐਲ",
+  "http://ekzemplo.com:8765/cams/...": "http: //example.com: 8765 / ਕੈਮਜ਼ / ...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "ਕੈਮਰਾ ਯੂਆਰਐਲ (ਉਦਾਹਰਣ ਲਈ http://example.com:8080/cam/)",
+  "uzantnomo...": "ਉਪਭੋਗਤਾ ਨਾਮ ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "ਯੂਆਰਐਲ ਲਈ ਯੂਜ਼ਰ-ਨਾਂ, ਜੇ ਜਰੂਰੀ ਹੋਵੇ (ਜਿਵੇਂ ਐਡਮਿਨ)",
+  "pasvorto...": "ਪਾਸਵਰਡ ...",
+  "la pasvorto por la URL, se bezonata": "ਯੂਆਰਐਲ ਲਈ ਪਾਸਵਰਡ, ਜੇ ਜਰੂਰੀ ਹੈ",
+  "Kamerao": "ਕੈਮਰਾ",
+  "la kameraon, kiun vi volas aldoni": "ਕੈਮਰਾ ਜੋ ਤੁਸੀਂ ਜੋੜਨਾ ਚਾਹੁੰਦੇ ਹੋ",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "ਇੱਕ ਰਿਮੋਟ ਮੋਸ਼ਨਈ ਕੈਮਰਾ ਇੱਕ ਕੈਮਰਾ ਹੈ ਜੋ ਇੱਕ ਹੋਰ ਮੋਸ਼ਨ ਈ ਸਰਵਰ ਦੇ ਪਿੱਛੇ ਸਥਾਪਤ ਕੀਤਾ ਗਿਆ ਹੈ. ਉਨ੍ਹਾਂ ਨੂੰ ਇੱਥੇ ਜੋੜਨ ਨਾਲ ਤੁਸੀਂ ਉਨ੍ਹਾਂ ਨੂੰ ਦੂਰੋਂ ਵੇਖਣ ਅਤੇ ਪ੍ਰਬੰਧਿਤ ਕਰ ਸਕੋਗੇ.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "ਨੈਟਵਰਕ ਕੈਮਰੇ (ਜਾਂ ਆਈਪੀ ਕੈਮਰੇ) ਉਹ ਉਪਕਰਣ ਹਨ ਜੋ ਆਰਟੀਐਸਪੀ / ਆਰਟੀਐਮਪੀ ਜਾਂ ਐਮਜੇਪੀਈਜੀ ਵੀਡਿਓਜ ਜਾਂ ਸਧਾਰਣ ਜੇਪੀਈਜੀ ਚਿੱਤਰਾਂ ਦਾ ਮੂਲ ਰੂਪ ਵਿਚ ਸਟ੍ਰੀਮ ਕਰਦੇ ਹਨ. ਸਹੀ RTSP, RTMP, MJPEG ਜਾਂ JPEG URL ਨੂੰ ਲੱਭਣ ਲਈ ਆਪਣੀ ਡਿਵਾਈਸ ਦੇ ਮੈਨੂਅਲ ਤੋਂ ਸਲਾਹ ਲਓ.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "ਸਥਾਨਕ ਐਮ ਐਮ ਐਲ ਕੈਮਰਾ ਉਹ ਉਪਕਰਣ ਹਨ ਜੋ ਸਿੱਧੇ ਤੁਹਾਡੇ ਮੋਸ਼ਨਇ ਸਿਸਟਮ ਨਾਲ ਜੁੜੇ ਹੋਏ ਹਨ. ਇਹ ਆਮ ਤੌਰ ਤੇ ਕਾਰਡ ਸੰਬੰਧੀ ਕੈਮਰੇ ਹੁੰਦੇ ਹਨ.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "ਆਪਣੀ ਡਿਵਾਈਸ ਨੂੰ ਵੈੱਬ ਕੈਮਰੇ ਦੀ ਬਜਾਏ ਇੱਕ ਸਧਾਰਣ ਐਮਜੇਪੀਈਜੀ ਕੈਮਰੇ ਵਜੋਂ ਸ਼ਾਮਲ ਕਰਨ ਨਾਲ ਫੋਟੋਗ੍ਰਾਫੀ ਵਿੱਚ ਸੁਧਾਰ ਹੋਵੇਗਾ, ਪਰ ਇਸ ਦੇ ਲਈ ਕੋਈ ਗਤੀ ਖੋਜ, ਚਿੱਤਰ ਕੈਪਚਰ ਜਾਂ ਫਿਲਮ ਰਿਕਾਰਡਿੰਗ ਉਪਲਬਧ ਨਹੀਂ ਹੋਏਗੀ. ਕੈਮਰਾ ਤੁਹਾਡੇ ਸਰਵਰ ਅਤੇ ਤੁਹਾਡੇ ਬ੍ਰਾ .ਜ਼ਰ ਲਈ ਪਹੁੰਚਯੋਗ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ. ਇਸ ਕਿਸਮ ਦਾ ਕੈਮਰਾ ਇੰਟਰਨੈੱਟ ਐਕਸਪਲੋਰਰ ਨਾਲ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "ਸਥਾਨਕ ਵੀ 4 ਐਲ 2 ਕੈਮਰੇ ਕੈਮਰਾ ਉਪਕਰਣ ਹਨ ਜੋ ਸਿੱਧੇ ਤੁਹਾਡੇ ਮੋਸ਼ਨਇ ਸਿਸਟਮ ਨਾਲ ਜੁੜੇ ਹੁੰਦੇ ਹਨ, ਆਮ ਤੌਰ ਤੇ ਯੂ ਐਸ ਬੀ ਦੁਆਰਾ.",
+  "Aldonadi kameraon...": "ਕੈਮਰਾ ਸ਼ਾਮਲ ਕਰੋ ...",
+  "Grupo": "ਸਮੂਹ",
+  "Inkluzivi foton prenitan ĉiun": "ਹਰ ਇੱਕ ਲਈ ਗਈ ਇੱਕ ਫੋਟੋ ਸ਼ਾਮਲ ਕਰੋ",
+  "sekundo": "ਦੂਜਾ",
+  "5 sekundoj": "5 ਸਕਿੰਟ",
+  "10 sekundoj": "10 ਸਕਿੰਟ",
+  "30 sekundoj": "30 ਸਕਿੰਟ",
+  "minuto": "ਮਿੰਟ",
+  "5 minutoj": "5 ਮਿੰਟ",
+  "10 minutoj": "10 ਮਿੰਟ",
+  "30 minutoj": "30 ਮਿੰਟ",
+  "horo": "ਇਕ ਘੰਟਾ",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "ਦੋ ਚੁਣੇ ਚਿੱਤਰਾਂ ਵਿਚਕਾਰ ਸਮਾਂ ਅੰਤਰਾਲ ਦੀ ਚੋਣ ਕਰੋ.",
+  "Filmo framfrekvenco": "ਫਿਲਮ ਫਰੇਮ ਰੇਟ",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "ਚੁਣੋ ਕਿ ਤੁਸੀਂ ਕਿੰਨੀ ਤੇਜ਼ੀ ਨਾਲ ਐਕਸਲੇਟਿਡ ਵੀਡੀਓ ਚਾਹੁੰਦੇ ਹੋ.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "ਵੱਡੀ ਗਿਣਤੀ ਵਿੱਚ ਤਸਵੀਰਾਂ ਨੂੰ ਧਿਆਨ ਵਿੱਚ ਰੱਖਦਿਆਂ, ਤੁਹਾਡੇ ਵੀਡੀਓ ਨੂੰ ਬਣਾਉਣ ਵਿੱਚ ਕੁਝ ਸਮਾਂ ਲੱਗ ਸਕਦਾ ਹੈ!",
+  "Krei akselita video": "ਇੱਕ ਪ੍ਰਵੇਗਿਤ ਵੀਡੀਓ ਬਣਾਓ",
+  "Filmo kreanta en progreso...": "ਇੱਕ ਫਿਲਮ ਪ੍ਰਗਤੀ ਵਿੱਚ ਹੈ ...",
+  "Zipitaj": "ਜ਼ਿੱਪਰਡ",
+  "Akselita video": "ਤੇਜ਼ ਵੀਡੀਓ",
+  "Forigi ĉiujn": "ਸਭ ਨੂੰ ਹਟਾਓ",
+  "Bildoj prenitaj de ": "ਦੁਆਰਾ ਖਿੱਚੀਆਂ ਤਸਵੀਰਾਂ",
+  "Filmoj registritaj de ": "ਦੁਆਰਾ ਰਿਕਾਰਡ ਕੀਤੀਆਂ ਫਿਲਮਾਂ",
+  "montru ĉi tiun fotilon plenekranan": "ਇਸ ਕੈਮਰਾ ਨੂੰ ਪੂਰਾ ਸਮਾਂ ਦਿਖਾਓ",
+  "montri ĉiujn fotilojn": "ਸਾਰੇ ਕੈਮਰੇ ਦਿਖਾਓ",
+  "montru nur ĉi tiun fotilon": "ਸਿਰਫ ਇਹ ਕੈਮਰਾ ਦਿਖਾਓ",
+  "malfermaj bildoj retumilo": "ਚਿੱਤਰ ਬਰਾ browserਜ਼ਰ ਖੋਲ੍ਹੋ",
+  "malferma videoj retumilo": "ਵੀਡੀਓ ਬਰਾ browserਜ਼ਰ ਖੋਲ੍ਹੋ",
+  "agordi ĉi tiun kameraon": "ਇਸ ਕੈਮਰਾ ਸੈੱਟ ਕਰੋ",
+  "preni instantaron": "ਇੱਕ ਸਨੈਪਸ਼ਾਟ ਲਓ",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "ਤੁਸੀਂ ਅਜੇ ਤੱਕ ਕਿਸੇ ਵੀ ਕੈਮਰੇ ਨੂੰ ਕੌਂਫਿਗਰ ਨਹੀਂ ਕੀਤਾ ਹੈ. % ਨੂੰ ਜੋਡ਼ਨ ਲਈ ਇੱਥੇ ਕਲਿਕ ਕਰੋਂ ...",
+  "enigu pozitivan nombron": "ਸਕਾਰਾਤਮਕ ਨੰਬਰ ਦਾਖਲ ਕਰੋ",
+  "enigu pozitivan entjeran nombron": "ਇੱਕ ਸਕਾਰਾਤਮਕ ਪੂਰਨ ਅੰਕ ਦਾਖਲ ਕਰੋ",
+  "enigu nombron": "ਇੱਕ ਨੰਬਰ ਦਰਜ ਕਰੋ",
+  "enigu entjeran nombron": "ਇੱਕ ਪੂਰਨ ਅੰਕ ਦਾਖਲ ਕਰੋ",
+  " inter ": "ਵਿਚਕਾਰ",
+  " kaj ": "ਅਤੇ",
+  " pli ol ": "ਵੱਧ ਹੋਰ",
+  " malpli ol ": "ਤੋਂ ਘੱਟ",
+  "enigu validan tempon en la sekva formato: HH:MM": "ਹੇਠ ਦਿੱਤੇ ਫਾਰਮੈਟ ਵਿੱਚ ਯੋਗ ਸਮਾਂ ਦਾਖਲ ਕਰੋ: ਐਚਐਚ: ਐਮਐਮ",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ਇੱਕ ਵੈਧ URL ਦਾਖਲ ਕਰੋ (ਉਦਾਹਰਣ ਲਈ http://example.com:8080/cams/)",
+  "fermi": "ਬੰਦ ਕਰਨ ਲਈ",
+  "Ne": "ਨਹੀਂ",
+  "Jes": "ਹਾਂ",
+  "Bone": "ਠੀਕ ਹੈ",
+  "Auto Exposure": "ਆਟੋ ਐਕਸਪੋਜਰ",
+  "Backlight Compensation": "ਬੈਕਲਾਈਟ ਮੁਆਵਜ਼ਾ",
+  "Brightness": "ਚਮਕ",
+  "Contrast": "ਇਸ ਦੇ ਉਲਟ",
+  "Exposure Absolute": "ਐਕਸਪੋਜਰ ਬਿਲਕੁਲ",
+  "Exposure Auto": "ਐਕਸਪੋਜਰ ਆਟੋ",
+  "Exposure Auto Priority": "ਐਕਸਪੋਜਰ ਆਟੋ ਪ੍ਰਾਥਮਿਕਤਾ",
+  "Exposure Time Absolute": "ਐਕਸਪੋਜਰ ਟਾਈਮ ਬਿਲਕੁਲ",
+  "Focus Absolute": "ਬਿਲਕੁਲ ਧਿਆਨ ਦਿਓ",
+  "Focus Auto": "ਫੋਕਸ ਆਟੋ",
+  "Gain": "ਲਾਭ",
+  "Gamma": "ਗਾਮਾ",
+  "Hue": "ਹੂ",
+  "Led1 Mode": "LED1 ਮੋਡ",
+  "Led1 Frequency": "LED1 ਬਾਰੰਬਾਰਤਾ",
+  "Pan Absolute": "ਹਿੰਮਤ",
+  "Power Line Frequency": "ਪਾਵਰ ਲਾਈਨ ਬਾਰੰਬਾਰਤਾ",
+  "Saturation": "ਸੰਤ੍ਰਿਪਤਾ",
+  "Sharpness": "ਤਿੱਖਾਪਨ",
+  "Tilt Absolute": "ਥੋੜਾ ਜਿਹਾ ਝੁਕੋ",
+  "White Balance Temperature": "ਚਿੱਟਾ ਸੰਤੁਲਨ ਦਾ ਤਾਪਮਾਨ",
+  "White Balance Temperature Auto": "ਚਿੱਟਾ ਸੰਤੁਲਨ ਦਾ ਤਾਪਮਾਨ ਆਟੋ",
+  "Zoom Absolute": "ਜ਼ੂਮ ਬਿਲਕੁਲ",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.pl.json
+++ b/motioneye/static/js/motioneye.pl.json
@@ -1,164 +1,176 @@
-{"":{"language":"pl","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "znaki specjalne w haśle nie są dozwolone"
-,"Ĉi tiu kampo estas deviga": "To pole jest wymagane"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "znaki specjalne nie są dozwolone w nazwie kamery"
-,"valoro devas esti multoblo de 8": "wartość musi być wielokrotnością 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "znaki specjalne nie są dozwolone w nazwie katalogu głównego"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "nie można tworzyć plików bezpośrednio w katalogu głównym systemu"
-,"enigu validan retpoŝtadreson": "wprowadź prawidłowy adres e-mail"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "wprowadź listę prawidłowych adresów e-mail oddzielonych przecinkami"
-,"specialaj signoj ne rajtas en dosiernomo": "znaki specjalne nie są dozwolone w nazwie pliku"
-,"enigu validan valoron": "wprowadź prawidłową wartość"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Spowoduje to rekurencyjne usunięcie wszystkich plików obecnych w katalogu chmury \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "”, nie tylko przesłanych przez motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "To spowoduje rekurencyjne usunięcie wszystkich starych plików multimedialnych znajdujących się w katalogu \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", nie tylko tych stworzonych przez motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Nie można edytować maski bez prawidłowego obrazu z kamery!"
-,"Propra": "Niestandardowy"
-,"Propra dosierindiko": "Ścieżka niestandardowa"
-,"Retan kunlokon": "Udział sieciowy"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Twoja przeglądarka nie obsługuje tej funkcji!"
-,"Apliki": "Zastosuj"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Upewnij się, że wszystkie opcje konfiguracji są prawidłowe!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "To spowoduje ponowne uruchomienie systemu. Kontynuować?"
-,"Vere fermiti sistemon?": "Na pewno wyłączyć?"
-,"Malŝaltita": "Wyłączony"
-,"Ĉu vere restartigi ?": "Na pewno zrestartować?"
-,"La sistemo rekomencis!": "System został zrestartowany!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Najpierw potwierdź modyfikację ustawień!"
-,"Neniu fotilo por forigi!": "Brak kamery do usunięcia!"
-,"Ĉu forigi kameraon ": "Usuń kamerę "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye jest aktualne (aktualna wersja: "
-,"Nova versio havebla: ": "Dostępna jest nowa wersja: "
-,". Ĝisdatigi?": ". Zaktualizować?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye zostało pomyślnie zaktualizowane!"
-,"Ĝisdatigo malsukcesis!": "Aktualizacja nieudana!"
-,"La ĝisdatiga procezo malsukcesis!": "Proces aktualizacji nie powiódł się!"
-,"Rezerva dosiero": "Plik kopii zapasowej"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Plik kopii zapasowej, który wcześniej pobrałeś."
-,"Restaŭrigi Agordon": "Przywróć konfigurację"
-,"Restaŭriganta agordon ...": "Przywracanie konfiguracji..."
-,"La agordo restaŭrigis!": "Konfiguracja została przywrócona!"
-,"Malsukcesis restaŭri la agordon!": "Nie udało się przywrócić konfiguracji!"
-,"Aliri la alŝutan servon malsukcesis: ": "Dostęp do usługi przesyłania nie powiódł się: "
-,"Aliri la alŝutan servon sukcesis!": "Uzyskanie dostępu do usługi przesyłania powiodło się!"
-,"Sciiga retpoŝto fiaskis:": "Nie udało się wysłać e-maila z powiadomieniem:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Upewnij się, że wszystkie opcje konfiguracji są prawidłowe!"
-,"Sciiga Telegramo fiaskis:": "Nie udało się wysłać wiadomości Telegram z powiadomieniem:"
-,"Sciiga Telegramo sukcesis!": "Powiadomienie Telegram powiodło się!"
-,"Aliro al retdividado fiaskis: ": "Dostęp do udziału sieciowego nie powiódł się: "
-,"Aliro al retdividado sukcesis!": "Uzyskanie dostępu do udziału sieciowego powiodło się!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Na pewno usunąć ten plik?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Na pewno usunąć wszystkie zdjęcia z grupy \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Na pewno usunąć wszystkie filmy z \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Czy na pewno usunąć wszystkie niezgrupowane zdjęcia?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Czy na pewno usunąć wszystkie niezgrupowane filmy?"
-,"aldonadi kameraon...": "dodaj kamerę..."
-,"Uzantnomo": "Użytkownik"
-,"Pasvorto": "Hasło"
-,"Memoru min": "Zapamiętaj mnie"
-,"Ensaluti": "Login"
-,"Nuligi": "Anuluj"
-,"Vi abortis la filmeton.": "Przerwałeś odtwarzanie wideo."
-,"Reto eraro okazis.": "Wystąpił błąd sieciowy."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Błąd dekodowania multimediów lub nieobsługiwane funkcje multimediów."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format nieobsługiwany lub niedostępny/nieodpowiedni do odtwarzania."
-,"Nekonata eraro okazis.": "Wystąpił nieznany błąd."
-,"Eraro : ": "Błąd: "
-,"antaŭa bildo": "poprzednie zdjęcie"
-,"ludi": "odtwórz"
-,"ludi * 5 kaj enĉenigi": "Odtwarzaj 5 razy szybciej"
-,"sekva bildo": "następne zdjęcie"
-,"Fermi": "Zamknij"
-,"Elŝuti": "Pobierz"
-,"Forigi": "Usuń"
-,"Kamerao tipo": "Typ kamery"
-,"Loka V4L2-kamerao": "Lokalna kamera V4L2"
-,"Loka MMAL-kamerao": "Lokalna kamera MMAL"
-,"Reta kamerao": "Kamera sieciowa"
-,"Fora motionEye kamerao": "Zdalna kamera motionEye"
-,"Simpla MJPEG-kamerao": "Prosta kamera MJPEG"
-,"la speco de kamerao, kiun vi volas aldoni": "typ kamery, którą chcesz dodać"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "adres URL kamery (np. http://example.com:8080/cam/)"
-,"uzantnomo...": "username ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "nazwa użytkownika dla adresu URL, jeśli to konieczne (np. admin)"
-,"pasvorto...": "hasło..."
-,"la pasvorto por la URL, se bezonata": "hasło do adresu URL, jeśli to konieczne"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kamerę, którą chcesz dodać"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Zdalne kamery motionEye to kamery zainstalowane za innym serwerem motionEye. Dodanie ich tutaj umożliwi Ci zdalne przeglądanie i zarządzanie nimi."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Kamery sieciowe (lub kamery IP) to urządzenia, które natywnie przesyłają strumieniowo wideo RTSP/RTMP lub MJPEG lub zwykłe obrazy JPEG. Zapoznaj się z instrukcją obsługi urządzenia, aby znaleźć prawidłowy adres URL RTSP, RTMP, MJPEG lub JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokalne kamery MMAL to urządzenia podłączone bezpośrednio do systemu motionEye. Są to zwykle kamery dedykowane do konkretnych płyt SBC."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Dodanie urządzenia jako zwykłej kamery MJPEG zamiast jako kamery sieciowej poprawi liczbę klatek na sekundę, ale nie będzie dla niego dostępne wykrywanie ruchu, robienie zdjęć ani nagrywanie filmów. Kamera musi być dostępna zarówno dla serwera, jak i przeglądarki. Ten typ kamery nie jest zgodny z Internet Explorerem."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokalne kamery V4L2 to kamery, które są podłączone bezpośrednio do systemu motionEye, zwykle przez USB."
-,"Aldonadi kameraon...": "Dodaj kamerę..."
-,"Grupo": "Grupa"
-,"Inkluzivi foton prenitan ĉiun": "Dołącz zdjęcie zrobione co"
-,"sekundo": "sekundę"
-,"5 sekundoj": "5 sekund"
-,"10 sekundoj": "10 sekund"
-,"30 sekundoj": "30 sekund"
-,"minuto": "minutę"
-,"5 minutoj": "5 minut"
-,"10 minutoj": "10 minut"
-,"30 minutoj": "30 minut"
-,"horo": "godzinę"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "wybierz odstęp czasu między dwoma wybranymi zdjęciami."
-,"Filmo framfrekvenco": "Liczba klatek na sekundę filmu"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "wybierz szybkość odtwarzania poklatkowego."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Biorąc pod uwagę dużą liczbę zdjęć, utworzenie filmu poklatkowego może chwilę potrwać!"
-,"Krei akselita video": "Utwórz film poklatkowy"
-,"Filmo kreanta en progreso...": "Tworzenie filmu poklatkowego..."
-,"Zipitaj": "Spakowana"
-,"Akselita video": "Film poklatkowy"
-,"Forigi ĉiujn": "Usuń wszystko"
-,"Bildoj prenitaj de ": "Zdjęcia wykonane przez "
-,"Filmoj registritaj de ": "Filmy nagrane przez "
-,"montru ĉi tiun fotilon plenekranan": "Pokaż tę kamerę na pełnym ekranie"
-,"montri ĉiujn fotilojn": "pokaż wszystkie kamery"
-,"montru nur ĉi tiun fotilon": "pokaż tylko tą kamerę"
-,"malfermaj bildoj retumilo": "otwórz przeglądarkę zdjęć"
-,"malferma videoj retumilo": "otwórz przeglądarkę filmów"
-,"agordi ĉi tiun kameraon": "skonfiguruj tą kamerę"
-,"preni instantaron": "zrób zdjęcie"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Nie skonfigurowałeś jeszcze żadnej kamery. Kliknij tutaj, aby jedną dodać..."
-,"enigu pozitivan nombron": "wprowadź liczbę dodatnią"
-,"enigu pozitivan entjeran nombron": "wprowadź dodatnią liczbę całkowitą"
-,"enigu nombron": "wprowadź numer"
-,"enigu entjeran nombron": "wprowadź liczbę całkowitą"
-," inter ": " pomiędzy "
-," kaj ": " i "
-," pli ol ": " więcej niż "
-," malpli ol ": " mniej niż "
-,"enigu validan tempon en la sekva formato: HH:MM": "wprowadź prawidłowy czas w następującym formacie: GG:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "wprowadź prawidłowy adres URL (np. http://example.com:8080/cams/)"
-,"fermi": "zamknij"
-,"Ne": "Nie"
-,"Jes": "Tak"
-,"Bone": "OK"
-,"Auto Exposure": "Ekspozycja auto"
-,"Backlight Compensation": "Kompensacja podświetlenia"
-,"Brightness": "Jasność"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Ekspozycja bezwzględna"
-,"Exposure Auto": "Automatyczna ekspozycja"
-,"Exposure Auto Priority": "Automatyczny priorytet ekspozycji"
-,"Exposure Time Absolute": "Bezwzględny czas ekspozycji"
-,"Focus Absolute": "Ostrość bezwzględna"
-,"Focus Auto": "Automatyczna ostrość"
-,"Gain": "Wzmocnienie"
-,"Gamma": "Gamma"
-,"Hue": "Odcień"
-,"Led1 Mode": "Tryb Led1"
-,"Led1 Frequency": "Częstotliwość Led1"
-,"Pan Absolute": "Panorama bezwzględna"
-,"Power Line Frequency": "Częstotliwość linii energetycznej"
-,"Saturation": "Nasycenie"
-,"Sharpness": "Ostrość"
-,"Tilt Absolute": "Nachylenie bezwzględne"
-,"White Balance Temperature": "Temperatura barwowa balansu bieli"
-,"White Balance Temperature Auto": "Automatyczna temperatura barwowa balansu bieli"
-,"Zoom Absolute": "Zbliżenie bezwzględne"
+{
+  "": {
+    "language": "pl",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "znaki specjalne w haśle nie są dozwolone",
+  "Ĉi tiu kampo estas deviga": "To pole jest wymagane",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "znaki specjalne nie są dozwolone w nazwie kamery",
+  "valoro devas esti multoblo de 8": "wartość musi być wielokrotnością 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "znaki specjalne nie są dozwolone w nazwie katalogu głównego",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "nie można tworzyć plików bezpośrednio w katalogu głównym systemu",
+  "enigu validan retpoŝtadreson": "wprowadź prawidłowy adres e-mail",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "wprowadź listę prawidłowych adresów e-mail oddzielonych przecinkami",
+  "specialaj signoj ne rajtas en dosiernomo": "znaki specjalne nie są dozwolone w nazwie pliku",
+  "enigu validan valoron": "wprowadź prawidłową wartość",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Spowoduje to rekurencyjne usunięcie wszystkich plików obecnych w katalogu chmury \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "”, nie tylko przesłanych przez motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "To spowoduje rekurencyjne usunięcie wszystkich starych plików multimedialnych znajdujących się w katalogu \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", nie tylko tych stworzonych przez motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Nie można edytować maski bez prawidłowego obrazu z kamery!",
+  "Propra": "Niestandardowy",
+  "Propra dosierindiko": "Ścieżka niestandardowa",
+  "Retan kunlokon": "Udział sieciowy",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Twoja przeglądarka nie obsługuje tej funkcji!",
+  "Apliki": "Zastosuj",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Upewnij się, że wszystkie opcje konfiguracji są prawidłowe!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "To spowoduje ponowne uruchomienie systemu. Kontynuować?",
+  "Vere fermiti sistemon?": "Na pewno wyłączyć?",
+  "Malŝaltita": "Wyłączony",
+  "Ĉu vere restartigi ?": "Na pewno zrestartować?",
+  "La sistemo rekomencis!": "System został zrestartowany!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Najpierw potwierdź modyfikację ustawień!",
+  "Neniu fotilo por forigi!": "Brak kamery do usunięcia!",
+  "Ĉu forigi kameraon ": "Usuń kamerę ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye jest aktualne (aktualna wersja: ",
+  "Nova versio havebla: ": "Dostępna jest nowa wersja: ",
+  ". Ĝisdatigi?": ". Zaktualizować?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye zostało pomyślnie zaktualizowane!",
+  "Ĝisdatigo malsukcesis!": "Aktualizacja nieudana!",
+  "La ĝisdatiga procezo malsukcesis!": "Proces aktualizacji nie powiódł się!",
+  "Rezerva dosiero": "Plik kopii zapasowej",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Plik kopii zapasowej, który wcześniej pobrałeś.",
+  "Restaŭrigi Agordon": "Przywróć konfigurację",
+  "Restaŭriganta agordon ...": "Przywracanie konfiguracji...",
+  "La agordo restaŭrigis!": "Konfiguracja została przywrócona!",
+  "Malsukcesis restaŭri la agordon!": "Nie udało się przywrócić konfiguracji!",
+  "Aliri la alŝutan servon malsukcesis: ": "Dostęp do usługi przesyłania nie powiódł się: ",
+  "Aliri la alŝutan servon sukcesis!": "Uzyskanie dostępu do usługi przesyłania powiodło się!",
+  "Sciiga retpoŝto fiaskis:": "Nie udało się wysłać e-maila z powiadomieniem:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Upewnij się, że wszystkie opcje konfiguracji są prawidłowe!",
+  "Sciiga Telegramo fiaskis:": "Nie udało się wysłać wiadomości Telegram z powiadomieniem:",
+  "Sciiga Telegramo sukcesis!": "Powiadomienie Telegram powiodło się!",
+  "Aliro al retdividado fiaskis: ": "Dostęp do udziału sieciowego nie powiódł się: ",
+  "Aliro al retdividado sukcesis!": "Uzyskanie dostępu do udziału sieciowego powiodło się!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Na pewno usunąć ten plik?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Na pewno usunąć wszystkie zdjęcia z grupy \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Na pewno usunąć wszystkie filmy z \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Czy na pewno usunąć wszystkie niezgrupowane zdjęcia?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Czy na pewno usunąć wszystkie niezgrupowane filmy?",
+  "aldonadi kameraon...": "dodaj kamerę...",
+  "Uzantnomo": "Użytkownik",
+  "Pasvorto": "Hasło",
+  "Memoru min": "Zapamiętaj mnie",
+  "Ensaluti": "Login",
+  "Nuligi": "Anuluj",
+  "Vi abortis la filmeton.": "Przerwałeś odtwarzanie wideo.",
+  "Reto eraro okazis.": "Wystąpił błąd sieciowy.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Błąd dekodowania multimediów lub nieobsługiwane funkcje multimediów.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format nieobsługiwany lub niedostępny/nieodpowiedni do odtwarzania.",
+  "Nekonata eraro okazis.": "Wystąpił nieznany błąd.",
+  "Eraro : ": "Błąd: ",
+  "antaŭa bildo": "poprzednie zdjęcie",
+  "ludi": "odtwórz",
+  "ludi * 5 kaj enĉenigi": "Odtwarzaj 5 razy szybciej",
+  "sekva bildo": "następne zdjęcie",
+  "Fermi": "Zamknij",
+  "Elŝuti": "Pobierz",
+  "Forigi": "Usuń",
+  "Kamerao tipo": "Typ kamery",
+  "Loka V4L2-kamerao": "Lokalna kamera V4L2",
+  "Loka MMAL-kamerao": "Lokalna kamera MMAL",
+  "Reta kamerao": "Kamera sieciowa",
+  "Fora motionEye kamerao": "Zdalna kamera motionEye",
+  "Simpla MJPEG-kamerao": "Prosta kamera MJPEG",
+  "la speco de kamerao, kiun vi volas aldoni": "typ kamery, którą chcesz dodać",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "adres URL kamery (np. http://example.com:8080/cam/)",
+  "uzantnomo...": "username ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "nazwa użytkownika dla adresu URL, jeśli to konieczne (np. admin)",
+  "pasvorto...": "hasło...",
+  "la pasvorto por la URL, se bezonata": "hasło do adresu URL, jeśli to konieczne",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kamerę, którą chcesz dodać",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Zdalne kamery motionEye to kamery zainstalowane za innym serwerem motionEye. Dodanie ich tutaj umożliwi Ci zdalne przeglądanie i zarządzanie nimi.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Kamery sieciowe (lub kamery IP) to urządzenia, które natywnie przesyłają strumieniowo wideo RTSP/RTMP lub MJPEG lub zwykłe obrazy JPEG. Zapoznaj się z instrukcją obsługi urządzenia, aby znaleźć prawidłowy adres URL RTSP, RTMP, MJPEG lub JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokalne kamery MMAL to urządzenia podłączone bezpośrednio do systemu motionEye. Są to zwykle kamery dedykowane do konkretnych płyt SBC.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Dodanie urządzenia jako zwykłej kamery MJPEG zamiast jako kamery sieciowej poprawi liczbę klatek na sekundę, ale nie będzie dla niego dostępne wykrywanie ruchu, robienie zdjęć ani nagrywanie filmów. Kamera musi być dostępna zarówno dla serwera, jak i przeglądarki. Ten typ kamery nie jest zgodny z Internet Explorerem.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokalne kamery V4L2 to kamery, które są podłączone bezpośrednio do systemu motionEye, zwykle przez USB.",
+  "Aldonadi kameraon...": "Dodaj kamerę...",
+  "Grupo": "Grupa",
+  "Inkluzivi foton prenitan ĉiun": "Dołącz zdjęcie zrobione co",
+  "sekundo": "sekundę",
+  "5 sekundoj": "5 sekund",
+  "10 sekundoj": "10 sekund",
+  "30 sekundoj": "30 sekund",
+  "minuto": "minutę",
+  "5 minutoj": "5 minut",
+  "10 minutoj": "10 minut",
+  "30 minutoj": "30 minut",
+  "horo": "godzinę",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "wybierz odstęp czasu między dwoma wybranymi zdjęciami.",
+  "Filmo framfrekvenco": "Liczba klatek na sekundę filmu",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "wybierz szybkość odtwarzania poklatkowego.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Biorąc pod uwagę dużą liczbę zdjęć, utworzenie filmu poklatkowego może chwilę potrwać!",
+  "Krei akselita video": "Utwórz film poklatkowy",
+  "Filmo kreanta en progreso...": "Tworzenie filmu poklatkowego...",
+  "Zipitaj": "Spakowana",
+  "Akselita video": "Film poklatkowy",
+  "Forigi ĉiujn": "Usuń wszystko",
+  "Bildoj prenitaj de ": "Zdjęcia wykonane przez ",
+  "Filmoj registritaj de ": "Filmy nagrane przez ",
+  "montru ĉi tiun fotilon plenekranan": "Pokaż tę kamerę na pełnym ekranie",
+  "montri ĉiujn fotilojn": "pokaż wszystkie kamery",
+  "montru nur ĉi tiun fotilon": "pokaż tylko tą kamerę",
+  "malfermaj bildoj retumilo": "otwórz przeglądarkę zdjęć",
+  "malferma videoj retumilo": "otwórz przeglądarkę filmów",
+  "agordi ĉi tiun kameraon": "skonfiguruj tą kamerę",
+  "preni instantaron": "zrób zdjęcie",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Nie skonfigurowałeś jeszcze żadnej kamery. Kliknij tutaj, aby jedną dodać...",
+  "enigu pozitivan nombron": "wprowadź liczbę dodatnią",
+  "enigu pozitivan entjeran nombron": "wprowadź dodatnią liczbę całkowitą",
+  "enigu nombron": "wprowadź numer",
+  "enigu entjeran nombron": "wprowadź liczbę całkowitą",
+  " inter ": " pomiędzy ",
+  " kaj ": " i ",
+  " pli ol ": " więcej niż ",
+  " malpli ol ": " mniej niż ",
+  "enigu validan tempon en la sekva formato: HH:MM": "wprowadź prawidłowy czas w następującym formacie: GG:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "wprowadź prawidłowy adres URL (np. http://example.com:8080/cams/)",
+  "fermi": "zamknij",
+  "Ne": "Nie",
+  "Jes": "Tak",
+  "Bone": "OK",
+  "Auto Exposure": "Ekspozycja auto",
+  "Backlight Compensation": "Kompensacja podświetlenia",
+  "Brightness": "Jasność",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Ekspozycja bezwzględna",
+  "Exposure Auto": "Automatyczna ekspozycja",
+  "Exposure Auto Priority": "Automatyczny priorytet ekspozycji",
+  "Exposure Time Absolute": "Bezwzględny czas ekspozycji",
+  "Focus Absolute": "Ostrość bezwzględna",
+  "Focus Auto": "Automatyczna ostrość",
+  "Gain": "Wzmocnienie",
+  "Gamma": "Gamma",
+  "Hue": "Odcień",
+  "Led1 Mode": "Tryb Led1",
+  "Led1 Frequency": "Częstotliwość Led1",
+  "Pan Absolute": "Panorama bezwzględna",
+  "Power Line Frequency": "Częstotliwość linii energetycznej",
+  "Saturation": "Nasycenie",
+  "Sharpness": "Ostrość",
+  "Tilt Absolute": "Nachylenie bezwzględne",
+  "White Balance Temperature": "Temperatura barwowa balansu bieli",
+  "White Balance Temperature Auto": "Automatyczna temperatura barwowa balansu bieli",
+  "Zoom Absolute": "Zbliżenie bezwzględne",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.pt.json
+++ b/motioneye/static/js/motioneye.pt.json
@@ -1,164 +1,176 @@
-{"":{"language":"pt","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "caracteres especiais não são permitidos na senha"
-,"Ĉi tiu kampo estas deviga": "Este campo é obrigatório"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "caracteres especiais não são permitidos no nome de câmera"
-,"valoro devas esti multoblo de 8": "o valor deve ser um múltiplo de 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "caracteres especiais não são permitidos no nome de pasta raiz"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "ficheiros não podem ser criados diretamente na raiz do seu sistema"
-,"enigu validan retpoŝtadreson": "insira um endereço de email válido"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "insira uma lista de endereços de email válidos separados por vírgula"
-,"specialaj signoj ne rajtas en dosiernomo": "caracteres especiais não são permitidos no nome do ficheiro"
-,"enigu validan valoron": "insira um valor válido"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Isto recursivamente excluirá todos os ficheiros da pasta na nuvem \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", não apenas aqueles enviados por motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Isto recursivamente excluirá todos os ficheiros de mídia velhos da pasta \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", não apenas aqueles criados por motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Não é possível editar a máscara sem uma imagem de câmera válida!"
-,"Propra": "Personalizado"
-,"Propra dosierindiko": "Nome de caminho personalizado"
-,"Retan kunlokon": "compartilhamento de rede"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Seu navegador não realiza este recurso!"
-,"Apliki": "Aplicar"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Verifique, se todas as opções de configuração são válidas!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Isso reiniciará o sistema. Continuar?"
-,"Vere fermiti sistemon?": "Deseja realmente desligar o sistema?"
-,"Malŝaltita": "Desligado"
-,"Ĉu vere restartigi ?": "Deseja realmente reiniciar agora?"
-,"La sistemo rekomencis!": "O sistema foi reiniciado!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Aplique primeiro as configurações modificadas!"
-,"Neniu fotilo por forigi!": "Nenhuma câmera para remover!"
-,"Ĉu forigi kameraon ": "Pode remover a câmera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "O motionEye está atualizado (versão atual: "
-,"Nova versio havebla: ": "Nova versão disponível: "
-,". Ĝisdatigi?": ". Atualizar?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye foi atualizado com sucesso!"
-,"Ĝisdatigo malsukcesis!": "Atualização malsucedida!"
-,"La ĝisdatiga procezo malsukcesis!": "O processo de atualização falhou!"
-,"Rezerva dosiero": "Arquivo de cópia de segurança"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "O arquivo de cópia de segurança que você baixou anteriormente."
-,"Restaŭrigi Agordon": "Restaurar configuração"
-,"Restaŭriganta agordon ...": "Restaurando configuração ..."
-,"La agordo restaŭrigis!": "A configuração foi restaurada!"
-,"Malsukcesis restaŭri la agordon!": "Restauração de configuração malsucedida!"
-,"Aliri la alŝutan servon malsukcesis: ": "O acesso ao serviço de upload falhou: "
-,"Aliri la alŝutan servon sukcesis!": "O acesso ao serviço de upload foi bem-sucedido!"
-,"Sciiga retpoŝto fiaskis:": "E-mail de notificação falhou:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Verifique, se todas as opções de configuração são válidas!"
-,"Sciiga Telegramo fiaskis:": "O telegrama de notificação falhou:"
-,"Sciiga Telegramo sukcesis!": "O telegrama de notificação foi bem sucedido!"
-,"Aliro al retdividado fiaskis: ": "O acesso à transmissão de rede falhou: "
-,"Aliro al retdividado sukcesis!": "O acesso ao compartilhamento de rede foi bem sucedido!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Deseja mesmo excluir este ficheiro?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Excluir realmente todas as imagens de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Remover realmente todos os vídeos de \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Deseja excluir todas as imagens não agrupadas?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Deseja excluir todos os filmes não agrupados?"
-,"aldonadi kameraon...": "adicionar câmera..."
-,"Uzantnomo": "Nome de usuário"
-,"Pasvorto": "Senha"
-,"Memoru min": "Lembra de mim"
-,"Ensaluti": "Entrar"
-,"Nuligi": "Cancelar"
-,"Vi abortis la filmeton.": "Você terminou o vídeo."
-,"Reto eraro okazis.": "Ocorreu um erro de rede."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Erro de decodificação ou função não progredida."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato não compatível ou inacessível/inadequado para reprodução."
-,"Nekonata eraro okazis.": "Ocorreu um erro desconhecido."
-,"Eraro : ": "Erro: "
-,"antaŭa bildo": "imagem anterior"
-,"ludi": "Reproduzir"
-,"ludi * 5 kaj enĉenigi": "Reproduzir 5 vezes mais rápido"
-,"sekva bildo": "próxima imagem"
-,"Fermi": "Fechar"
-,"Elŝuti": "Baixar"
-,"Forigi": "Excluir"
-,"Kamerao tipo": "Tipo de câmera"
-,"Loka V4L2-kamerao": "Câmera V4L2 local"
-,"Loka MMAL-kamerao": "Câmera MMAL local"
-,"Reta kamerao": "Câmera de Rede"
-,"Fora motionEye kamerao": "Câmera motionEye externa"
-,"Simpla MJPEG-kamerao": "Câmera MJPEG simples"
-,"la speco de kamerao, kiun vi volas aldoni": "o tipo de câmera, que você deseja adicionar"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://exemplo.pt:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "o URL da câmera (por exemplo, http://exemplo.pt:8080/cam/)"
-,"uzantnomo...": "nome de usuário ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "o nome de usuário para o URL, se necessário (p. ex.: admin)"
-,"pasvorto...": "senha..."
-,"la pasvorto por la URL, se bezonata": "a senha do URL, se necessário"
-,"Kamerao": "Camera"
-,"la kameraon, kiun vi volas aldoni": "a câmera que deseja adicionar"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Uma câmera motionEye externa é uma câmera instalada atrás de outro servidor MotionEye. Adicioná-las aqui, lhe permitirá a visualização e administração à distância."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "As câmeras de rede (ou câmeras IP) são dispositivos que transmitem nativamente vídeos RTSP/RTMP ou MJPEG, ou imagens JPEG simples. Consulte o manual do seu dispositivo para descobrir o URL de RTSP, RTMP, MJPEG ou JPEG correto."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "As câmeras MMAL locais são dispositivos conectados diretamente ao seu sistema motionEye. Geralmente, são câmeras específicas da placa(board)."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adicionar seu dispositivo como câmera MJPEG simples e não como uma câmera de rede, melhorará a imagem, mas a detecção de movimento, captura de imagem e gravação de filme não estarão disponíveis para essa mesma. A câmera deve estar acessível ao seu servidor e seu navegador. Este tipo de câmera não é compatível ao Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "As câmeras V4L2 locais são dispositivos de câmera conectados diretamente ao seu sistema motionEye, geralmente por USB."
-,"Aldonadi kameraon...": "Adicionar câmera ..."
-,"Grupo": "Grupo"
-,"Inkluzivi foton prenitan ĉiun": "Incluir uma foto tirada cada"
-,"sekundo": "segundo"
-,"5 sekundoj": "5 segundos"
-,"10 sekundoj": "10 segundos"
-,"30 sekundoj": "30 segundos"
-,"minuto": "minuto"
-,"5 minutoj": "5 minutos"
-,"10 minutoj": "10 minutos"
-,"30 minutoj": "30 minutos"
-,"horo": "hora"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Escolha o espaço de tempo entre duas fotos tiradas."
-,"Filmo framfrekvenco": "Frequência de imagens do filme"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Escolha a velocidade de reprodução do vídeo de timelapse."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Considerando o grande número de imagens, a criação do seu vídeo pode levar algum tempo!"
-,"Krei akselita video": "Crie um vídeo timelapse"
-,"Filmo kreanta en progreso...": "Criando video timelapse..."
-,"Zipitaj": "Zipado"
-,"Akselita video": "Vídeo Timelapse"
-,"Forigi ĉiujn": "Excluir todos"
-,"Bildoj prenitaj de ": "Fotos tiradas por "
-,"Filmoj registritaj de ": "Filmes gravados por "
-,"montru ĉi tiun fotilon plenekranan": "Mostrar esta câmera em ecrã inteiro"
-,"montri ĉiujn fotilojn": "Mostrar todas as câmeras"
-,"montru nur ĉi tiun fotilon": "Mostrar apenas esta câmera"
-,"malfermaj bildoj retumilo": "Abrir navegador de imagens"
-,"malferma videoj retumilo": "Abrir navegador de vídeos"
-,"agordi ĉi tiun kameraon": "Configurar esta câmera"
-,"preni instantaron": "Tirar uma foto"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Você ainda não configurou nenhuma câmera. Clique aqui para adicionar uma ..."
-,"enigu pozitivan nombron": "insira um número positivo"
-,"enigu pozitivan entjeran nombron": "insira um número inteiro positivo"
-,"enigu nombron": "insira um número"
-,"enigu entjeran nombron": "insira um número inteiro"
-," inter ": " entre "
-," kaj ": " e "
-," pli ol ": " mais que "
-," malpli ol ": " menos que "
-,"enigu validan tempon en la sekva formato: HH:MM": "insira um horario válido no seguinte formato: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "insira um URL válido (por exemplo, http://exemplo.pt:8080/cams/)"
-,"fermi": "fechar"
-,"Ne": "Não"
-,"Jes": "Sim"
-,"Bone": "Tá bem"
-,"Auto Exposure": "Auto Exposure"
-,"Backlight Compensation": "Compensação de Luz de Fundo"
-,"Brightness": "Brilho"
-,"Contrast": "Contraste"
-,"Exposure Absolute": "Exposição absoluta"
-,"Exposure Auto": "Exposição automática"
-,"Exposure Auto Priority": "Exposure Auto Priority"
-,"Exposure Time Absolute": "Tempo de exposição absoluta"
-,"Focus Absolute": "Focus absoluto"
-,"Focus Auto": "Focus automático"
-,"Gain": "Gain"
-,"Gamma": "Gamma"
-,"Hue": "Hue"
-,"Led1 Mode": "Modo LED1"
-,"Led1 Frequency": "Frequência LED1"
-,"Pan Absolute": "Pan Absoluto"
-,"Power Line Frequency": "Frequência da linha de energia"
-,"Saturation": "Saturação"
-,"Sharpness": "Nitidez"
-,"Tilt Absolute": "Inclinação absoluta"
-,"White Balance Temperature": "Temperatura do equilíbrio de branco"
-,"White Balance Temperature Auto": "Temperatura de equilíbrio de branco Automatica"
-,"Zoom Absolute": "Zoom absoluto"
+{
+  "": {
+    "language": "pt",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "caracteres especiais não são permitidos na senha",
+  "Ĉi tiu kampo estas deviga": "Este campo é obrigatório",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "caracteres especiais não são permitidos no nome de câmera",
+  "valoro devas esti multoblo de 8": "o valor deve ser um múltiplo de 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "caracteres especiais não são permitidos no nome de pasta raiz",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "ficheiros não podem ser criados diretamente na raiz do seu sistema",
+  "enigu validan retpoŝtadreson": "insira um endereço de email válido",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "insira uma lista de endereços de email válidos separados por vírgula",
+  "specialaj signoj ne rajtas en dosiernomo": "caracteres especiais não são permitidos no nome do ficheiro",
+  "enigu validan valoron": "insira um valor válido",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Isto recursivamente excluirá todos os ficheiros da pasta na nuvem \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", não apenas aqueles enviados por motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Isto recursivamente excluirá todos os ficheiros de mídia velhos da pasta \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", não apenas aqueles criados por motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Não é possível editar a máscara sem uma imagem de câmera válida!",
+  "Propra": "Personalizado",
+  "Propra dosierindiko": "Nome de caminho personalizado",
+  "Retan kunlokon": "compartilhamento de rede",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Seu navegador não realiza este recurso!",
+  "Apliki": "Aplicar",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Verifique, se todas as opções de configuração são válidas!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Isso reiniciará o sistema. Continuar?",
+  "Vere fermiti sistemon?": "Deseja realmente desligar o sistema?",
+  "Malŝaltita": "Desligado",
+  "Ĉu vere restartigi ?": "Deseja realmente reiniciar agora?",
+  "La sistemo rekomencis!": "O sistema foi reiniciado!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Aplique primeiro as configurações modificadas!",
+  "Neniu fotilo por forigi!": "Nenhuma câmera para remover!",
+  "Ĉu forigi kameraon ": "Pode remover a câmera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "O motionEye está atualizado (versão atual: ",
+  "Nova versio havebla: ": "Nova versão disponível: ",
+  ". Ĝisdatigi?": ". Atualizar?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye foi atualizado com sucesso!",
+  "Ĝisdatigo malsukcesis!": "Atualização malsucedida!",
+  "La ĝisdatiga procezo malsukcesis!": "O processo de atualização falhou!",
+  "Rezerva dosiero": "Arquivo de cópia de segurança",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "O arquivo de cópia de segurança que você baixou anteriormente.",
+  "Restaŭrigi Agordon": "Restaurar configuração",
+  "Restaŭriganta agordon ...": "Restaurando configuração ...",
+  "La agordo restaŭrigis!": "A configuração foi restaurada!",
+  "Malsukcesis restaŭri la agordon!": "Restauração de configuração malsucedida!",
+  "Aliri la alŝutan servon malsukcesis: ": "O acesso ao serviço de upload falhou: ",
+  "Aliri la alŝutan servon sukcesis!": "O acesso ao serviço de upload foi bem-sucedido!",
+  "Sciiga retpoŝto fiaskis:": "E-mail de notificação falhou:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Verifique, se todas as opções de configuração são válidas!",
+  "Sciiga Telegramo fiaskis:": "O telegrama de notificação falhou:",
+  "Sciiga Telegramo sukcesis!": "O telegrama de notificação foi bem sucedido!",
+  "Aliro al retdividado fiaskis: ": "O acesso à transmissão de rede falhou: ",
+  "Aliro al retdividado sukcesis!": "O acesso ao compartilhamento de rede foi bem sucedido!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Deseja mesmo excluir este ficheiro?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Excluir realmente todas as imagens de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Remover realmente todos os vídeos de \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Deseja excluir todas as imagens não agrupadas?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Deseja excluir todos os filmes não agrupados?",
+  "aldonadi kameraon...": "adicionar câmera...",
+  "Uzantnomo": "Nome de usuário",
+  "Pasvorto": "Senha",
+  "Memoru min": "Lembra de mim",
+  "Ensaluti": "Entrar",
+  "Nuligi": "Cancelar",
+  "Vi abortis la filmeton.": "Você terminou o vídeo.",
+  "Reto eraro okazis.": "Ocorreu um erro de rede.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Erro de decodificação ou função não progredida.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formato não compatível ou inacessível/inadequado para reprodução.",
+  "Nekonata eraro okazis.": "Ocorreu um erro desconhecido.",
+  "Eraro : ": "Erro: ",
+  "antaŭa bildo": "imagem anterior",
+  "ludi": "Reproduzir",
+  "ludi * 5 kaj enĉenigi": "Reproduzir 5 vezes mais rápido",
+  "sekva bildo": "próxima imagem",
+  "Fermi": "Fechar",
+  "Elŝuti": "Baixar",
+  "Forigi": "Excluir",
+  "Kamerao tipo": "Tipo de câmera",
+  "Loka V4L2-kamerao": "Câmera V4L2 local",
+  "Loka MMAL-kamerao": "Câmera MMAL local",
+  "Reta kamerao": "Câmera de Rede",
+  "Fora motionEye kamerao": "Câmera motionEye externa",
+  "Simpla MJPEG-kamerao": "Câmera MJPEG simples",
+  "la speco de kamerao, kiun vi volas aldoni": "o tipo de câmera, que você deseja adicionar",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://exemplo.pt:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "o URL da câmera (por exemplo, http://exemplo.pt:8080/cam/)",
+  "uzantnomo...": "nome de usuário ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "o nome de usuário para o URL, se necessário (p. ex.: admin)",
+  "pasvorto...": "senha...",
+  "la pasvorto por la URL, se bezonata": "a senha do URL, se necessário",
+  "Kamerao": "Camera",
+  "la kameraon, kiun vi volas aldoni": "a câmera que deseja adicionar",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Uma câmera motionEye externa é uma câmera instalada atrás de outro servidor MotionEye. Adicioná-las aqui, lhe permitirá a visualização e administração à distância.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "As câmeras de rede (ou câmeras IP) são dispositivos que transmitem nativamente vídeos RTSP/RTMP ou MJPEG, ou imagens JPEG simples. Consulte o manual do seu dispositivo para descobrir o URL de RTSP, RTMP, MJPEG ou JPEG correto.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "As câmeras MMAL locais são dispositivos conectados diretamente ao seu sistema motionEye. Geralmente, são câmeras específicas da placa(board).",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adicionar seu dispositivo como câmera MJPEG simples e não como uma câmera de rede, melhorará a imagem, mas a detecção de movimento, captura de imagem e gravação de filme não estarão disponíveis para essa mesma. A câmera deve estar acessível ao seu servidor e seu navegador. Este tipo de câmera não é compatível ao Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "As câmeras V4L2 locais são dispositivos de câmera conectados diretamente ao seu sistema motionEye, geralmente por USB.",
+  "Aldonadi kameraon...": "Adicionar câmera ...",
+  "Grupo": "Grupo",
+  "Inkluzivi foton prenitan ĉiun": "Incluir uma foto tirada cada",
+  "sekundo": "segundo",
+  "5 sekundoj": "5 segundos",
+  "10 sekundoj": "10 segundos",
+  "30 sekundoj": "30 segundos",
+  "minuto": "minuto",
+  "5 minutoj": "5 minutos",
+  "10 minutoj": "10 minutos",
+  "30 minutoj": "30 minutos",
+  "horo": "hora",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Escolha o espaço de tempo entre duas fotos tiradas.",
+  "Filmo framfrekvenco": "Frequência de imagens do filme",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Escolha a velocidade de reprodução do vídeo de timelapse.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Considerando o grande número de imagens, a criação do seu vídeo pode levar algum tempo!",
+  "Krei akselita video": "Crie um vídeo timelapse",
+  "Filmo kreanta en progreso...": "Criando video timelapse...",
+  "Zipitaj": "Zipado",
+  "Akselita video": "Vídeo Timelapse",
+  "Forigi ĉiujn": "Excluir todos",
+  "Bildoj prenitaj de ": "Fotos tiradas por ",
+  "Filmoj registritaj de ": "Filmes gravados por ",
+  "montru ĉi tiun fotilon plenekranan": "Mostrar esta câmera em ecrã inteiro",
+  "montri ĉiujn fotilojn": "Mostrar todas as câmeras",
+  "montru nur ĉi tiun fotilon": "Mostrar apenas esta câmera",
+  "malfermaj bildoj retumilo": "Abrir navegador de imagens",
+  "malferma videoj retumilo": "Abrir navegador de vídeos",
+  "agordi ĉi tiun kameraon": "Configurar esta câmera",
+  "preni instantaron": "Tirar uma foto",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Você ainda não configurou nenhuma câmera. Clique aqui para adicionar uma ...",
+  "enigu pozitivan nombron": "insira um número positivo",
+  "enigu pozitivan entjeran nombron": "insira um número inteiro positivo",
+  "enigu nombron": "insira um número",
+  "enigu entjeran nombron": "insira um número inteiro",
+  " inter ": " entre ",
+  " kaj ": " e ",
+  " pli ol ": " mais que ",
+  " malpli ol ": " menos que ",
+  "enigu validan tempon en la sekva formato: HH:MM": "insira um horario válido no seguinte formato: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "insira um URL válido (por exemplo, http://exemplo.pt:8080/cams/)",
+  "fermi": "fechar",
+  "Ne": "Não",
+  "Jes": "Sim",
+  "Bone": "Tá bem",
+  "Auto Exposure": "Auto Exposure",
+  "Backlight Compensation": "Compensação de Luz de Fundo",
+  "Brightness": "Brilho",
+  "Contrast": "Contraste",
+  "Exposure Absolute": "Exposição absoluta",
+  "Exposure Auto": "Exposição automática",
+  "Exposure Auto Priority": "Exposure Auto Priority",
+  "Exposure Time Absolute": "Tempo de exposição absoluta",
+  "Focus Absolute": "Focus absoluto",
+  "Focus Auto": "Focus automático",
+  "Gain": "Gain",
+  "Gamma": "Gamma",
+  "Hue": "Hue",
+  "Led1 Mode": "Modo LED1",
+  "Led1 Frequency": "Frequência LED1",
+  "Pan Absolute": "Pan Absoluto",
+  "Power Line Frequency": "Frequência da linha de energia",
+  "Saturation": "Saturação",
+  "Sharpness": "Nitidez",
+  "Tilt Absolute": "Inclinação absoluta",
+  "White Balance Temperature": "Temperatura do equilíbrio de branco",
+  "White Balance Temperature Auto": "Temperatura de equilíbrio de branco Automatica",
+  "Zoom Absolute": "Zoom absoluto",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ro.json
+++ b/motioneye/static/js/motioneye.ro.json
@@ -1,164 +1,176 @@
-{"":{"language":"ro","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "nu sunt permise caractere speciale pentru parolă"
-,"Ĉi tiu kampo estas deviga": "Acest câmp este obligatoriu"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "nu sunt permise caractere speciale pentru numele camerei"
-,"valoro devas esti multoblo de 8": "valoarea trebuie să fie un multiplu de 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "nu sunt permise caractere speciale pentru numele căilor root"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "fișierele nu pot fi create direct la root pentru sistemul dumneavoastră"
-,"enigu validan retpoŝtadreson": "introduceți o adresă de email validă"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "introduceți o listă de adrese de e-mail valide, separate prin virgulă"
-,"specialaj signoj ne rajtas en dosiernomo": "nu sunt permise caracterele speciale pentru numele fișierului"
-,"enigu validan valoron": "introduceți o valoare validă"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Aceasta va șterge recursiv toate fișierele din directorul cloud \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", nu doar cele încărcate de motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Aceasta va șterge recursiv toate fișierele media vechi din directorul \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", nu doar cele create de motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Masca nu poate fi editată fără o imagine validă a camerei!"
-,"Propra": "Personalizat"
-,"Propra dosierindiko": "Cale personalizată"
-,"Retan kunlokon": "Partajare în rețea"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Browserul dumneavoastră nu implementează această funcție!"
-,"Apliki": "Aplică"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Asigurați-vă că toate opțiunile de configurare sunt valide!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Aceasta va reporni sistemul. Continuare?"
-,"Vere fermiti sistemon?": "Chiar doriți să opriți sistemul?"
-,"Malŝaltita": "Oprit"
-,"Ĉu vere restartigi ?": "Chiar doriți să reporniți?"
-,"La sistemo rekomencis!": "Sistemul a fost repornit!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Vă rugăm să aplicați mai întâi setările modificate!"
-,"Neniu fotilo por forigi!": "Nicio cameră de eliminat!"
-,"Ĉu forigi kameraon ": "Eliminați camera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye este actualizat (versiunea curentă: "
-,"Nova versio havebla: ": "Versiune nouă disponibilă: "
-,". Ĝisdatigi?": ". Actualizați?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye a fost actualizat cu succes!"
-,"Ĝisdatigo malsukcesis!": "Actualizarea a eșuat!"
-,"La ĝisdatiga procezo malsukcesis!": "Procesul de actualizare a eșuat!"
-,"Rezerva dosiero": "Fișierul de configurare"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "fișierul de configurare descărcat anterior."
-,"Restaŭrigi Agordon": "Restaurați configurația"
-,"Restaŭriganta agordon ...": "Se restabilește configurația..."
-,"La agordo restaŭrigis!": "Configurația a fost restabilită!"
-,"Malsukcesis restaŭri la agordon!": "Restaurarea configurației a eșuat!"
-,"Aliri la alŝutan servon malsukcesis: ": "Accesul la serviciul de încărcare a eșuat: "
-,"Aliri la alŝutan servon sukcesis!": "Serviciul de încărcare a fost accesat cu succes!"
-,"Sciiga retpoŝto fiaskis:": "E-mailul de notificare a eșuat:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Asigurați-vă că toate opțiunile de configurare sunt valide!"
-,"Sciiga Telegramo fiaskis:": "Notificarea Telegram a eșuat:"
-,"Sciiga Telegramo sukcesis!": "Notificarea Telegram a avut succes!"
-,"Aliro al retdividado fiaskis: ": "Accesul la partajarea rețelei a eșuat: "
-,"Aliro al retdividado sukcesis!": "Accesul la partajarea de rețea a avut succes!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Chiar doriți să ștergeți acest fișier?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Chiar doriți să ștergeți toate imaginile din „(grup)uri %”?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Chiar doriți să ștergeți toate videoclipurile din „(grup)uri %”?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Chiar doriți să ștergeți toate imaginile negrupate?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Chiar doriți să ștergeți toate videoclipurile negrupate?"
-,"aldonadi kameraon...": "adaugă o cameră..."
-,"Uzantnomo": "Nume de utilizator"
-,"Pasvorto": "Parola"
-,"Memoru min": "Ține-mă minte"
-,"Ensaluti": "Autentificare"
-,"Nuligi": "Renunțare"
-,"Vi abortis la filmeton.": "Ai renunțat la videoclip."
-,"Reto eraro okazis.": "A apărut o eroare de rețea."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Eroare de decodare sau funcție neacceptată."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format neacceptat sau inaccesibil/nepotrivit pentru redare."
-,"Nekonata eraro okazis.": "A apărut o eroare necunoscută."
-,"Eraro : ": "Eroare: "
-,"antaŭa bildo": "imaginea anterioară"
-,"ludi": "Redă"
-,"ludi * 5 kaj enĉenigi": "Redă x5 în șir"
-,"sekva bildo": "imaginea următoare"
-,"Fermi": "Închide"
-,"Elŝuti": "Descarcă"
-,"Forigi": "Șterge"
-,"Kamerao tipo": "Tipul camerei"
-,"Loka V4L2-kamerao": "Cameră locală V4L2"
-,"Loka MMAL-kamerao": "Cameră locală MMAL"
-,"Reta kamerao": "Cameră de rețea"
-,"Fora motionEye kamerao": "Cameră motionEye la distanță"
-,"Simpla MJPEG-kamerao": "Cameră MJPEG simplă"
-,"la speco de kamerao, kiun vi volas aldoni": "Tipul camerei pe care doriți s-o adăugați."
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://exemplu.com:8765 /cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "adresa URL a camerei (ex. http://examplu.com:8080/cam/)"
-,"uzantnomo...": "nume de utilizator ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "Numele de utilizator pentru adresa URL, dacă este necesar (ex. admin)."
-,"pasvorto...": "parola ..."
-,"la pasvorto por la URL, se bezonata": "Parola pentru adresa URL, dacă este necesară."
-,"Kamerao": "Cameră"
-,"la kameraon, kiun vi volas aldoni": "Camera pe care doriți să o adăugați."
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Camerele motionEye la distanță sunt camere instalate în spatele altui server MotionEye. Adăugarea acestora aici vă va permite să le vizualizați și să le gestionați de la distanță."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Camerele de rețea (sau camerele IP) sunt dispozitive care transmit în mod nativ videoclipuri RTSP / RTMP sau MJPEG sau imagini JPEG simple. Verificați manualul dispozitivului pentru a afla adresa URL corectă RTSP, RTMP, MJPEG sau JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Camerele locale MMAL sunt dispozitive conectate direct la sistemul dumneavoastră motionEye. Acestea sunt de obicei camere specifice plăcii."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adăugarea dispozitivului ca o simplă cameră MJPEG în loc de ca o cameră de rețea va îmbunătăți imaginea, dar nu va fi disponibilă detectarea a mișcării, captarea imaginii sau înregistrarea videoclipurilor. Camera trebuie să fie accesibilă atât pentru server, cât și pentru browser. Acest tip de cameră nu este compatibil cu Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Camerele locale V4L2 sunt dispozitivele video conectate direct la sistemul dumneavoastră motionEye, de obicei prin USB."
-,"Aldonadi kameraon...": "Adaugă o cameră..."
-,"Grupo": "Grup"
-,"Inkluzivi foton prenitan ĉiun": "Includeți câte o fotografie făcută la fiecare"
-,"sekundo": "secundă"
-,"5 sekundoj": "5 secunde"
-,"10 sekundoj": "10 secunde"
-,"30 sekundoj": "30 de secunde"
-,"minuto": "minut"
-,"5 minutoj": "5 minute"
-,"10 minutoj": "10 minute"
-,"30 minutoj": "30 minute"
-,"horo": "oră"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Alegeți intervalul de timp dintre două imagini selectate."
-,"Filmo framfrekvenco": "Rata de cadre a videoclipurilor"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Alegeți cât de rapid doriți să fie redat videoclipul timelapse."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Având în vedere numărul mare de imagini, crearea videoclip-ului timelapse poate dura ceva timp!"
-,"Krei akselita video": "Creați videoclip timelapse"
-,"Filmo kreanta en progreso...": "Creare videoclip timelapse..."
-,"Zipitaj": "Arhivat"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Șterge tot"
-,"Bildoj prenitaj de ": "Imagini înregistrate de camera "
-,"Filmoj registritaj de ": "Videoclipuri înregistrate de camera "
-,"montru ĉi tiun fotilon plenekranan": "Afișează această cameră pe ecran complet"
-,"montri ĉiujn fotilojn": "Afișează toate camerele"
-,"montru nur ĉi tiun fotilon": "Afișează doar această cameră"
-,"malfermaj bildoj retumilo": "deschide browserul de imagini"
-,"malferma videoj retumilo": "deschide browserul de videoclipuri"
-,"agordi ĉi tiun kameraon": "configurați această cameră"
-,"preni instantaron": "efectuați o captură"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Nu ați configurat încă nicio cameră. Click aici pentru a adăuga una..."
-,"enigu pozitivan nombron": "introduceți un număr pozitiv"
-,"enigu pozitivan entjeran nombron": "introduceți un număr întreg pozitiv"
-,"enigu nombron": "introduceți un număr"
-,"enigu entjeran nombron": "introduceți un număr întreg"
-," inter ": " între "
-," kaj ": " și "
-," pli ol ": " mai mare decât "
-," malpli ol ": " mai mic decât "
-,"enigu validan tempon en la sekva formato: HH:MM": "introduceți o oră validă în următorul format: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "introduceți o adresă URL validă (ex. http://example.com:8080/cams/)"
-,"fermi": "Închide"
-,"Ne": "Nu"
-,"Jes": "Da"
-,"Bone": "OK"
-,"Auto Exposure": "Expunere automată"
-,"Backlight Compensation": "Compensare pentru lumina de fundal"
-,"Brightness": "Luminozitate"
-,"Contrast": "Contrast"
-,"Exposure Absolute": "Expunere absolută"
-,"Exposure Auto": "Expunere automată"
-,"Exposure Auto Priority": "Prioritate automată expunere"
-,"Exposure Time Absolute": "Timp de expunere absolut"
-,"Focus Absolute": "Focalizare Absolută"
-,"Focus Auto": "Focalizare automată"
-,"Gain": "Creștere"
-,"Gamma": "Gamma"
-,"Hue": "Nuanță"
-,"Led1 Mode": "Modul pt. Led1"
-,"Led1 Frequency": "Frecvența pt. Led1"
-,"Pan Absolute": "Pan absolut"
-,"Power Line Frequency": "Frecvența liniei de alimentare"
-,"Saturation": "Saturare"
-,"Sharpness": "Asprime"
-,"Tilt Absolute": "Înclinare absolută"
-,"White Balance Temperature": "Temperatura balansului de alb"
-,"White Balance Temperature Auto": "Temperatura balansului de alb automată"
-,"Zoom Absolute": "Zoom absolut"
+{
+  "": {
+    "language": "ro",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "nu sunt permise caractere speciale pentru parolă",
+  "Ĉi tiu kampo estas deviga": "Acest câmp este obligatoriu",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "nu sunt permise caractere speciale pentru numele camerei",
+  "valoro devas esti multoblo de 8": "valoarea trebuie să fie un multiplu de 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "nu sunt permise caractere speciale pentru numele căilor root",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "fișierele nu pot fi create direct la root pentru sistemul dumneavoastră",
+  "enigu validan retpoŝtadreson": "introduceți o adresă de email validă",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "introduceți o listă de adrese de e-mail valide, separate prin virgulă",
+  "specialaj signoj ne rajtas en dosiernomo": "nu sunt permise caracterele speciale pentru numele fișierului",
+  "enigu validan valoron": "introduceți o valoare validă",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Aceasta va șterge recursiv toate fișierele din directorul cloud \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", nu doar cele încărcate de motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Aceasta va șterge recursiv toate fișierele media vechi din directorul \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", nu doar cele create de motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Masca nu poate fi editată fără o imagine validă a camerei!",
+  "Propra": "Personalizat",
+  "Propra dosierindiko": "Cale personalizată",
+  "Retan kunlokon": "Partajare în rețea",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Browserul dumneavoastră nu implementează această funcție!",
+  "Apliki": "Aplică",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Asigurați-vă că toate opțiunile de configurare sunt valide!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Aceasta va reporni sistemul. Continuare?",
+  "Vere fermiti sistemon?": "Chiar doriți să opriți sistemul?",
+  "Malŝaltita": "Oprit",
+  "Ĉu vere restartigi ?": "Chiar doriți să reporniți?",
+  "La sistemo rekomencis!": "Sistemul a fost repornit!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Vă rugăm să aplicați mai întâi setările modificate!",
+  "Neniu fotilo por forigi!": "Nicio cameră de eliminat!",
+  "Ĉu forigi kameraon ": "Eliminați camera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye este actualizat (versiunea curentă: ",
+  "Nova versio havebla: ": "Versiune nouă disponibilă: ",
+  ". Ĝisdatigi?": ". Actualizați?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye a fost actualizat cu succes!",
+  "Ĝisdatigo malsukcesis!": "Actualizarea a eșuat!",
+  "La ĝisdatiga procezo malsukcesis!": "Procesul de actualizare a eșuat!",
+  "Rezerva dosiero": "Fișierul de configurare",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "fișierul de configurare descărcat anterior.",
+  "Restaŭrigi Agordon": "Restaurați configurația",
+  "Restaŭriganta agordon ...": "Se restabilește configurația...",
+  "La agordo restaŭrigis!": "Configurația a fost restabilită!",
+  "Malsukcesis restaŭri la agordon!": "Restaurarea configurației a eșuat!",
+  "Aliri la alŝutan servon malsukcesis: ": "Accesul la serviciul de încărcare a eșuat: ",
+  "Aliri la alŝutan servon sukcesis!": "Serviciul de încărcare a fost accesat cu succes!",
+  "Sciiga retpoŝto fiaskis:": "E-mailul de notificare a eșuat:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Asigurați-vă că toate opțiunile de configurare sunt valide!",
+  "Sciiga Telegramo fiaskis:": "Notificarea Telegram a eșuat:",
+  "Sciiga Telegramo sukcesis!": "Notificarea Telegram a avut succes!",
+  "Aliro al retdividado fiaskis: ": "Accesul la partajarea rețelei a eșuat: ",
+  "Aliro al retdividado sukcesis!": "Accesul la partajarea de rețea a avut succes!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Chiar doriți să ștergeți acest fișier?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Chiar doriți să ștergeți toate imaginile din „(grup)uri %”?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Chiar doriți să ștergeți toate videoclipurile din „(grup)uri %”?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Chiar doriți să ștergeți toate imaginile negrupate?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Chiar doriți să ștergeți toate videoclipurile negrupate?",
+  "aldonadi kameraon...": "adaugă o cameră...",
+  "Uzantnomo": "Nume de utilizator",
+  "Pasvorto": "Parola",
+  "Memoru min": "Ține-mă minte",
+  "Ensaluti": "Autentificare",
+  "Nuligi": "Renunțare",
+  "Vi abortis la filmeton.": "Ai renunțat la videoclip.",
+  "Reto eraro okazis.": "A apărut o eroare de rețea.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Eroare de decodare sau funcție neacceptată.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format neacceptat sau inaccesibil/nepotrivit pentru redare.",
+  "Nekonata eraro okazis.": "A apărut o eroare necunoscută.",
+  "Eraro : ": "Eroare: ",
+  "antaŭa bildo": "imaginea anterioară",
+  "ludi": "Redă",
+  "ludi * 5 kaj enĉenigi": "Redă x5 în șir",
+  "sekva bildo": "imaginea următoare",
+  "Fermi": "Închide",
+  "Elŝuti": "Descarcă",
+  "Forigi": "Șterge",
+  "Kamerao tipo": "Tipul camerei",
+  "Loka V4L2-kamerao": "Cameră locală V4L2",
+  "Loka MMAL-kamerao": "Cameră locală MMAL",
+  "Reta kamerao": "Cameră de rețea",
+  "Fora motionEye kamerao": "Cameră motionEye la distanță",
+  "Simpla MJPEG-kamerao": "Cameră MJPEG simplă",
+  "la speco de kamerao, kiun vi volas aldoni": "Tipul camerei pe care doriți s-o adăugați.",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://exemplu.com:8765 /cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "adresa URL a camerei (ex. http://examplu.com:8080/cam/)",
+  "uzantnomo...": "nume de utilizator ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "Numele de utilizator pentru adresa URL, dacă este necesar (ex. admin).",
+  "pasvorto...": "parola ...",
+  "la pasvorto por la URL, se bezonata": "Parola pentru adresa URL, dacă este necesară.",
+  "Kamerao": "Cameră",
+  "la kameraon, kiun vi volas aldoni": "Camera pe care doriți să o adăugați.",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Camerele motionEye la distanță sunt camere instalate în spatele altui server MotionEye. Adăugarea acestora aici vă va permite să le vizualizați și să le gestionați de la distanță.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Camerele de rețea (sau camerele IP) sunt dispozitive care transmit în mod nativ videoclipuri RTSP / RTMP sau MJPEG sau imagini JPEG simple. Verificați manualul dispozitivului pentru a afla adresa URL corectă RTSP, RTMP, MJPEG sau JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Camerele locale MMAL sunt dispozitive conectate direct la sistemul dumneavoastră motionEye. Acestea sunt de obicei camere specifice plăcii.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Adăugarea dispozitivului ca o simplă cameră MJPEG în loc de ca o cameră de rețea va îmbunătăți imaginea, dar nu va fi disponibilă detectarea a mișcării, captarea imaginii sau înregistrarea videoclipurilor. Camera trebuie să fie accesibilă atât pentru server, cât și pentru browser. Acest tip de cameră nu este compatibil cu Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Camerele locale V4L2 sunt dispozitivele video conectate direct la sistemul dumneavoastră motionEye, de obicei prin USB.",
+  "Aldonadi kameraon...": "Adaugă o cameră...",
+  "Grupo": "Grup",
+  "Inkluzivi foton prenitan ĉiun": "Includeți câte o fotografie făcută la fiecare",
+  "sekundo": "secundă",
+  "5 sekundoj": "5 secunde",
+  "10 sekundoj": "10 secunde",
+  "30 sekundoj": "30 de secunde",
+  "minuto": "minut",
+  "5 minutoj": "5 minute",
+  "10 minutoj": "10 minute",
+  "30 minutoj": "30 minute",
+  "horo": "oră",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Alegeți intervalul de timp dintre două imagini selectate.",
+  "Filmo framfrekvenco": "Rata de cadre a videoclipurilor",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Alegeți cât de rapid doriți să fie redat videoclipul timelapse.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Având în vedere numărul mare de imagini, crearea videoclip-ului timelapse poate dura ceva timp!",
+  "Krei akselita video": "Creați videoclip timelapse",
+  "Filmo kreanta en progreso...": "Creare videoclip timelapse...",
+  "Zipitaj": "Arhivat",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Șterge tot",
+  "Bildoj prenitaj de ": "Imagini înregistrate de camera ",
+  "Filmoj registritaj de ": "Videoclipuri înregistrate de camera ",
+  "montru ĉi tiun fotilon plenekranan": "Afișează această cameră pe ecran complet",
+  "montri ĉiujn fotilojn": "Afișează toate camerele",
+  "montru nur ĉi tiun fotilon": "Afișează doar această cameră",
+  "malfermaj bildoj retumilo": "deschide browserul de imagini",
+  "malferma videoj retumilo": "deschide browserul de videoclipuri",
+  "agordi ĉi tiun kameraon": "configurați această cameră",
+  "preni instantaron": "efectuați o captură",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Nu ați configurat încă nicio cameră. Click aici pentru a adăuga una...",
+  "enigu pozitivan nombron": "introduceți un număr pozitiv",
+  "enigu pozitivan entjeran nombron": "introduceți un număr întreg pozitiv",
+  "enigu nombron": "introduceți un număr",
+  "enigu entjeran nombron": "introduceți un număr întreg",
+  " inter ": " între ",
+  " kaj ": " și ",
+  " pli ol ": " mai mare decât ",
+  " malpli ol ": " mai mic decât ",
+  "enigu validan tempon en la sekva formato: HH:MM": "introduceți o oră validă în următorul format: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "introduceți o adresă URL validă (ex. http://example.com:8080/cams/)",
+  "fermi": "Închide",
+  "Ne": "Nu",
+  "Jes": "Da",
+  "Bone": "OK",
+  "Auto Exposure": "Expunere automată",
+  "Backlight Compensation": "Compensare pentru lumina de fundal",
+  "Brightness": "Luminozitate",
+  "Contrast": "Contrast",
+  "Exposure Absolute": "Expunere absolută",
+  "Exposure Auto": "Expunere automată",
+  "Exposure Auto Priority": "Prioritate automată expunere",
+  "Exposure Time Absolute": "Timp de expunere absolut",
+  "Focus Absolute": "Focalizare Absolută",
+  "Focus Auto": "Focalizare automată",
+  "Gain": "Creștere",
+  "Gamma": "Gamma",
+  "Hue": "Nuanță",
+  "Led1 Mode": "Modul pt. Led1",
+  "Led1 Frequency": "Frecvența pt. Led1",
+  "Pan Absolute": "Pan absolut",
+  "Power Line Frequency": "Frecvența liniei de alimentare",
+  "Saturation": "Saturare",
+  "Sharpness": "Asprime",
+  "Tilt Absolute": "Înclinare absolută",
+  "White Balance Temperature": "Temperatura balansului de alb",
+  "White Balance Temperature Auto": "Temperatura balansului de alb automată",
+  "Zoom Absolute": "Zoom absolut",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ru.json
+++ b/motioneye/static/js/motioneye.ru.json
@@ -1,164 +1,176 @@
-{"":{"language":"ru","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "спецсимволы не допускаются в пароле"
-,"Ĉi tiu kampo estas deviga": "Это поле обязательно для заполнения"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "спецсимволы не допускаются в имени камеры"
-,"valoro devas esti multoblo de 8": "значение должно быть кратным 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "спецсимволы не допускаются в имени корневого пути"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "файлы не могут быть созданы в корне вашей системы"
-,"enigu validan retpoŝtadreson": "введите действительный адрес электронной почты"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "введите список действительных адресов электронной почты, разделенных запятыми"
-,"specialaj signoj ne rajtas en dosiernomo": "спецсимволы не допускаются в имени файла"
-,"enigu validan valoron": "введите допустимое значение"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Это рекурсивно удалит все файлы в папке облака \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", а не только загруженные motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Это рекурсивно удалит все старые медиа-файлы в папке \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", а не только созданные motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Невозможно изменить маску без действительного изображения с камеры!"
-,"Propra": "Свой"
-,"Propra dosierindiko": "Пользовательский путь"
-,"Retan kunlokon": "Сетевая папка"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Ваш браузер не поддерживает эту функцию!"
-,"Apliki": "Применить"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Убедитесь, что все параметры конфигурации действительны!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Это перезагрузит систему. Продолжить?"
-,"Vere fermiti sistemon?": "Выключить систему?"
-,"Malŝaltita": "Выключен"
-,"Ĉu vere restartigi ?": "Действительно перезагрузить?"
-,"La sistemo rekomencis!": "Система перезапущена!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Сначала примените измененные настройки!"
-,"Neniu fotilo por forigi!": "Нет камеры для удаления!"
-,"Ĉu forigi kameraon ": "Удалить камеру "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye обновлён (текущая версия: "
-,"Nova versio havebla: ": "Доступна новая версия: "
-,". Ĝisdatigi?": ". Обновить?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye был успешно обновлен!"
-,"Ĝisdatigo malsukcesis!": "Обновление не удалось!"
-,"La ĝisdatiga procezo malsukcesis!": "Процесс обновления не удался!"
-,"Rezerva dosiero": "Резервный файл"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Файл резервной копии, который вы скачали ранее."
-,"Restaŭrigi Agordon": "Восстановить конфигурацию"
-,"Restaŭriganta agordon ...": "Восстановление конфигурации ..."
-,"La agordo restaŭrigis!": "Конфигурация была восстановлена!"
-,"Malsukcesis restaŭri la agordon!": "Не удалось восстановить конфигурацию!"
-,"Aliri la alŝutan servon malsukcesis: ": "Не удалось получить доступ к службе загрузки: "
-,"Aliri la alŝutan servon sukcesis!": "Доступ к службе загрузки был успешным!"
-,"Sciiga retpoŝto fiaskis:": "Оповещение по эл. почте не удалось:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Убедитесь, что все параметры конфигурации верны!"
-,"Sciiga Telegramo fiaskis:": "Оповещение через Telegram не удалось:"
-,"Sciiga Telegramo sukcesis!": "Уведомление по Telegram успешно!"
-,"Aliro al retdividado fiaskis: ": "Доступ к сетевой папке не удался: "
-,"Aliro al retdividado sukcesis!": "Доступ к сетевой папке успешен!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Действительно удалить этот файл?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Действительно удалить все изображения из \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Удалить все видео из \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Действительно удалить все несгруппированные изображения?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Действительно удалить все несгруппированные видео?"
-,"aldonadi kameraon...": "добавить камеру ..."
-,"Uzantnomo": "Имя пользователя"
-,"Pasvorto": "Пароль"
-,"Memoru min": "Запомнить меня"
-,"Ensaluti": "Логин"
-,"Nuligi": "Отмена"
-,"Vi abortis la filmeton.": "Вы прервали видео."
-,"Reto eraro okazis.": "Произошла ошибка сети."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Ошибка декодирования или неподдерживаемые функции медиа."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Формат не поддерживается или недоступен/не подходит для воспроизведения."
-,"Nekonata eraro okazis.": "Произошла неизвестная ошибка."
-,"Eraro : ": "Ошибка: "
-,"antaŭa bildo": "предыдущее изображение"
-,"ludi": "играть"
-,"ludi * 5 kaj enĉenigi": "играть * 5 и цепочку"
-,"sekva bildo": "следующее изображение"
-,"Fermi": "Закрыть"
-,"Elŝuti": "Скачать"
-,"Forigi": "Удалить"
-,"Kamerao tipo": "Тип камеры"
-,"Loka V4L2-kamerao": "Локальная камера V4L2"
-,"Loka MMAL-kamerao": "Локальная MMAL камера"
-,"Reta kamerao": "Сетевая камера"
-,"Fora motionEye kamerao": "Удалённая камера motionEye"
-,"Simpla MJPEG-kamerao": "Простая MJPEG камера"
-,"la speco de kamerao, kiun vi volas aldoni": "тип камеры, которую вы хотите добавить"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL камеры (например, http://example.com:8080/cam/)"
-,"uzantnomo...": "имя пользователя..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "имя пользователя для URL, если требуется (например, admin)"
-,"pasvorto...": "пароль..."
-,"la pasvorto por la URL, se bezonata": "пароль для URL, если требуется"
-,"Kamerao": "Камера"
-,"la kameraon, kiun vi volas aldoni": "камера, которую вы хотите добавить"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Удаленная камера motionEye - это камера, установленная на другом сервером MotionEye. Добавление их здесь позволит вам наблюдать и управлять ими удалённо."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Сетевые камеры (или IP-камеры) - это устройства, которые изначально передают потоковое видео RTSP/RTMP или MJPEG или простые изображения JPEG. Обратитесь к руководству вашего устройства, чтобы узнать правильный URL RTSP, RTMP, MJPEG или JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Локальные MMAL камеры — это устройства, подключенные непосредственно к вашей системе motionEye. Обычно это камеры для определённых плат."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Добавление вашего устройства в качестве простой MJPEG камеры вместо сетевой камеры улучшит частоту кадров, но не будет доступно обнаружение движения, захват изображения или видеозапись. Камера должна быть доступна вашему серверу и вашему браузеру. Этот тип камеры не совместим с Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Локальные V4L2 камеры - это камеры, подключенные непосредственно к вашей системе motionEye, обычно через USB."
-,"Aldonadi kameraon...": "Добавить камеру ..."
-,"Grupo": "Группа"
-,"Inkluzivi foton prenitan ĉiun": "Включать фото, сделанные каждые"
-,"sekundo": "секунд"
-,"5 sekundoj": "5 секунд"
-,"10 sekundoj": "10 секунд"
-,"30 sekundoj": "30 секунд"
-,"minuto": "минут"
-,"5 minutoj": "5 минут"
-,"10 minutoj": "10 минут"
-,"30 minutoj": "30 минут"
-,"horo": "час"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Выберите временной интервал между двумя выбранными изображениями."
-,"Filmo framfrekvenco": "Частота кадров видео"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Выберите, насколько быстрый таймлапс вы хотите."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Учитывая большое количество изображений, создание таймлапса может занять некоторое время!"
-,"Krei akselita video": "Создать таймлапс"
-,"Filmo kreanta en progreso...": "Создание таймлапса..."
-,"Zipitaj": "Архив"
-,"Akselita video": "Таймлапс"
-,"Forigi ĉiujn": "Удалить всё"
-,"Bildoj prenitaj de ": "Снимки сделаны "
-,"Filmoj registritaj de ": "Видео записаны "
-,"montru ĉi tiun fotilon plenekranan": "Показать эту камеру на весь экран"
-,"montri ĉiujn fotilojn": "Показать все камеры"
-,"montru nur ĉi tiun fotilon": "Показать только эту камеру"
-,"malfermaj bildoj retumilo": "открыть браузер изображений"
-,"malferma videoj retumilo": "открыть браузер видео"
-,"agordi ĉi tiun kameraon": "настроить эту камеру"
-,"preni instantaron": "сделать снимок"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Вы еще не настроили ни одной камеры. Нажмите здесь, чтобы добавить..."
-,"enigu pozitivan nombron": "введите положительное число"
-,"enigu pozitivan entjeran nombron": "введите положительное целое число"
-,"enigu nombron": "введите число"
-,"enigu entjeran nombron": "введите целое число"
-," inter ": " между "
-," kaj ": " и "
-," pli ol ": " больше чем "
-," malpli ol ": " меньше чем "
-,"enigu validan tempon en la sekva formato: HH:MM": "введите правильное время в следующем формате: ЧЧ:ММ"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "введите действительный URL (например, http://example.com:8080/cams/)"
-,"fermi": "закрыть"
-,"Ne": "Нет"
-,"Jes": "Да"
-,"Bone": "OK"
-,"Auto Exposure": "Автоматическая экспозиция"
-,"Backlight Compensation": "Компенсация подсветки"
-,"Brightness": "Яркость"
-,"Contrast": "Контраст"
-,"Exposure Absolute": "Абсолютная экспозиция"
-,"Exposure Auto": "Автоматическая экспозиция"
-,"Exposure Auto Priority": "Автоматический приоритет экспозиции"
-,"Exposure Time Absolute": "Абсолютное время экспозиции"
-,"Focus Absolute": "Абсолютный фокус"
-,"Focus Auto": "Авто фокус"
-,"Gain": "Усиление"
-,"Gamma": "Гамма"
-,"Hue": "Оттенок"
-,"Led1 Mode": "Режим Led1"
-,"Led1 Frequency": "Частота Led1"
-,"Pan Absolute": "Абсолютное панарамирование"
-,"Power Line Frequency": "Частота линии"
-,"Saturation": "Насыщенность"
-,"Sharpness": "Чёткость"
-,"Tilt Absolute": "Абсолютный наклон"
-,"White Balance Temperature": "Температура баланса белого"
-,"White Balance Temperature Auto": "Авто температура баланса белого"
-,"Zoom Absolute": "Абсолютный зум"
+{
+  "": {
+    "language": "ru",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "спецсимволы не допускаются в пароле",
+  "Ĉi tiu kampo estas deviga": "Это поле обязательно для заполнения",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "спецсимволы не допускаются в имени камеры",
+  "valoro devas esti multoblo de 8": "значение должно быть кратным 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "спецсимволы не допускаются в имени корневого пути",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "файлы не могут быть созданы в корне вашей системы",
+  "enigu validan retpoŝtadreson": "введите действительный адрес электронной почты",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "введите список действительных адресов электронной почты, разделенных запятыми",
+  "specialaj signoj ne rajtas en dosiernomo": "спецсимволы не допускаются в имени файла",
+  "enigu validan valoron": "введите допустимое значение",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Это рекурсивно удалит все файлы в папке облака \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", а не только загруженные motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Это рекурсивно удалит все старые медиа-файлы в папке \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", а не только созданные motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Невозможно изменить маску без действительного изображения с камеры!",
+  "Propra": "Свой",
+  "Propra dosierindiko": "Пользовательский путь",
+  "Retan kunlokon": "Сетевая папка",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Ваш браузер не поддерживает эту функцию!",
+  "Apliki": "Применить",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Убедитесь, что все параметры конфигурации действительны!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Это перезагрузит систему. Продолжить?",
+  "Vere fermiti sistemon?": "Выключить систему?",
+  "Malŝaltita": "Выключен",
+  "Ĉu vere restartigi ?": "Действительно перезагрузить?",
+  "La sistemo rekomencis!": "Система перезапущена!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Сначала примените измененные настройки!",
+  "Neniu fotilo por forigi!": "Нет камеры для удаления!",
+  "Ĉu forigi kameraon ": "Удалить камеру ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye обновлён (текущая версия: ",
+  "Nova versio havebla: ": "Доступна новая версия: ",
+  ". Ĝisdatigi?": ". Обновить?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye был успешно обновлен!",
+  "Ĝisdatigo malsukcesis!": "Обновление не удалось!",
+  "La ĝisdatiga procezo malsukcesis!": "Процесс обновления не удался!",
+  "Rezerva dosiero": "Резервный файл",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Файл резервной копии, который вы скачали ранее.",
+  "Restaŭrigi Agordon": "Восстановить конфигурацию",
+  "Restaŭriganta agordon ...": "Восстановление конфигурации ...",
+  "La agordo restaŭrigis!": "Конфигурация была восстановлена!",
+  "Malsukcesis restaŭri la agordon!": "Не удалось восстановить конфигурацию!",
+  "Aliri la alŝutan servon malsukcesis: ": "Не удалось получить доступ к службе загрузки: ",
+  "Aliri la alŝutan servon sukcesis!": "Доступ к службе загрузки был успешным!",
+  "Sciiga retpoŝto fiaskis:": "Оповещение по эл. почте не удалось:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Убедитесь, что все параметры конфигурации верны!",
+  "Sciiga Telegramo fiaskis:": "Оповещение через Telegram не удалось:",
+  "Sciiga Telegramo sukcesis!": "Уведомление по Telegram успешно!",
+  "Aliro al retdividado fiaskis: ": "Доступ к сетевой папке не удался: ",
+  "Aliro al retdividado sukcesis!": "Доступ к сетевой папке успешен!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Действительно удалить этот файл?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Действительно удалить все изображения из \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Удалить все видео из \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Действительно удалить все несгруппированные изображения?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Действительно удалить все несгруппированные видео?",
+  "aldonadi kameraon...": "добавить камеру ...",
+  "Uzantnomo": "Имя пользователя",
+  "Pasvorto": "Пароль",
+  "Memoru min": "Запомнить меня",
+  "Ensaluti": "Логин",
+  "Nuligi": "Отмена",
+  "Vi abortis la filmeton.": "Вы прервали видео.",
+  "Reto eraro okazis.": "Произошла ошибка сети.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Ошибка декодирования или неподдерживаемые функции медиа.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Формат не поддерживается или недоступен/не подходит для воспроизведения.",
+  "Nekonata eraro okazis.": "Произошла неизвестная ошибка.",
+  "Eraro : ": "Ошибка: ",
+  "antaŭa bildo": "предыдущее изображение",
+  "ludi": "играть",
+  "ludi * 5 kaj enĉenigi": "играть * 5 и цепочку",
+  "sekva bildo": "следующее изображение",
+  "Fermi": "Закрыть",
+  "Elŝuti": "Скачать",
+  "Forigi": "Удалить",
+  "Kamerao tipo": "Тип камеры",
+  "Loka V4L2-kamerao": "Локальная камера V4L2",
+  "Loka MMAL-kamerao": "Локальная MMAL камера",
+  "Reta kamerao": "Сетевая камера",
+  "Fora motionEye kamerao": "Удалённая камера motionEye",
+  "Simpla MJPEG-kamerao": "Простая MJPEG камера",
+  "la speco de kamerao, kiun vi volas aldoni": "тип камеры, которую вы хотите добавить",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL камеры (например, http://example.com:8080/cam/)",
+  "uzantnomo...": "имя пользователя...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "имя пользователя для URL, если требуется (например, admin)",
+  "pasvorto...": "пароль...",
+  "la pasvorto por la URL, se bezonata": "пароль для URL, если требуется",
+  "Kamerao": "Камера",
+  "la kameraon, kiun vi volas aldoni": "камера, которую вы хотите добавить",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Удаленная камера motionEye - это камера, установленная на другом сервером MotionEye. Добавление их здесь позволит вам наблюдать и управлять ими удалённо.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Сетевые камеры (или IP-камеры) - это устройства, которые изначально передают потоковое видео RTSP/RTMP или MJPEG или простые изображения JPEG. Обратитесь к руководству вашего устройства, чтобы узнать правильный URL RTSP, RTMP, MJPEG или JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Локальные MMAL камеры — это устройства, подключенные непосредственно к вашей системе motionEye. Обычно это камеры для определённых плат.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Добавление вашего устройства в качестве простой MJPEG камеры вместо сетевой камеры улучшит частоту кадров, но не будет доступно обнаружение движения, захват изображения или видеозапись. Камера должна быть доступна вашему серверу и вашему браузеру. Этот тип камеры не совместим с Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Локальные V4L2 камеры - это камеры, подключенные непосредственно к вашей системе motionEye, обычно через USB.",
+  "Aldonadi kameraon...": "Добавить камеру ...",
+  "Grupo": "Группа",
+  "Inkluzivi foton prenitan ĉiun": "Включать фото, сделанные каждые",
+  "sekundo": "секунд",
+  "5 sekundoj": "5 секунд",
+  "10 sekundoj": "10 секунд",
+  "30 sekundoj": "30 секунд",
+  "minuto": "минут",
+  "5 minutoj": "5 минут",
+  "10 minutoj": "10 минут",
+  "30 minutoj": "30 минут",
+  "horo": "час",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Выберите временной интервал между двумя выбранными изображениями.",
+  "Filmo framfrekvenco": "Частота кадров видео",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Выберите, насколько быстрый таймлапс вы хотите.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Учитывая большое количество изображений, создание таймлапса может занять некоторое время!",
+  "Krei akselita video": "Создать таймлапс",
+  "Filmo kreanta en progreso...": "Создание таймлапса...",
+  "Zipitaj": "Архив",
+  "Akselita video": "Таймлапс",
+  "Forigi ĉiujn": "Удалить всё",
+  "Bildoj prenitaj de ": "Снимки сделаны ",
+  "Filmoj registritaj de ": "Видео записаны ",
+  "montru ĉi tiun fotilon plenekranan": "Показать эту камеру на весь экран",
+  "montri ĉiujn fotilojn": "Показать все камеры",
+  "montru nur ĉi tiun fotilon": "Показать только эту камеру",
+  "malfermaj bildoj retumilo": "открыть браузер изображений",
+  "malferma videoj retumilo": "открыть браузер видео",
+  "agordi ĉi tiun kameraon": "настроить эту камеру",
+  "preni instantaron": "сделать снимок",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Вы еще не настроили ни одной камеры. Нажмите здесь, чтобы добавить...",
+  "enigu pozitivan nombron": "введите положительное число",
+  "enigu pozitivan entjeran nombron": "введите положительное целое число",
+  "enigu nombron": "введите число",
+  "enigu entjeran nombron": "введите целое число",
+  " inter ": " между ",
+  " kaj ": " и ",
+  " pli ol ": " больше чем ",
+  " malpli ol ": " меньше чем ",
+  "enigu validan tempon en la sekva formato: HH:MM": "введите правильное время в следующем формате: ЧЧ:ММ",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "введите действительный URL (например, http://example.com:8080/cams/)",
+  "fermi": "закрыть",
+  "Ne": "Нет",
+  "Jes": "Да",
+  "Bone": "OK",
+  "Auto Exposure": "Автоматическая экспозиция",
+  "Backlight Compensation": "Компенсация подсветки",
+  "Brightness": "Яркость",
+  "Contrast": "Контраст",
+  "Exposure Absolute": "Абсолютная экспозиция",
+  "Exposure Auto": "Автоматическая экспозиция",
+  "Exposure Auto Priority": "Автоматический приоритет экспозиции",
+  "Exposure Time Absolute": "Абсолютное время экспозиции",
+  "Focus Absolute": "Абсолютный фокус",
+  "Focus Auto": "Авто фокус",
+  "Gain": "Усиление",
+  "Gamma": "Гамма",
+  "Hue": "Оттенок",
+  "Led1 Mode": "Режим Led1",
+  "Led1 Frequency": "Частота Led1",
+  "Pan Absolute": "Абсолютное панарамирование",
+  "Power Line Frequency": "Частота линии",
+  "Saturation": "Насыщенность",
+  "Sharpness": "Чёткость",
+  "Tilt Absolute": "Абсолютный наклон",
+  "White Balance Temperature": "Температура баланса белого",
+  "White Balance Temperature Auto": "Авто температура баланса белого",
+  "Zoom Absolute": "Абсолютный зум",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.sk.json
+++ b/motioneye/static/js/motioneye.sk.json
@@ -1,164 +1,176 @@
-{"":{"language":"sk","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "špeciálne znaky v hesle nie sú povolené"
-,"Ĉi tiu kampo estas deviga": "Toto pole je povinné"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "špeciálne znaky v názve kamery nie sú povolené"
-,"valoro devas esti multoblo de 8": "hodnota musí byť násobkom čísla 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "špeciálne znaky v názve koreňového adresára nie sú povolené"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "súbory nesmú byť vytvorené v koreňovom adresári vášho systému"
-,"enigu validan retpoŝtadreson": "zadajte platnú e-mailovú adresu"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "zadajte zoznam čiarkou oddelených platných e-mailových adries"
-,"specialaj signoj ne rajtas en dosiernomo": "špeciálne znaky v názve súboru nie sú povolené"
-,"enigu validan valoron": "zadajte platnú hodnotu"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Toto rekurzívne odstráni všetky existujúce súbory v cloudovom priečinku \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", nielen tie, ktoré boli nahrané motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Toto rekurzívne odstráni všetky staré multimediálne súbory v adresári \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", nielen tie, ktoré vytvoril motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Masku nie je možné upraviť bez platného obrázka z kamery!"
-,"Propra": "Vlastná"
-,"Propra dosierindiko": "Vlastná cesta"
-,"Retan kunlokon": "Sieťové zdieľanie"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Váš prehliadač neimplementuje túto funkciu!"
-,"Apliki": "Použiť"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Skontrolute, či sú všetky nastavenia konfigurácie platné!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Týmto reštartujete systém. Pokračovať?"
-,"Vere fermiti sistemon?": "Naozaj vypnúť?"
-,"Malŝaltita": "Vypnuté"
-,"Ĉu vere restartigi ?": "Naozaj reštartovať?"
-,"La sistemo rekomencis!": "Systém bol reštartovaný!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Aplikujte najprv zmenené nastavenia!"
-,"Neniu fotilo por forigi!": "Neexistuje kamera, ktorú by bolo možné odstrániť!"
-,"Ĉu forigi kameraon ": "Odstrániť kameru "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye je aktuálny (aktuálna verzia: "
-,"Nova versio havebla: ": "Je dostupná nová verzia: "
-,". Ĝisdatigi?": ". Aktualizovať?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye bol úspešne aktualizovaný!"
-,"Ĝisdatigo malsukcesis!": "Aktualizácia skončila s chybou!"
-,"La ĝisdatiga procezo malsukcesis!": "Proces aktualizácie zlyhal!"
-,"Rezerva dosiero": "Súbor so zálohou"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "súbor so zálohou, ktorú ste v minulosti uložili."
-,"Restaŭrigi Agordon": "Obnoviť nastavenia"
-,"Restaŭriganta agordon ...": "Obnovujem nastavenia…"
-,"La agordo restaŭrigis!": "Nastavenia boli obnovené zo zálohy!"
-,"Malsukcesis restaŭri la agordon!": "Nepodarilo sa obnoviť nastavenia!"
-,"Aliri la alŝutan servon malsukcesis: ": "Pokus o prístup k nahrávacej službe skončil s chybou: "
-,"Aliri la alŝutan servon sukcesis!": "Komunikácia s nahrávacou službou bola úspešne nadviazaná!"
-,"Sciiga retpoŝto fiaskis:": "E-mail s upozornením zlyhal:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Uistite sa, že všetky nastavenia sú platné!"
-,"Sciiga Telegramo fiaskis:": "Upozornenie na Telegram skončilo s chybou:"
-,"Sciiga Telegramo sukcesis!": "Upozornenie na Telegram bolo úspešné!"
-,"Aliro al retdividado fiaskis: ": "Pokus o prístup ku sieťovému zdieľaniu skončil s chybou: "
-,"Aliro al retdividado sukcesis!": "Komunikácia so sieťovým zdieľaním bola úspešne nadviazaná!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Naozaj odstrániť tento súbor?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Naozaj odstrániť všetky súbory obrázkov z \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Naozaj odstrániť všetky videá z \"%(group)s\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Naozaj odstrániť všetky nezoskupené obrázky?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Naozaj odstrániť všetky nezoskupené videá?"
-,"aldonadi kameraon...": "pridať kameru..."
-,"Uzantnomo": "Meno používateľa"
-,"Pasvorto": "Heslo"
-,"Memoru min": "Pamätaj si ma"
-,"Ensaluti": "Prihlásiť"
-,"Nuligi": "Zrušiť"
-,"Vi abortis la filmeton.": "Video ste zrušili."
-,"Reto eraro okazis.": "Vyskytol sa problém na sieti."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Chyba dekódovania multimédia alebo nepodporované vlastnosti súboru."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formát nie je podporovaný alebo nie je dostupný/vhodný na prehrávanie."
-,"Nekonata eraro okazis.": "Nastala neznáma chyba."
-,"Eraro : ": "Chyba: "
-,"antaŭa bildo": "predchádzajúci obrázok"
-,"ludi": "prehrať"
-,"ludi * 5 kaj enĉenigi": "prehrať * 5 a zreťaziť"
-,"sekva bildo": "nasledujúci obrázok"
-,"Fermi": "Zavrieť"
-,"Elŝuti": "Stiahnuť"
-,"Forigi": "Odstrániť"
-,"Kamerao tipo": "Typ kamery"
-,"Loka V4L2-kamerao": "Miestna V4L2 kamera"
-,"Loka MMAL-kamerao": "Miestna MMAL kamera"
-,"Reta kamerao": "Sieťová kamera"
-,"Fora motionEye kamerao": "Vzdialená motionEye kamera"
-,"Simpla MJPEG-kamerao": "Jednoduchá MJPEG kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "typ kamery, ktorú si želáte pridať"
-,"URL": "URL adresa"
-,"http://ekzemplo.com:8765/cams/...": "http://priklad.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL adresa kamery (napr. http://priklad.com:8080/cam/)"
-,"uzantnomo...": "meno používateľa ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "meno používateľa pre URL adresu, ak je potrebné jeho zadanie (napr. admin)"
-,"pasvorto...": "heslo ..."
-,"la pasvorto por la URL, se bezonata": "heslo pre URL adresau, ak je potrebné"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kamera, ktorú si želáte pridať"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Vzdialené kamery motionEye sú kamery nainštalované na inom serveri motionEye. Ak ich sem pridáte, umožní vám to ich prezeranie a vzdialenú správu."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Sieťové kamery (alebo IP kamery) sú zariadenia, ktoré natívne vysielajú prúd RTSP/RTMP alebo MJPEG videá prípadne obyčajné obrázky JPEG. Preštudujte si návod k vášmu zariadeniu, kde nájdete správnu URL adresu pre RTSP, RTMP, MJPEG alebo JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Miestne MMAL kamery sú zariadenia pripojené priamo k vášmu motionEye systému. Zvyčajne to bývajú kamery určené pre konkrétnu dosku/čip."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Ak pridáte vaše zariadenie ako jednoduchú MJPEG kameru namiesto sieťovej kamery, dosiahnete tak vyššiu snímkovú frekvenciu, ale nebude možné pre ňu dostupná detekcia pohybu, zachytávanie obrázkov alebo nahrávanie videí. Kamera musí byť dostupná z vášho servera aj webového prehliadača. Tento typ kamery nie je kompatibilný s Internet Explorerom."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Miestne V4L2 kamery sú kamerové zariadenia pripojené priamo k vášmu motionEye systému, zvyčajne prostredníctvom USB."
-,"Aldonadi kameraon...": "Pridať kameru..."
-,"Grupo": "Skupina"
-,"Inkluzivi foton prenitan ĉiun": "Zahrnúť obrázok každú/ých"
-,"sekundo": "sekunda"
-,"5 sekundoj": "5 sekúnd"
-,"10 sekundoj": "10 sekúnd"
-,"30 sekundoj": "30 sekúnd"
-,"minuto": "minúta"
-,"5 minutoj": "5 minút"
-,"10 minutoj": "10 minút"
-,"30 minutoj": "30 minút"
-,"horo": "hodina"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "vyberte časový interval medzi dvoma vybranými obrázkami."
-,"Filmo framfrekvenco": "Snímková frekvencia videí"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "vyberte rýchlosť prehrávania časozberného videa."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Vzhľadom na veľký počet obrázkov môže vytváranie časozberného video nejaký čas trvať!"
-,"Krei akselita video": "Vytvoriť časozberné video"
-,"Filmo kreanta en progreso...": "Vytváram časozberné video…"
-,"Zipitaj": "ZIP archív"
-,"Akselita video": "Časozber"
-,"Forigi ĉiujn": "Odstrániť všetko"
-,"Bildoj prenitaj de ": "Obrázky zachytené kamerou "
-,"Filmoj registritaj de ": "Videá nahrané kamerou "
-,"montru ĉi tiun fotilon plenekranan": "Zobraziť túto kameru na celej obrazovke"
-,"montri ĉiujn fotilojn": "Zobraziť všetky kamery"
-,"montru nur ĉi tiun fotilon": "Zobraziť iba túto kameru"
-,"malfermaj bildoj retumilo": "otvoriť prehliadač obrázkov"
-,"malferma videoj retumilo": "otvoriť prehliadač videí"
-,"agordi ĉi tiun kameraon": "nastaviť túto kameru"
-,"preni instantaron": "vytvoriť snímku"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ešte ste nenastavili žiadne kamery. Kliknite sem pre pridanie prvej..."
-,"enigu pozitivan nombron": "zadajte kladné číslo"
-,"enigu pozitivan entjeran nombron": "zadajte kladné celé číslo"
-,"enigu nombron": "zadajte číslo"
-,"enigu entjeran nombron": "zadajte celé číslo"
-," inter ": " medzi "
-," kaj ": " a "
-," pli ol ": " väčšie ako "
-," malpli ol ": " menšie ako "
-,"enigu validan tempon en la sekva formato: HH:MM": "zadajte platný čas vo formáte: HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "zadajte platnú URL adresu (napr. http://priklad.com:8080/cams/)"
-,"fermi": "zavrieť"
-,"Ne": "Nie"
-,"Jes": "Áno"
-,"Bone": "OK"
-,"Auto Exposure": "Automatická expozícia"
-,"Backlight Compensation": "Kompenzácia podsvietenia"
-,"Brightness": "Jas"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Absolútna expozícia"
-,"Exposure Auto": "Automatická expozícia"
-,"Exposure Auto Priority": "Automatická priorita expozície"
-,"Exposure Time Absolute": "Absolútny čas expozície"
-,"Focus Absolute": "Absolútny fokus"
-,"Focus Auto": "Automatický fokus"
-,"Gain": "Zisk"
-,"Gamma": "Gamma"
-,"Hue": "Zafarbenie"
-,"Led1 Mode": "Režim LED1"
-,"Led1 Frequency": "Frekvencia LED1"
-,"Pan Absolute": "Absolútny posun"
-,"Power Line Frequency": "Frekvencia napätia"
-,"Saturation": "Sýtosť"
-,"Sharpness": "Ostrosť"
-,"Tilt Absolute": "Absolútny sklon"
-,"White Balance Temperature": "Teplota vyváženia bielej"
-,"White Balance Temperature Auto": "Automatická teplota vyváženia bielej"
-,"Zoom Absolute": "Absolútne priblíženie"
+{
+  "": {
+    "language": "sk",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "špeciálne znaky v hesle nie sú povolené",
+  "Ĉi tiu kampo estas deviga": "Toto pole je povinné",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "špeciálne znaky v názve kamery nie sú povolené",
+  "valoro devas esti multoblo de 8": "hodnota musí byť násobkom čísla 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "špeciálne znaky v názve koreňového adresára nie sú povolené",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "súbory nesmú byť vytvorené v koreňovom adresári vášho systému",
+  "enigu validan retpoŝtadreson": "zadajte platnú e-mailovú adresu",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "zadajte zoznam čiarkou oddelených platných e-mailových adries",
+  "specialaj signoj ne rajtas en dosiernomo": "špeciálne znaky v názve súboru nie sú povolené",
+  "enigu validan valoron": "zadajte platnú hodnotu",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Toto rekurzívne odstráni všetky existujúce súbory v cloudovom priečinku \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", nielen tie, ktoré boli nahrané motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Toto rekurzívne odstráni všetky staré multimediálne súbory v adresári \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", nielen tie, ktoré vytvoril motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Masku nie je možné upraviť bez platného obrázka z kamery!",
+  "Propra": "Vlastná",
+  "Propra dosierindiko": "Vlastná cesta",
+  "Retan kunlokon": "Sieťové zdieľanie",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Váš prehliadač neimplementuje túto funkciu!",
+  "Apliki": "Použiť",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Skontrolute, či sú všetky nastavenia konfigurácie platné!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Týmto reštartujete systém. Pokračovať?",
+  "Vere fermiti sistemon?": "Naozaj vypnúť?",
+  "Malŝaltita": "Vypnuté",
+  "Ĉu vere restartigi ?": "Naozaj reštartovať?",
+  "La sistemo rekomencis!": "Systém bol reštartovaný!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Aplikujte najprv zmenené nastavenia!",
+  "Neniu fotilo por forigi!": "Neexistuje kamera, ktorú by bolo možné odstrániť!",
+  "Ĉu forigi kameraon ": "Odstrániť kameru ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye je aktuálny (aktuálna verzia: ",
+  "Nova versio havebla: ": "Je dostupná nová verzia: ",
+  ". Ĝisdatigi?": ". Aktualizovať?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye bol úspešne aktualizovaný!",
+  "Ĝisdatigo malsukcesis!": "Aktualizácia skončila s chybou!",
+  "La ĝisdatiga procezo malsukcesis!": "Proces aktualizácie zlyhal!",
+  "Rezerva dosiero": "Súbor so zálohou",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "súbor so zálohou, ktorú ste v minulosti uložili.",
+  "Restaŭrigi Agordon": "Obnoviť nastavenia",
+  "Restaŭriganta agordon ...": "Obnovujem nastavenia…",
+  "La agordo restaŭrigis!": "Nastavenia boli obnovené zo zálohy!",
+  "Malsukcesis restaŭri la agordon!": "Nepodarilo sa obnoviť nastavenia!",
+  "Aliri la alŝutan servon malsukcesis: ": "Pokus o prístup k nahrávacej službe skončil s chybou: ",
+  "Aliri la alŝutan servon sukcesis!": "Komunikácia s nahrávacou službou bola úspešne nadviazaná!",
+  "Sciiga retpoŝto fiaskis:": "E-mail s upozornením zlyhal:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Uistite sa, že všetky nastavenia sú platné!",
+  "Sciiga Telegramo fiaskis:": "Upozornenie na Telegram skončilo s chybou:",
+  "Sciiga Telegramo sukcesis!": "Upozornenie na Telegram bolo úspešné!",
+  "Aliro al retdividado fiaskis: ": "Pokus o prístup ku sieťovému zdieľaniu skončil s chybou: ",
+  "Aliro al retdividado sukcesis!": "Komunikácia so sieťovým zdieľaním bola úspešne nadviazaná!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Naozaj odstrániť tento súbor?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Naozaj odstrániť všetky súbory obrázkov z \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Naozaj odstrániť všetky videá z \"%(group)s\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Naozaj odstrániť všetky nezoskupené obrázky?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Naozaj odstrániť všetky nezoskupené videá?",
+  "aldonadi kameraon...": "pridať kameru...",
+  "Uzantnomo": "Meno používateľa",
+  "Pasvorto": "Heslo",
+  "Memoru min": "Pamätaj si ma",
+  "Ensaluti": "Prihlásiť",
+  "Nuligi": "Zrušiť",
+  "Vi abortis la filmeton.": "Video ste zrušili.",
+  "Reto eraro okazis.": "Vyskytol sa problém na sieti.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Chyba dekódovania multimédia alebo nepodporované vlastnosti súboru.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formát nie je podporovaný alebo nie je dostupný/vhodný na prehrávanie.",
+  "Nekonata eraro okazis.": "Nastala neznáma chyba.",
+  "Eraro : ": "Chyba: ",
+  "antaŭa bildo": "predchádzajúci obrázok",
+  "ludi": "prehrať",
+  "ludi * 5 kaj enĉenigi": "prehrať * 5 a zreťaziť",
+  "sekva bildo": "nasledujúci obrázok",
+  "Fermi": "Zavrieť",
+  "Elŝuti": "Stiahnuť",
+  "Forigi": "Odstrániť",
+  "Kamerao tipo": "Typ kamery",
+  "Loka V4L2-kamerao": "Miestna V4L2 kamera",
+  "Loka MMAL-kamerao": "Miestna MMAL kamera",
+  "Reta kamerao": "Sieťová kamera",
+  "Fora motionEye kamerao": "Vzdialená motionEye kamera",
+  "Simpla MJPEG-kamerao": "Jednoduchá MJPEG kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "typ kamery, ktorú si želáte pridať",
+  "URL": "URL adresa",
+  "http://ekzemplo.com:8765/cams/...": "http://priklad.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL adresa kamery (napr. http://priklad.com:8080/cam/)",
+  "uzantnomo...": "meno používateľa ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "meno používateľa pre URL adresu, ak je potrebné jeho zadanie (napr. admin)",
+  "pasvorto...": "heslo ...",
+  "la pasvorto por la URL, se bezonata": "heslo pre URL adresau, ak je potrebné",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kamera, ktorú si želáte pridať",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Vzdialené kamery motionEye sú kamery nainštalované na inom serveri motionEye. Ak ich sem pridáte, umožní vám to ich prezeranie a vzdialenú správu.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Sieťové kamery (alebo IP kamery) sú zariadenia, ktoré natívne vysielajú prúd RTSP/RTMP alebo MJPEG videá prípadne obyčajné obrázky JPEG. Preštudujte si návod k vášmu zariadeniu, kde nájdete správnu URL adresu pre RTSP, RTMP, MJPEG alebo JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Miestne MMAL kamery sú zariadenia pripojené priamo k vášmu motionEye systému. Zvyčajne to bývajú kamery určené pre konkrétnu dosku/čip.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Ak pridáte vaše zariadenie ako jednoduchú MJPEG kameru namiesto sieťovej kamery, dosiahnete tak vyššiu snímkovú frekvenciu, ale nebude možné pre ňu dostupná detekcia pohybu, zachytávanie obrázkov alebo nahrávanie videí. Kamera musí byť dostupná z vášho servera aj webového prehliadača. Tento typ kamery nie je kompatibilný s Internet Explorerom.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Miestne V4L2 kamery sú kamerové zariadenia pripojené priamo k vášmu motionEye systému, zvyčajne prostredníctvom USB.",
+  "Aldonadi kameraon...": "Pridať kameru...",
+  "Grupo": "Skupina",
+  "Inkluzivi foton prenitan ĉiun": "Zahrnúť obrázok každú/ých",
+  "sekundo": "sekunda",
+  "5 sekundoj": "5 sekúnd",
+  "10 sekundoj": "10 sekúnd",
+  "30 sekundoj": "30 sekúnd",
+  "minuto": "minúta",
+  "5 minutoj": "5 minút",
+  "10 minutoj": "10 minút",
+  "30 minutoj": "30 minút",
+  "horo": "hodina",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "vyberte časový interval medzi dvoma vybranými obrázkami.",
+  "Filmo framfrekvenco": "Snímková frekvencia videí",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "vyberte rýchlosť prehrávania časozberného videa.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Vzhľadom na veľký počet obrázkov môže vytváranie časozberného video nejaký čas trvať!",
+  "Krei akselita video": "Vytvoriť časozberné video",
+  "Filmo kreanta en progreso...": "Vytváram časozberné video…",
+  "Zipitaj": "ZIP archív",
+  "Akselita video": "Časozber",
+  "Forigi ĉiujn": "Odstrániť všetko",
+  "Bildoj prenitaj de ": "Obrázky zachytené kamerou ",
+  "Filmoj registritaj de ": "Videá nahrané kamerou ",
+  "montru ĉi tiun fotilon plenekranan": "Zobraziť túto kameru na celej obrazovke",
+  "montri ĉiujn fotilojn": "Zobraziť všetky kamery",
+  "montru nur ĉi tiun fotilon": "Zobraziť iba túto kameru",
+  "malfermaj bildoj retumilo": "otvoriť prehliadač obrázkov",
+  "malferma videoj retumilo": "otvoriť prehliadač videí",
+  "agordi ĉi tiun kameraon": "nastaviť túto kameru",
+  "preni instantaron": "vytvoriť snímku",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ešte ste nenastavili žiadne kamery. Kliknite sem pre pridanie prvej...",
+  "enigu pozitivan nombron": "zadajte kladné číslo",
+  "enigu pozitivan entjeran nombron": "zadajte kladné celé číslo",
+  "enigu nombron": "zadajte číslo",
+  "enigu entjeran nombron": "zadajte celé číslo",
+  " inter ": " medzi ",
+  " kaj ": " a ",
+  " pli ol ": " väčšie ako ",
+  " malpli ol ": " menšie ako ",
+  "enigu validan tempon en la sekva formato: HH:MM": "zadajte platný čas vo formáte: HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "zadajte platnú URL adresu (napr. http://priklad.com:8080/cams/)",
+  "fermi": "zavrieť",
+  "Ne": "Nie",
+  "Jes": "Áno",
+  "Bone": "OK",
+  "Auto Exposure": "Automatická expozícia",
+  "Backlight Compensation": "Kompenzácia podsvietenia",
+  "Brightness": "Jas",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Absolútna expozícia",
+  "Exposure Auto": "Automatická expozícia",
+  "Exposure Auto Priority": "Automatická priorita expozície",
+  "Exposure Time Absolute": "Absolútny čas expozície",
+  "Focus Absolute": "Absolútny fokus",
+  "Focus Auto": "Automatický fokus",
+  "Gain": "Zisk",
+  "Gamma": "Gamma",
+  "Hue": "Zafarbenie",
+  "Led1 Mode": "Režim LED1",
+  "Led1 Frequency": "Frekvencia LED1",
+  "Pan Absolute": "Absolútny posun",
+  "Power Line Frequency": "Frekvencia napätia",
+  "Saturation": "Sýtosť",
+  "Sharpness": "Ostrosť",
+  "Tilt Absolute": "Absolútny sklon",
+  "White Balance Temperature": "Teplota vyváženia bielej",
+  "White Balance Temperature Auto": "Automatická teplota vyváženia bielej",
+  "Zoom Absolute": "Absolútne priblíženie",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.sv.json
+++ b/motioneye/static/js/motioneye.sv.json
@@ -1,164 +1,176 @@
-{"":{"language":"sv","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "Särskilda tecken är inte tillåtna i lösenordet"
-,"Ĉi tiu kampo estas deviga": "Detta fält krävs"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "Speciella tecken är inte tillåtna i namnet för kameran"
-,"valoro devas esti multoblo de 8": "värdet måste vara en multipel av 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "Speciella tecken är inte tillåtna i trädmapps namnet"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "filer kan inte skapas direkt i ditt systems rotkatalog"
-,"enigu validan retpoŝtadreson": "Skriv en giltig e-post adress"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "Skriv en lista med komma-separerade giltiga e-postadresser"
-,"specialaj signoj ne rajtas en dosiernomo": "speciella tecken är inte tillåtna i filnamnet"
-,"enigu validan valoron": "Ange ett giltigt värde"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Detta kommer att rekursivt ta bort filer i mappen på din molntjänst \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", inte bara de som laddats upp av motionEye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Detta kommer att rekursivt ta bort äldre media filer som finns i filkatalogen \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", inte bara de som skapats av motionEye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Det går inte att redigera masken utan en giltig kamerabild!"
-,"Propra": "Anpassad"
-,"Propra dosierindiko": "Anpassad sökväg"
-,"Retan kunlokon": "Nätverksdelning"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Din webbläsare implementerar inte denna funktion!"
-,"Apliki": "Tillämpa"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Säkerställ att alla konfigurationsalternativ är giltiga!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Detta kommer att starta om systemet. Fortsätt?"
-,"Vere fermiti sistemon?": "Vill du verkligen stänga av systemet?"
-,"Malŝaltita": "Avstängd"
-,"Ĉu vere restartigi ?": "Vill du verkligen starta om?"
-,"La sistemo rekomencis!": "Systemet har startats om!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Tillämpa de ändrade inställningarna först!"
-,"Neniu fotilo por forigi!": "Ingen kamera att ta bort!"
-,"Ĉu forigi kameraon ": "Ta bort kamera "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye är uppdaterat (nuvarande version: "
-,"Nova versio havebla: ": "Ny version tillgänglig: "
-,". Ĝisdatigi?": ". Uppdatera?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye har uppdaterats!"
-,"Ĝisdatigo malsukcesis!": "Uppdatering misslyckades!"
-,"La ĝisdatiga procezo malsukcesis!": "Uppdateringsprocessen misslyckades!"
-,"Rezerva dosiero": "Backup-fil"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "backup-fil som du laddade ner senast."
-,"Restaŭrigi Agordon": "Återställ Konfiguration"
-,"Restaŭriganta agordon ...": "Återställer konfigurationen ..."
-,"La agordo restaŭrigis!": "Konfigurationen har återställts!"
-,"Malsukcesis restaŭri la agordon!": "Misslyckades med att återställa konfigurationen!"
-,"Aliri la alŝutan servon malsukcesis: ": "Åtkomst till uppladdningstjänsten misslyckades: "
-,"Aliri la alŝutan servon sukcesis!": "Åtkomst till uppladdningstjänsten lyckades!"
-,"Sciiga retpoŝto fiaskis:": "Notifikations email misslyckades:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Kontrollera att alla konfigurationsalternativ är korrekta!"
-,"Sciiga Telegramo fiaskis:": ""
-,"Sciiga Telegramo sukcesis!": ""
-,"Aliro al retdividado fiaskis: ": "Åtkomst till utdelad nätverksmapp misslyckades: "
-,"Aliro al retdividado sukcesis!": "Åtkomst till utdelad nätverksmapp lyckades!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Vill du verkligen ta bort denna fil?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": ""
-,"aldonadi kameraon...": "Lägg till kamera ..."
-,"Uzantnomo": "Användarnamn"
-,"Pasvorto": "Lösenord"
-,"Memoru min": "Kom ihåg mig"
-,"Ensaluti": "Logga in"
-,"Nuligi": "Avbryt"
-,"Vi abortis la filmeton.": "Du avbröt videon."
-,"Reto eraro okazis.": "Ett nätverksfel inträffade."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": ""
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formatet stöds inte eller är otillgängligt/olämpligt för uppspelning."
-,"Nekonata eraro okazis.": "Okänt fel inträffade."
-,"Eraro : ": "Fel: "
-,"antaŭa bildo": "Föregående bild"
-,"ludi": "spela"
-,"ludi * 5 kaj enĉenigi": ""
-,"sekva bildo": "nästa bild"
-,"Fermi": "Stäng"
-,"Elŝuti": "Ladda ner"
-,"Forigi": "Ta bort"
-,"Kamerao tipo": "Kamerattyp"
-,"Loka V4L2-kamerao": "Lokal V4L2-kamera"
-,"Loka MMAL-kamerao": "Lokal MMAL-kamera"
-,"Reta kamerao": "Nätverkskamera"
-,"Fora motionEye kamerao": "Fjärrstyrd motionEye-kamera"
-,"Simpla MJPEG-kamerao": "Simpel MJPEG-kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "Typ av kamera som du önskar att lägga till"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "Kamerans URL (t.ex http://example.com:8080/cam/)"
-,"uzantnomo...": "användarnamn ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "användarnamnet för URL:en, om det behövs (t.ex admin)"
-,"pasvorto...": "lösenord ..."
-,"la pasvorto por la URL, se bezonata": "lösenordet för URL:en, om det behövs"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "kameran du önskar att lägga till"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Fjärrstyrd motionEye-kamera är kameror installerad bakom en annan motionEye server. Att lägga till dom här tillåter dig att se och hantera dom fjärrstyrt."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Nätverkskameror (eller IP-kameror) är enheter som strömmar RTSP/RTMP eller MJPEG-videor eller vanliga JPEG-bilder. Läs igenom din enhets manual för att ta reda på den korrekta RTSP, MJPEG eller JPEG URL:en."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokala MMAL kameror är enheter som är direkt anslutna till ditt motionEye system. Dessa är vanligtvis hårdvaruspecifika kameror."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Att lägga till din kamera som en simpel MJPEG-kamera istället för en nätverkskamera kommer att förbättra uppdateringsfrekvensen, men ingen rörelse avkänning, bildtagning eller filminspelning är tillgänglig för den. Kameran måste vara tillgänglig för både din server och webbläsare."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokala V4L2-kameror är kamera enheter som är anslutna direkt till ditt motionEye system, vanligtvis genom USB."
-,"Aldonadi kameraon...": "Lägg till kamera ..."
-,"Grupo": "Grupp"
-,"Inkluzivi foton prenitan ĉiun": "Inkludera en bild tagen varje"
-,"sekundo": "sekund"
-,"5 sekundoj": "5:e sekund"
-,"10 sekundoj": "10:e sekund"
-,"30 sekundoj": "30:e sekund"
-,"minuto": "minut"
-,"5 minutoj": "5:e minut"
-,"10 minutoj": "10:e minut"
-,"30 minutoj": "30:e minut"
-,"horo": "timme"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "välj intervall för tiden mellan två valda bilder."
-,"Filmo framfrekvenco": ""
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "välj hur snabb du vill att timelapse-uppspelningen ska vara."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "med tanke på det stora antalet bilder, skapandet av din timelapse kommer ta ett tag!"
-,"Krei akselita video": "Skapa en timelapse film"
-,"Filmo kreanta en progreso...": "Skapar timelapse film..."
-,"Zipitaj": "Zippad"
-,"Akselita video": "Timelapse"
-,"Forigi ĉiujn": "Ta bort alla"
-,"Bildoj prenitaj de ": "Bilder tagen av "
-,"Filmoj registritaj de ": "Filmer inspelade av "
-,"montru ĉi tiun fotilon plenekranan": "Visa den här kameran i fullskärm"
-,"montri ĉiujn fotilojn": "Visa alla kameror"
-,"montru nur ĉi tiun fotilon": "Visa bara denna kamera"
-,"malfermaj bildoj retumilo": "öppna bildbläddrare"
-,"malferma videoj retumilo": ""
-,"agordi ĉi tiun kameraon": "konfigurera den här kameran"
-,"preni instantaron": "ta en bild"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Du har inte konfigurerat en kamera ännu. Klicka här för att lägga till en…"
-,"enigu pozitivan nombron": "Ange ett positivt nummer"
-,"enigu pozitivan entjeran nombron": ""
-,"enigu nombron": "Ange ett nummer"
-,"enigu entjeran nombron": ""
-," inter ": " emellan "
-," kaj ": " och "
-," pli ol ": " större än "
-," malpli ol ": " mindre än "
-,"enigu validan tempon en la sekva formato: HH:MM": "ange en giltig tid i följande format HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ange en giltig URL (t.ex http://example.com:8080/cams/)"
-,"fermi": "stäng"
-,"Ne": "Nej"
-,"Jes": "Ja"
-,"Bone": "Okej"
-,"Auto Exposure": ""
-,"Backlight Compensation": "Bakgrundsljuskompensation"
-,"Brightness": "Ljusstyrka"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": ""
-,"Exposure Auto": ""
-,"Exposure Auto Priority": ""
-,"Exposure Time Absolute": ""
-,"Focus Absolute": ""
-,"Focus Auto": ""
-,"Gain": ""
-,"Gamma": "Gamma"
-,"Hue": "Hue"
-,"Led1 Mode": ""
-,"Led1 Frequency": ""
-,"Pan Absolute": ""
-,"Power Line Frequency": ""
-,"Saturation": "Mättnad"
-,"Sharpness": "Skärpa"
-,"Tilt Absolute": ""
-,"White Balance Temperature": "Vitbalans temperatur"
-,"White Balance Temperature Auto": ""
-,"Zoom Absolute": ""
+{
+  "": {
+    "language": "sv",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "Särskilda tecken är inte tillåtna i lösenordet",
+  "Ĉi tiu kampo estas deviga": "Detta fält krävs",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "Speciella tecken är inte tillåtna i namnet för kameran",
+  "valoro devas esti multoblo de 8": "värdet måste vara en multipel av 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "Speciella tecken är inte tillåtna i trädmapps namnet",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "filer kan inte skapas direkt i ditt systems rotkatalog",
+  "enigu validan retpoŝtadreson": "Skriv en giltig e-post adress",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "Skriv en lista med komma-separerade giltiga e-postadresser",
+  "specialaj signoj ne rajtas en dosiernomo": "speciella tecken är inte tillåtna i filnamnet",
+  "enigu validan valoron": "Ange ett giltigt värde",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Detta kommer att rekursivt ta bort filer i mappen på din molntjänst \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", inte bara de som laddats upp av motionEye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Detta kommer att rekursivt ta bort äldre media filer som finns i filkatalogen \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", inte bara de som skapats av motionEye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Det går inte att redigera masken utan en giltig kamerabild!",
+  "Propra": "Anpassad",
+  "Propra dosierindiko": "Anpassad sökväg",
+  "Retan kunlokon": "Nätverksdelning",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Din webbläsare implementerar inte denna funktion!",
+  "Apliki": "Tillämpa",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Säkerställ att alla konfigurationsalternativ är giltiga!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Detta kommer att starta om systemet. Fortsätt?",
+  "Vere fermiti sistemon?": "Vill du verkligen stänga av systemet?",
+  "Malŝaltita": "Avstängd",
+  "Ĉu vere restartigi ?": "Vill du verkligen starta om?",
+  "La sistemo rekomencis!": "Systemet har startats om!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Tillämpa de ändrade inställningarna först!",
+  "Neniu fotilo por forigi!": "Ingen kamera att ta bort!",
+  "Ĉu forigi kameraon ": "Ta bort kamera ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye är uppdaterat (nuvarande version: ",
+  "Nova versio havebla: ": "Ny version tillgänglig: ",
+  ". Ĝisdatigi?": ". Uppdatera?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye har uppdaterats!",
+  "Ĝisdatigo malsukcesis!": "Uppdatering misslyckades!",
+  "La ĝisdatiga procezo malsukcesis!": "Uppdateringsprocessen misslyckades!",
+  "Rezerva dosiero": "Backup-fil",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "backup-fil som du laddade ner senast.",
+  "Restaŭrigi Agordon": "Återställ Konfiguration",
+  "Restaŭriganta agordon ...": "Återställer konfigurationen ...",
+  "La agordo restaŭrigis!": "Konfigurationen har återställts!",
+  "Malsukcesis restaŭri la agordon!": "Misslyckades med att återställa konfigurationen!",
+  "Aliri la alŝutan servon malsukcesis: ": "Åtkomst till uppladdningstjänsten misslyckades: ",
+  "Aliri la alŝutan servon sukcesis!": "Åtkomst till uppladdningstjänsten lyckades!",
+  "Sciiga retpoŝto fiaskis:": "Notifikations email misslyckades:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Kontrollera att alla konfigurationsalternativ är korrekta!",
+  "Sciiga Telegramo fiaskis:": "",
+  "Sciiga Telegramo sukcesis!": "",
+  "Aliro al retdividado fiaskis: ": "Åtkomst till utdelad nätverksmapp misslyckades: ",
+  "Aliro al retdividado sukcesis!": "Åtkomst till utdelad nätverksmapp lyckades!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Vill du verkligen ta bort denna fil?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "",
+  "aldonadi kameraon...": "Lägg till kamera ...",
+  "Uzantnomo": "Användarnamn",
+  "Pasvorto": "Lösenord",
+  "Memoru min": "Kom ihåg mig",
+  "Ensaluti": "Logga in",
+  "Nuligi": "Avbryt",
+  "Vi abortis la filmeton.": "Du avbröt videon.",
+  "Reto eraro okazis.": "Ett nätverksfel inträffade.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Formatet stöds inte eller är otillgängligt/olämpligt för uppspelning.",
+  "Nekonata eraro okazis.": "Okänt fel inträffade.",
+  "Eraro : ": "Fel: ",
+  "antaŭa bildo": "Föregående bild",
+  "ludi": "spela",
+  "ludi * 5 kaj enĉenigi": "",
+  "sekva bildo": "nästa bild",
+  "Fermi": "Stäng",
+  "Elŝuti": "Ladda ner",
+  "Forigi": "Ta bort",
+  "Kamerao tipo": "Kamerattyp",
+  "Loka V4L2-kamerao": "Lokal V4L2-kamera",
+  "Loka MMAL-kamerao": "Lokal MMAL-kamera",
+  "Reta kamerao": "Nätverkskamera",
+  "Fora motionEye kamerao": "Fjärrstyrd motionEye-kamera",
+  "Simpla MJPEG-kamerao": "Simpel MJPEG-kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "Typ av kamera som du önskar att lägga till",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://example.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "Kamerans URL (t.ex http://example.com:8080/cam/)",
+  "uzantnomo...": "användarnamn ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "användarnamnet för URL:en, om det behövs (t.ex admin)",
+  "pasvorto...": "lösenord ...",
+  "la pasvorto por la URL, se bezonata": "lösenordet för URL:en, om det behövs",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "kameran du önskar att lägga till",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Fjärrstyrd motionEye-kamera är kameror installerad bakom en annan motionEye server. Att lägga till dom här tillåter dig att se och hantera dom fjärrstyrt.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Nätverkskameror (eller IP-kameror) är enheter som strömmar RTSP/RTMP eller MJPEG-videor eller vanliga JPEG-bilder. Läs igenom din enhets manual för att ta reda på den korrekta RTSP, MJPEG eller JPEG URL:en.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Lokala MMAL kameror är enheter som är direkt anslutna till ditt motionEye system. Dessa är vanligtvis hårdvaruspecifika kameror.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Att lägga till din kamera som en simpel MJPEG-kamera istället för en nätverkskamera kommer att förbättra uppdateringsfrekvensen, men ingen rörelse avkänning, bildtagning eller filminspelning är tillgänglig för den. Kameran måste vara tillgänglig för både din server och webbläsare.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Lokala V4L2-kameror är kamera enheter som är anslutna direkt till ditt motionEye system, vanligtvis genom USB.",
+  "Aldonadi kameraon...": "Lägg till kamera ...",
+  "Grupo": "Grupp",
+  "Inkluzivi foton prenitan ĉiun": "Inkludera en bild tagen varje",
+  "sekundo": "sekund",
+  "5 sekundoj": "5:e sekund",
+  "10 sekundoj": "10:e sekund",
+  "30 sekundoj": "30:e sekund",
+  "minuto": "minut",
+  "5 minutoj": "5:e minut",
+  "10 minutoj": "10:e minut",
+  "30 minutoj": "30:e minut",
+  "horo": "timme",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "välj intervall för tiden mellan två valda bilder.",
+  "Filmo framfrekvenco": "",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "välj hur snabb du vill att timelapse-uppspelningen ska vara.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "med tanke på det stora antalet bilder, skapandet av din timelapse kommer ta ett tag!",
+  "Krei akselita video": "Skapa en timelapse film",
+  "Filmo kreanta en progreso...": "Skapar timelapse film...",
+  "Zipitaj": "Zippad",
+  "Akselita video": "Timelapse",
+  "Forigi ĉiujn": "Ta bort alla",
+  "Bildoj prenitaj de ": "Bilder tagen av ",
+  "Filmoj registritaj de ": "Filmer inspelade av ",
+  "montru ĉi tiun fotilon plenekranan": "Visa den här kameran i fullskärm",
+  "montri ĉiujn fotilojn": "Visa alla kameror",
+  "montru nur ĉi tiun fotilon": "Visa bara denna kamera",
+  "malfermaj bildoj retumilo": "öppna bildbläddrare",
+  "malferma videoj retumilo": "",
+  "agordi ĉi tiun kameraon": "konfigurera den här kameran",
+  "preni instantaron": "ta en bild",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Du har inte konfigurerat en kamera ännu. Klicka här för att lägga till en…",
+  "enigu pozitivan nombron": "Ange ett positivt nummer",
+  "enigu pozitivan entjeran nombron": "",
+  "enigu nombron": "Ange ett nummer",
+  "enigu entjeran nombron": "",
+  " inter ": " emellan ",
+  " kaj ": " och ",
+  " pli ol ": " större än ",
+  " malpli ol ": " mindre än ",
+  "enigu validan tempon en la sekva formato: HH:MM": "ange en giltig tid i följande format HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "ange en giltig URL (t.ex http://example.com:8080/cams/)",
+  "fermi": "stäng",
+  "Ne": "Nej",
+  "Jes": "Ja",
+  "Bone": "Okej",
+  "Auto Exposure": "",
+  "Backlight Compensation": "Bakgrundsljuskompensation",
+  "Brightness": "Ljusstyrka",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "",
+  "Exposure Auto": "",
+  "Exposure Auto Priority": "",
+  "Exposure Time Absolute": "",
+  "Focus Absolute": "",
+  "Focus Auto": "",
+  "Gain": "",
+  "Gamma": "Gamma",
+  "Hue": "Hue",
+  "Led1 Mode": "",
+  "Led1 Frequency": "",
+  "Pan Absolute": "",
+  "Power Line Frequency": "",
+  "Saturation": "Mättnad",
+  "Sharpness": "Skärpa",
+  "Tilt Absolute": "",
+  "White Balance Temperature": "Vitbalans temperatur",
+  "White Balance Temperature Auto": "",
+  "Zoom Absolute": "",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.ta.json
+++ b/motioneye/static/js/motioneye.ta.json
@@ -1,164 +1,176 @@
-{"":{"language":"ta","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "கடவுச்சொல்லில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை"
-,"Ĉi tiu kampo estas deviga": "இந்த புலம் கட்டாயமாகும்"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "கேமராவின் பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை"
-,"valoro devas esti multoblo de 8": "மதிப்பு 8 இன் பெருக்கமாக இருக்க வேண்டும்"
-,"specialaj signoj ne rajtas en radika voja nomo": "ரூட் சாலை பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "உங்கள் கணினியின் மூலத்தில் கோப்புகளை நேரடியாக உருவாக்க முடியாது"
-,"enigu validan retpoŝtadreson": "சரியான மின்னஞ்சல் முகவரியை உள்ளிடவும்"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "கோமா தனி செல்லுபடியாகும் மின்னஞ்சல் முகவரிகளின் பட்டியலை உள்ளிடவும்"
-,"specialaj signoj ne rajtas en dosiernomo": "கோப்பு பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை"
-,"enigu validan valoron": "சரியான மதிப்பை உள்ளிடவும்"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "இந்த மறுநிகழ்வு முகில் கோப்பகத்தில் இருக்கும் அனைத்து கோப்புகளையும் நீக்கும் \""
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", மோசன் பதிவேற்றியவை மட்டுமல்ல!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "இந்த மறுநிகழ்வு கோப்பகத்தில் உள்ள அனைத்து பழைய ஊடக கோப்புகளையும் நீக்கும் \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", மோசன் உருவாக்கியவை மட்டுமல்ல!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "செல்லுபடியாகும் கேமரா படம் இல்லாமல் முகமூடியைத் திருத்த முடியவில்லை!"
-,"Propra": "சொந்தமானது"
-,"Propra dosierindiko": "சொந்த கோப்பு அறிகுறி"
-,"Retan kunlokon": "நிகழ்நிலை கோ -இடம்"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "உங்கள் உலாவி இந்த அம்சத்தை செய்யாது!"
-,"Apliki": "விண்ணப்பிக்கவும்"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "அனைத்து உள்ளமைவு விருப்பங்களும் செல்லுபடியாகும் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "இது கணினியை மீண்டும் தொடங்கும். தொடர?"
-,"Vere fermiti sistemon?": "உண்மையில் ஒரு அமைப்பை மூடியதா?"
-,"Malŝaltita": "அணைக்கப்பட்டது"
-,"Ĉu vere restartigi ?": "உண்மையில் மறுதொடக்கம் செய்யவா?"
-,"La sistemo rekomencis!": "கணினி மீண்டும் தொடங்கியது!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "மாற்றியமைக்கப்பட்ட அமைப்புகளை முதலில் பயன்படுத்துங்கள்!"
-,"Neniu fotilo por forigi!": "அகற்ற கேமரா இல்லை!"
-,"Ĉu forigi kameraon ": "கேமராவை அகற்ற வேண்டுமா "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "மோசன் புதுப்பிக்கப்பட்டுள்ளது (தற்போதைய பதிப்பு: "
-,"Nova versio havebla: ": "புதிய பதிப்பு கிடைக்கிறது: "
-,". Ĝisdatigi?": ". புதுப்பிப்பு?"
-,"motionEye estis sukcese ĝisdatigita!": "மோசன் ஐ வெற்றிகரமாக புதுப்பிக்கப்பட்டுள்ளது!"
-,"Ĝisdatigo malsukcesis!": "புதுப்பிப்பு தோல்வியடைந்தது!"
-,"La ĝisdatiga procezo malsukcesis!": "புதுப்பிப்பு செயல்முறை தோல்வியடைந்தது!"
-,"Rezerva dosiero": "காப்புப்பிரதி கோப்பு"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "நீங்கள் முன்பு பதிவிறக்கிய காப்பு கோப்பு."
-,"Restaŭrigi Agordon": "உள்ளமைவை மீட்டெடுக்கவும்"
-,"Restaŭriganta agordon ...": "அமைப்பை மீட்டமை ..."
-,"La agordo restaŭrigis!": "உள்ளமைவு மீட்டமைக்கப்பட்டுள்ளது!"
-,"Malsukcesis restaŭri la agordon!": "உள்ளமைவை மீட்டெடுப்பதில் தோல்வி!"
-,"Aliri la alŝutan servon malsukcesis: ": "பதிவேற்ற சேவையை அணுக தோல்வியுற்றது: "
-,"Aliri la alŝutan servon sukcesis!": "அணுகல் பதிவேற்ற பணி வெற்றிகரமாக உள்ளது!"
-,"Sciiga retpoŝto fiaskis:": "அறிவிப்பு மின்னஞ்சல் தோல்வியடைந்தது:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "அனைத்து உள்ளமைவு விருப்பங்களும் செல்லுபடியாகும் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்!"
-,"Sciiga Telegramo fiaskis:": "செய்தி தந்தி தோல்வியுற்றது:"
-,"Sciiga Telegramo sukcesis!": "செய்தி தந்தி வெற்றிகரமாக உள்ளது!"
-,"Aliro al retdividado fiaskis: ": "வலை பிரிவுக்கான அணுகல் தோல்வியடைந்துள்ளது: "
-,"Aliro al retdividado sukcesis!": "வலை பிரிவுக்கான அணுகல் வெற்றிகரமாக உள்ளது!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "உண்மையில் இந்த கோப்பை நீக்கவா?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "எல்லா படங்களையும் \"%(group)s\" இலிருந்து நீக்கவா?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "எல்லா திரைப்படங்களையும் \"%(group)s\" இலிருந்து நீக்கவா?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "தொகுக்கப்படாத அனைத்து படங்களையும் நீக்கவா?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "குழுவில் இல்லாத அனைத்து திரைப்படங்களையும் உண்மையில் அகற்றவா?"
-,"aldonadi kameraon...": "ஒரு கேமரா சேர்க்கவும் ..."
-,"Uzantnomo": "பயனர்பெயர்"
-,"Pasvorto": "கடவுச்சொல்"
-,"Memoru min": "என்னை நினைவில் கொள்ளுங்கள்"
-,"Ensaluti": "உள்நுழைக"
-,"Nuligi": "ரத்துசெய்"
-,"Vi abortis la filmeton.": "நீங்கள் வீடியோவை நிறுத்திவிட்டீர்கள்."
-,"Reto eraro okazis.": "பிணைய பிழை ஏற்பட்டது."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "டிகோடிங் பிழை அல்லது முற்போக்கான செயல்பாடு."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "வடிவமைப்பு ஆதரிக்கப்படவில்லை அல்லது கிடைக்கவில்லை/விளையாடுவதற்கு பொருத்தமற்றது."
-,"Nekonata eraro okazis.": "அறியப்படாத பிழை ஏற்பட்டது."
-,"Eraro : ": "பிழை: "
-,"antaŭa bildo": "முந்தைய படம்"
-,"ludi": "விளையாட"
-,"ludi * 5 kaj enĉenigi": "* 5 விளையாடவும் உள்ளே செல்லவும்"
-,"sekva bildo": "அடுத்த படம்"
-,"Fermi": "ஃபெர்மி"
-,"Elŝuti": "பதிவிறக்குங்கள்"
-,"Forigi": "அகற்ற"
-,"Kamerao tipo": "கேமரா வகை"
-,"Loka V4L2-kamerao": "உள்ளக வி 4 எல் 2 கேமரா"
-,"Loka MMAL-kamerao": "Mmal-camer அல்ல"
-,"Reta kamerao": "நிகழ்நிலை கேமரா"
-,"Fora motionEye kamerao": "ஃபோரா மோசன் ஐ கேமரா"
-,"Simpla MJPEG-kamerao": "எளிய"
-,"la speco de kamerao, kiun vi volas aldoni": "நீங்கள் சேர்க்க விரும்பும் கேமரா வகை"
-,"URL": "முகவரி"
-,"http://ekzemplo.com:8765/cams/...": "http://ekzemplo.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "கேமரா முகவரி (எ.கா. http://ekzemplo.com:8080/cam/)"
-,"uzantnomo...": "பயனர்பெயர் ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "தேவைப்பட்டால் (எ.கா. நிர்வாகி) முகவரி க்கான பயனர்பெயர்"
-,"pasvorto...": "கடவுச்சொல் ..."
-,"la pasvorto por la URL, se bezonata": "தேவைப்பட்டால், முகவரி க்கான கடவுச்சொல்"
-,"Kamerao": "கேமரா"
-,"la kameraon, kiun vi volas aldoni": "நீங்கள் சேர்க்க விரும்பும் கேமரா"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "ஃபோரா மோசன் ஐ கேமரா மற்றொரு மோசன்இஇ சேவையகத்தின் பின்னால் நிறுவப்பட்ட கேமராக்கள். அவற்றை இங்கே சேர்ப்பது தூரத்திலிருந்து அவற்றைப் பார்க்கவும் நிர்வகிக்கவும் உங்களை அனுமதிக்கும்."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "வலை கேமராக்கள் (அல்லது ஐபி கேமராக்கள்) என்பது RTSP/RTMP அல்லது MJPEG வீடியோக்கள் அல்லது எளிய JPEG படங்களை பூசும் சாதனங்கள். சரியான முகவரி RTSP, RTMP, MJPEG அல்லது JPEG ஐ அறிய உங்கள் சாதனத்தின் கையேட்டைப் பாருங்கள்."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "உள்ளக MMAL கேமராக்கள் உங்கள் இயக்க அமைப்புடன் நேரடியாக இணைக்கப்பட்ட சாதனங்கள். இவை பொதுவாக அட்டை சார்ந்த கேமராக்கள்."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "நிகழ்நிலை கேமரா புகைப்படத்தை எவ்வாறு மேம்படுத்துகிறது என்பதற்குப் பதிலாக உங்கள் சாதனத்தை எளிய MJPEG கேமராவாகச் சேர்ப்பது, ஆனால் இயக்கக் கண்டறிதல், பட பிடிப்பு அல்லது பதிவு திரைப்படங்கள் எதுவும் கிடைக்காது. உங்கள் சேவையகம் மற்றும் உங்கள் உலாவிக்கு கேமரா அணுகப்பட வேண்டும். இந்த வகை கேமரா இன்டர்நெட் எக்ச்ப்ளோரருடன் பொருந்தவில்லை."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "உள்ளக வி 4 எல் 2 கேமராக்கள் கேமரா சாதனங்கள் ஆகும், இது பொதுவாக யூ.எச்.பி மூலம் உங்கள் இயக்க அமைப்புடன் நேரடியாக இணைக்கப்பட்டுள்ளது."
-,"Aldonadi kameraon...": "ஒரு கேமரா சேர்க்கவும் ..."
-,"Grupo": "குழு"
-,"Inkluzivi foton prenitan ĉiun": "ஒவ்வொன்றும் எடுக்கப்பட்ட புகைப்படத்தை சேர்க்கவும்"
-,"sekundo": "ஒரு இரண்டாவது"
-,"5 sekundoj": "5 விநாடிகள்"
-,"10 sekundoj": "10 வினாடிகள்"
-,"30 sekundoj": "30 வினாடிகள்"
-,"minuto": "நிமிடங்கள்"
-,"5 minutoj": "5 நிமிடங்கள்"
-,"10 minutoj": "10 நிமிடங்கள்"
-,"30 minutoj": "30 நிமிடங்கள்"
-,"horo": "ஓரோ"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "தேர்ந்தெடுக்கப்பட்ட இரண்டு படங்களுக்கு இடையில் நேர வரம்பைத் தேர்ந்தெடுக்கவும்."
-,"Filmo framfrekvenco": "மூவி பிரேம் வீதம்"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "ஆயுதமேந்திய வீடியோ எவ்வளவு விரைவாக இருக்க வேண்டும் என்பதைத் தேர்வுசெய்க."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "அதிக எண்ணிக்கையிலான படங்களைக் கருத்தில் கொண்டு, உங்கள் வீடியோவை உருவாக்க சிறிது நேரம் ஆகலாம்!"
-,"Krei akselita video": "க்ரீ அச்சு வீடியோ"
-,"Filmo kreanta en progreso...": "திரைப்படத்தை உருவாக்குதல் முன்னேற்றத்தில் உள்ளது ..."
-,"Zipitaj": "சிப்"
-,"Akselita video": "அச்சு வீடியோ"
-,"Forigi ĉiujn": "அனைத்தையும் அகற்று"
-,"Bildoj prenitaj de ": "எடுக்கப்பட்ட படங்கள் "
-,"Filmoj registritaj de ": "படங்கள் பதிவு செய்தன "
-,"montru ĉi tiun fotilon plenekranan": "இந்த கேமராவைக் காட்டுங்கள்"
-,"montri ĉiujn fotilojn": "அனைத்து கேமராக்களையும் காட்டு"
-,"montru nur ĉi tiun fotilon": "இந்த கேமராவை மட்டும் காட்டு"
-,"malfermaj bildoj retumilo": "திறந்த படங்கள் உலாவி"
-,"malferma videoj retumilo": "திறந்த வீடியோக்கள் உலாவி"
-,"agordi ĉi tiun kameraon": "இந்த கேமராவை அமைக்கவும்"
-,"preni instantaron": "ஒரு உடனடி எடுக்க"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "நீங்கள் இதுவரை எந்த கேமராவையும் அமைக்கவில்லை. ஒன்றைச் சேர்க்க இங்கே சொடுக்கு செய்க ..."
-,"enigu pozitivan nombron": "நேர்மறை எண்ணை உள்ளிடவும்"
-,"enigu pozitivan entjeran nombron": "நேர்மறை முழு எண் எண்ணை உள்ளிடவும்"
-,"enigu nombron": "ஒரு எண்ணை உள்ளிடவும்"
-,"enigu entjeran nombron": "ஒரு முழு எண் எண்ணை உள்ளிடவும்"
-," inter ": " இடை "
-," kaj ": " மற்றும் "
-," pli ol ": " விட "
-," malpli ol ": " குறைவாக "
-,"enigu validan tempon en la sekva formato: HH:MM": "பின்வரும் வடிவத்தில் செல்லுபடியாகும் நேரத்தை உள்ளிடவும்: HH: மிமீ"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "செல்லுபடியாகும் முகவரி ஐ உள்ளிடவும் (எ.கா. http://ekzemplo.com:8080/cams/)"
-,"fermi": "ஃபெர்மி"
-,"Ne": "அது"
-,"Jes": "செச்"
-,"Bone": "எலும்பு"
-,"Auto Exposure": "ஆட்டோ வெளிப்பாடு"
-,"Backlight Compensation": "பின்னொளி இழப்பீடு"
-,"Brightness": "ஒளி"
-,"Contrast": "மாறுபாடு"
-,"Exposure Absolute": "வெளிப்பாடு முழுமையானது"
-,"Exposure Auto": "வெளிப்பாடு ஆட்டோ"
-,"Exposure Auto Priority": "வெளிப்பாடு ஆட்டோ முன்னுரிமை"
-,"Exposure Time Absolute": "வெளிப்பாடு நேரம் முழுமையானது"
-,"Focus Absolute": "முழுமையான கவனம் செலுத்துங்கள்"
-,"Focus Auto": "ஆட்டோ கவனம்"
-,"Gain": "பெருக்கம்"
-,"Gamma": "காமா"
-,"Hue": "வண்ணச்சாயல்"
-,"Led1 Mode": "LED1 பயன்முறை"
-,"Led1 Frequency": "LED1 அதிர்வெண்"
-,"Pan Absolute": "பான் முழுமையானது"
-,"Power Line Frequency": "ஆற்றல் வரி அதிர்வெண்"
-,"Saturation": "தெவிட்டல்"
-,"Sharpness": "கூர்மையானது"
-,"Tilt Absolute": "முழுமையான சாய்வு"
-,"White Balance Temperature": "வெள்ளை சமநிலை வெப்பநிலை"
-,"White Balance Temperature Auto": "வெள்ளை இருப்பு வெப்பநிலை ஆட்டோ"
-,"Zoom Absolute": "சூம் முழுமையான"
+{
+  "": {
+    "language": "ta",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "கடவுச்சொல்லில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை",
+  "Ĉi tiu kampo estas deviga": "இந்த புலம் கட்டாயமாகும்",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "கேமராவின் பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை",
+  "valoro devas esti multoblo de 8": "மதிப்பு 8 இன் பெருக்கமாக இருக்க வேண்டும்",
+  "specialaj signoj ne rajtas en radika voja nomo": "ரூட் சாலை பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "உங்கள் கணினியின் மூலத்தில் கோப்புகளை நேரடியாக உருவாக்க முடியாது",
+  "enigu validan retpoŝtadreson": "சரியான மின்னஞ்சல் முகவரியை உள்ளிடவும்",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "கோமா தனி செல்லுபடியாகும் மின்னஞ்சல் முகவரிகளின் பட்டியலை உள்ளிடவும்",
+  "specialaj signoj ne rajtas en dosiernomo": "கோப்பு பெயரில் சிறப்பு எழுத்துக்கள் அனுமதிக்கப்படவில்லை",
+  "enigu validan valoron": "சரியான மதிப்பை உள்ளிடவும்",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "இந்த மறுநிகழ்வு முகில் கோப்பகத்தில் இருக்கும் அனைத்து கோப்புகளையும் நீக்கும் \"",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", மோசன் பதிவேற்றியவை மட்டுமல்ல!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "இந்த மறுநிகழ்வு கோப்பகத்தில் உள்ள அனைத்து பழைய ஊடக கோப்புகளையும் நீக்கும் \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", மோசன் உருவாக்கியவை மட்டுமல்ல!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "செல்லுபடியாகும் கேமரா படம் இல்லாமல் முகமூடியைத் திருத்த முடியவில்லை!",
+  "Propra": "சொந்தமானது",
+  "Propra dosierindiko": "சொந்த கோப்பு அறிகுறி",
+  "Retan kunlokon": "நிகழ்நிலை கோ -இடம்",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "உங்கள் உலாவி இந்த அம்சத்தை செய்யாது!",
+  "Apliki": "விண்ணப்பிக்கவும்",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "அனைத்து உள்ளமைவு விருப்பங்களும் செல்லுபடியாகும் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "இது கணினியை மீண்டும் தொடங்கும். தொடர?",
+  "Vere fermiti sistemon?": "உண்மையில் ஒரு அமைப்பை மூடியதா?",
+  "Malŝaltita": "அணைக்கப்பட்டது",
+  "Ĉu vere restartigi ?": "உண்மையில் மறுதொடக்கம் செய்யவா?",
+  "La sistemo rekomencis!": "கணினி மீண்டும் தொடங்கியது!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "மாற்றியமைக்கப்பட்ட அமைப்புகளை முதலில் பயன்படுத்துங்கள்!",
+  "Neniu fotilo por forigi!": "அகற்ற கேமரா இல்லை!",
+  "Ĉu forigi kameraon ": "கேமராவை அகற்ற வேண்டுமா ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "மோசன் புதுப்பிக்கப்பட்டுள்ளது (தற்போதைய பதிப்பு: ",
+  "Nova versio havebla: ": "புதிய பதிப்பு கிடைக்கிறது: ",
+  ". Ĝisdatigi?": ". புதுப்பிப்பு?",
+  "motionEye estis sukcese ĝisdatigita!": "மோசன் ஐ வெற்றிகரமாக புதுப்பிக்கப்பட்டுள்ளது!",
+  "Ĝisdatigo malsukcesis!": "புதுப்பிப்பு தோல்வியடைந்தது!",
+  "La ĝisdatiga procezo malsukcesis!": "புதுப்பிப்பு செயல்முறை தோல்வியடைந்தது!",
+  "Rezerva dosiero": "காப்புப்பிரதி கோப்பு",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "நீங்கள் முன்பு பதிவிறக்கிய காப்பு கோப்பு.",
+  "Restaŭrigi Agordon": "உள்ளமைவை மீட்டெடுக்கவும்",
+  "Restaŭriganta agordon ...": "அமைப்பை மீட்டமை ...",
+  "La agordo restaŭrigis!": "உள்ளமைவு மீட்டமைக்கப்பட்டுள்ளது!",
+  "Malsukcesis restaŭri la agordon!": "உள்ளமைவை மீட்டெடுப்பதில் தோல்வி!",
+  "Aliri la alŝutan servon malsukcesis: ": "பதிவேற்ற சேவையை அணுக தோல்வியுற்றது: ",
+  "Aliri la alŝutan servon sukcesis!": "அணுகல் பதிவேற்ற பணி வெற்றிகரமாக உள்ளது!",
+  "Sciiga retpoŝto fiaskis:": "அறிவிப்பு மின்னஞ்சல் தோல்வியடைந்தது:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "அனைத்து உள்ளமைவு விருப்பங்களும் செல்லுபடியாகும் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்!",
+  "Sciiga Telegramo fiaskis:": "செய்தி தந்தி தோல்வியுற்றது:",
+  "Sciiga Telegramo sukcesis!": "செய்தி தந்தி வெற்றிகரமாக உள்ளது!",
+  "Aliro al retdividado fiaskis: ": "வலை பிரிவுக்கான அணுகல் தோல்வியடைந்துள்ளது: ",
+  "Aliro al retdividado sukcesis!": "வலை பிரிவுக்கான அணுகல் வெற்றிகரமாக உள்ளது!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "உண்மையில் இந்த கோப்பை நீக்கவா?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "எல்லா படங்களையும் \"%(group)s\" இலிருந்து நீக்கவா?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "எல்லா திரைப்படங்களையும் \"%(group)s\" இலிருந்து நீக்கவா?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "தொகுக்கப்படாத அனைத்து படங்களையும் நீக்கவா?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "குழுவில் இல்லாத அனைத்து திரைப்படங்களையும் உண்மையில் அகற்றவா?",
+  "aldonadi kameraon...": "ஒரு கேமரா சேர்க்கவும் ...",
+  "Uzantnomo": "பயனர்பெயர்",
+  "Pasvorto": "கடவுச்சொல்",
+  "Memoru min": "என்னை நினைவில் கொள்ளுங்கள்",
+  "Ensaluti": "உள்நுழைக",
+  "Nuligi": "ரத்துசெய்",
+  "Vi abortis la filmeton.": "நீங்கள் வீடியோவை நிறுத்திவிட்டீர்கள்.",
+  "Reto eraro okazis.": "பிணைய பிழை ஏற்பட்டது.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "டிகோடிங் பிழை அல்லது முற்போக்கான செயல்பாடு.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "வடிவமைப்பு ஆதரிக்கப்படவில்லை அல்லது கிடைக்கவில்லை/விளையாடுவதற்கு பொருத்தமற்றது.",
+  "Nekonata eraro okazis.": "அறியப்படாத பிழை ஏற்பட்டது.",
+  "Eraro : ": "பிழை: ",
+  "antaŭa bildo": "முந்தைய படம்",
+  "ludi": "விளையாட",
+  "ludi * 5 kaj enĉenigi": "* 5 விளையாடவும் உள்ளே செல்லவும்",
+  "sekva bildo": "அடுத்த படம்",
+  "Fermi": "ஃபெர்மி",
+  "Elŝuti": "பதிவிறக்குங்கள்",
+  "Forigi": "அகற்ற",
+  "Kamerao tipo": "கேமரா வகை",
+  "Loka V4L2-kamerao": "உள்ளக வி 4 எல் 2 கேமரா",
+  "Loka MMAL-kamerao": "Mmal-camer அல்ல",
+  "Reta kamerao": "நிகழ்நிலை கேமரா",
+  "Fora motionEye kamerao": "ஃபோரா மோசன் ஐ கேமரா",
+  "Simpla MJPEG-kamerao": "எளிய",
+  "la speco de kamerao, kiun vi volas aldoni": "நீங்கள் சேர்க்க விரும்பும் கேமரா வகை",
+  "URL": "முகவரி",
+  "http://ekzemplo.com:8765/cams/...": "http://ekzemplo.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "கேமரா முகவரி (எ.கா. http://ekzemplo.com:8080/cam/)",
+  "uzantnomo...": "பயனர்பெயர் ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "தேவைப்பட்டால் (எ.கா. நிர்வாகி) முகவரி க்கான பயனர்பெயர்",
+  "pasvorto...": "கடவுச்சொல் ...",
+  "la pasvorto por la URL, se bezonata": "தேவைப்பட்டால், முகவரி க்கான கடவுச்சொல்",
+  "Kamerao": "கேமரா",
+  "la kameraon, kiun vi volas aldoni": "நீங்கள் சேர்க்க விரும்பும் கேமரா",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "ஃபோரா மோசன் ஐ கேமரா மற்றொரு மோசன்இஇ சேவையகத்தின் பின்னால் நிறுவப்பட்ட கேமராக்கள். அவற்றை இங்கே சேர்ப்பது தூரத்திலிருந்து அவற்றைப் பார்க்கவும் நிர்வகிக்கவும் உங்களை அனுமதிக்கும்.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "வலை கேமராக்கள் (அல்லது ஐபி கேமராக்கள்) என்பது RTSP/RTMP அல்லது MJPEG வீடியோக்கள் அல்லது எளிய JPEG படங்களை பூசும் சாதனங்கள். சரியான முகவரி RTSP, RTMP, MJPEG அல்லது JPEG ஐ அறிய உங்கள் சாதனத்தின் கையேட்டைப் பாருங்கள்.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "உள்ளக MMAL கேமராக்கள் உங்கள் இயக்க அமைப்புடன் நேரடியாக இணைக்கப்பட்ட சாதனங்கள். இவை பொதுவாக அட்டை சார்ந்த கேமராக்கள்.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "நிகழ்நிலை கேமரா புகைப்படத்தை எவ்வாறு மேம்படுத்துகிறது என்பதற்குப் பதிலாக உங்கள் சாதனத்தை எளிய MJPEG கேமராவாகச் சேர்ப்பது, ஆனால் இயக்கக் கண்டறிதல், பட பிடிப்பு அல்லது பதிவு திரைப்படங்கள் எதுவும் கிடைக்காது. உங்கள் சேவையகம் மற்றும் உங்கள் உலாவிக்கு கேமரா அணுகப்பட வேண்டும். இந்த வகை கேமரா இன்டர்நெட் எக்ச்ப்ளோரருடன் பொருந்தவில்லை.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "உள்ளக வி 4 எல் 2 கேமராக்கள் கேமரா சாதனங்கள் ஆகும், இது பொதுவாக யூ.எச்.பி மூலம் உங்கள் இயக்க அமைப்புடன் நேரடியாக இணைக்கப்பட்டுள்ளது.",
+  "Aldonadi kameraon...": "ஒரு கேமரா சேர்க்கவும் ...",
+  "Grupo": "குழு",
+  "Inkluzivi foton prenitan ĉiun": "ஒவ்வொன்றும் எடுக்கப்பட்ட புகைப்படத்தை சேர்க்கவும்",
+  "sekundo": "ஒரு இரண்டாவது",
+  "5 sekundoj": "5 விநாடிகள்",
+  "10 sekundoj": "10 வினாடிகள்",
+  "30 sekundoj": "30 வினாடிகள்",
+  "minuto": "நிமிடங்கள்",
+  "5 minutoj": "5 நிமிடங்கள்",
+  "10 minutoj": "10 நிமிடங்கள்",
+  "30 minutoj": "30 நிமிடங்கள்",
+  "horo": "ஓரோ",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "தேர்ந்தெடுக்கப்பட்ட இரண்டு படங்களுக்கு இடையில் நேர வரம்பைத் தேர்ந்தெடுக்கவும்.",
+  "Filmo framfrekvenco": "மூவி பிரேம் வீதம்",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "ஆயுதமேந்திய வீடியோ எவ்வளவு விரைவாக இருக்க வேண்டும் என்பதைத் தேர்வுசெய்க.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "அதிக எண்ணிக்கையிலான படங்களைக் கருத்தில் கொண்டு, உங்கள் வீடியோவை உருவாக்க சிறிது நேரம் ஆகலாம்!",
+  "Krei akselita video": "க்ரீ அச்சு வீடியோ",
+  "Filmo kreanta en progreso...": "திரைப்படத்தை உருவாக்குதல் முன்னேற்றத்தில் உள்ளது ...",
+  "Zipitaj": "சிப்",
+  "Akselita video": "அச்சு வீடியோ",
+  "Forigi ĉiujn": "அனைத்தையும் அகற்று",
+  "Bildoj prenitaj de ": "எடுக்கப்பட்ட படங்கள் ",
+  "Filmoj registritaj de ": "படங்கள் பதிவு செய்தன ",
+  "montru ĉi tiun fotilon plenekranan": "இந்த கேமராவைக் காட்டுங்கள்",
+  "montri ĉiujn fotilojn": "அனைத்து கேமராக்களையும் காட்டு",
+  "montru nur ĉi tiun fotilon": "இந்த கேமராவை மட்டும் காட்டு",
+  "malfermaj bildoj retumilo": "திறந்த படங்கள் உலாவி",
+  "malferma videoj retumilo": "திறந்த வீடியோக்கள் உலாவி",
+  "agordi ĉi tiun kameraon": "இந்த கேமராவை அமைக்கவும்",
+  "preni instantaron": "ஒரு உடனடி எடுக்க",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "நீங்கள் இதுவரை எந்த கேமராவையும் அமைக்கவில்லை. ஒன்றைச் சேர்க்க இங்கே சொடுக்கு செய்க ...",
+  "enigu pozitivan nombron": "நேர்மறை எண்ணை உள்ளிடவும்",
+  "enigu pozitivan entjeran nombron": "நேர்மறை முழு எண் எண்ணை உள்ளிடவும்",
+  "enigu nombron": "ஒரு எண்ணை உள்ளிடவும்",
+  "enigu entjeran nombron": "ஒரு முழு எண் எண்ணை உள்ளிடவும்",
+  " inter ": " இடை ",
+  " kaj ": " மற்றும் ",
+  " pli ol ": " விட ",
+  " malpli ol ": " குறைவாக ",
+  "enigu validan tempon en la sekva formato: HH:MM": "பின்வரும் வடிவத்தில் செல்லுபடியாகும் நேரத்தை உள்ளிடவும்: HH: மிமீ",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "செல்லுபடியாகும் முகவரி ஐ உள்ளிடவும் (எ.கா. http://ekzemplo.com:8080/cams/)",
+  "fermi": "ஃபெர்மி",
+  "Ne": "அது",
+  "Jes": "செச்",
+  "Bone": "எலும்பு",
+  "Auto Exposure": "ஆட்டோ வெளிப்பாடு",
+  "Backlight Compensation": "பின்னொளி இழப்பீடு",
+  "Brightness": "ஒளி",
+  "Contrast": "மாறுபாடு",
+  "Exposure Absolute": "வெளிப்பாடு முழுமையானது",
+  "Exposure Auto": "வெளிப்பாடு ஆட்டோ",
+  "Exposure Auto Priority": "வெளிப்பாடு ஆட்டோ முன்னுரிமை",
+  "Exposure Time Absolute": "வெளிப்பாடு நேரம் முழுமையானது",
+  "Focus Absolute": "முழுமையான கவனம் செலுத்துங்கள்",
+  "Focus Auto": "ஆட்டோ கவனம்",
+  "Gain": "பெருக்கம்",
+  "Gamma": "காமா",
+  "Hue": "வண்ணச்சாயல்",
+  "Led1 Mode": "LED1 பயன்முறை",
+  "Led1 Frequency": "LED1 அதிர்வெண்",
+  "Pan Absolute": "பான் முழுமையானது",
+  "Power Line Frequency": "ஆற்றல் வரி அதிர்வெண்",
+  "Saturation": "தெவிட்டல்",
+  "Sharpness": "கூர்மையானது",
+  "Tilt Absolute": "முழுமையான சாய்வு",
+  "White Balance Temperature": "வெள்ளை சமநிலை வெப்பநிலை",
+  "White Balance Temperature Auto": "வெள்ளை இருப்பு வெப்பநிலை ஆட்டோ",
+  "Zoom Absolute": "சூம் முழுமையான",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.tr.json
+++ b/motioneye/static/js/motioneye.tr.json
@@ -1,164 +1,176 @@
-{"":{"language":"tr","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "şifrede özel karakterlere izin verilmez"
-,"Ĉi tiu kampo estas deviga": "Bu alan zorunludur"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "kamera adı için özel karakterlere izin verilmez"
-,"valoro devas esti multoblo de 8": "değer 8'in katı olmalıdır"
-,"specialaj signoj ne rajtas en radika voja nomo": "kök yol adına özel işaretlere izin verilmez"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "dosyalar doğrudan sisteminizin kök dizininde oluşturulamaz"
-,"enigu validan retpoŝtadreson": "geçerli bir e-posta adresi girin"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "koma'nın ayrı geçerli e-posta adreslerinin bir listesini girin"
-,"specialaj signoj ne rajtas en dosiernomo": "dosya adında özel karakterlere izin verilmez"
-,"enigu validan valoron": "geçerli değeri girin"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Bu, bulut klasöründe bulunan tüm dosyaları yinelemeli olarak silecektir"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", sadece motionEye tarafından yüklenenler değil!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Bu, klasördeki tüm eski medya dosyalarını yinelemeli olarak silecektir \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", sadece motionEye tarafından yaratılanlar değil!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Geçerli bir kamera görüntüsü olmadan maskeyi düzenlemek mümkün değildir!"
-,"Propra": "Özel"
-,"Propra dosierindiko": "Özel dosya göstergesi"
-,"Retan kunlokon": "Ağ ortak konumu"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Tarayıcınız bu işlevi uygulamıyor!"
-,"Apliki": "Uygula"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Tüm yapılandırma seçeneklerinin geçerli olduğundan emin olun!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Bu, sistemi yeniden başlatır. Devam mı?"
-,"Vere fermiti sistemon?": "Gerçekten sistemi kapansın mı?"
-,"Malŝaltita": "Engelli"
-,"Ĉu vere restartigi ?": "Gerçekten bir yeniden başlatılsın mı?"
-,"La sistemo rekomencis!": "Sistem yeniden başlatıldı!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Lütfen önce değiştirilen ayarları uygulayın!"
-,"Neniu fotilo por forigi!": "Silinecek kamera yok!"
-,"Ĉu forigi kameraon ": "Kamerayı sil "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye güncellendi (güncel sürüm: "
-,"Nova versio havebla: ": "Yeni sürüm mevcut: "
-,". Ĝisdatigi?": ". Güncelleme ?"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye başarıyla güncellendi!"
-,"Ĝisdatigo malsukcesis!": "Güncelleme başarısız oldu!"
-,"La ĝisdatiga procezo malsukcesis!": "Güncelleme işlemi başarısız oldu!"
-,"Rezerva dosiero": "Yedek dosya"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Daha önce indirdiğiniz yedekleme dosyası."
-,"Restaŭrigi Agordon": "Yapılandırmayı Geri Yükle"
-,"Restaŭriganta agordon ...": "Yapılandırma geri yükleniyor..."
-,"La agordo restaŭrigis!": "Ayar geri yüklendi!"
-,"Malsukcesis restaŭri la agordon!": "Yapılandırma geri yüklenemedi!"
-,"Aliri la alŝutan servon malsukcesis: ": "Yükleme hizmetine erişim başarısız oldu: "
-,"Aliri la alŝutan servon sukcesis!": "Yükleme hizmetine erişim başarılı oldu!"
-,"Sciiga retpoŝto fiaskis:": "Bildirim e-postası başarısız oldu:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Tüm yapılandırma seçeneklerinin, geçerli olduğundan emin olun!"
-,"Sciiga Telegramo fiaskis:": "Telegram Bildirimi başarısız oldu:"
-,"Sciiga Telegramo sukcesis!": "Telegram Bildirimi başarılı oldu!"
-,"Aliro al retdividado fiaskis: ": "Ağ paylaşımına erişim başarısız oldu: "
-,"Aliro al retdividado sukcesis!": "Ağ paylaşımına erişim başarılı!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Bu dosyayı gerçekten silmek istiyor musunuz?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "\"%(group)s\" grubundaki tüm görseller gerçekten silinsin mi?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "\"%(group)s\" grubundaki tüm filmler gerçekten silinsin mi?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Gruplandırılmamış tüm görseller gerçekten silinsin mi?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Gruplandırılmamış tüm filmler gerçekten silinsin mi?"
-,"aldonadi kameraon...": "Kamera Ekle..."
-,"Uzantnomo": "Kullanıcı Adı"
-,"Pasvorto": "Şifre"
-,"Memoru min": "Beni hatırla"
-,"Ensaluti": "Giriş"
-,"Nuligi": "İptal"
-,"Vi abortis la filmeton.": "Videoyu iptal ettiniz."
-,"Reto eraro okazis.": "Bir ağ hatası oluştu."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Kod çözme hatası veya eksik işlev."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format desteklenmiyor veya kullanılamıyor/oynatmak için uygun değil."
-,"Nekonata eraro okazis.": "Bilinmeyen bir hata oluştu."
-,"Eraro : ": "Hata : "
-,"antaŭa bildo": "önceki resim"
-,"ludi": "oynat"
-,"ludi * 5 kaj enĉenigi": "*5 oyna ve zincir çek"
-,"sekva bildo": "sonraki resim"
-,"Fermi": "Kapat"
-,"Elŝuti": "İndir"
-,"Forigi": "Kaldır"
-,"Kamerao tipo": "Kamera Tipi"
-,"Loka V4L2-kamerao": "Yerel V4L2 kamera"
-,"Loka MMAL-kamerao": "Yerel MMAL kamera"
-,"Reta kamerao": "Web kamerası"
-,"Fora motionEye kamerao": "Uzaktan motionEye kamerası"
-,"Simpla MJPEG-kamerao": "Basit bir MJPEG kamera"
-,"la speco de kamerao, kiun vi volas aldoni": "eklemek istediğiniz kamera türü"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://ornek.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kamera URL'si (örneğin, http://ornek.com:8080/cam/)"
-,"uzantnomo...": "Kullanıcı adı..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "gerekli, URL'nin kullanıcı adı (örn. admin)"
-,"pasvorto...": "şifre..."
-,"la pasvorto por la URL, se bezonata": "gerekli, URL'nin şifresi"
-,"Kamerao": "Kamera"
-,"la kameraon, kiun vi volas aldoni": "eklemek istediğiniz kamera"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Remote motionEye kameraları, başka bir MotionEye sunucusunun arkasına kurulan kameralardır. Bunları buraya eklemek, onları uzaktan görüntülemenize ve yönetmenize olanak tanır."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Ağ kameraları (veya IP kameraları), RTSP/RTMP veya MJPEG videolarını veya düz JPEG görüntülerini yerel olarak yayınlayan cihazlardır. Doğru RTSP, RTMP, MJPEG veya JPEG URL'sini bulmak için cihazınızın kılavuzuna bakın."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Yerel MMAL kameralar doğrudan motionEye sisteminize bağlı cihazlardır. Bunlar genellikle karta özel kameralardır."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Cihazınızı web kamerası yerine basit bir MJPEG kamera olarak eklemek, fotoğrafçılığı iyileştirecektir ancak hareket algılama, görüntü yakalama veya film kaydı mümkün olmayacaktır. Kameranın sunucunuz ve tarayıcınız tarafından erişilebilir olması gerekir. Bu kamera türü Internet Explorer ile uyumlu değildir."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Yerel V4L2 kameralar, genellikle USB aracılığıyla motionEye sisteminize doğrudan bağlanan kamera cihazlarıdır."
-,"Aldonadi kameraon...": "Bir kamera ekleyin..."
-,"Grupo": "Grup"
-,"Inkluzivi foton prenitan ĉiun": "Her birinin çekilmiş bir fotoğrafını ekleyin"
-,"sekundo": "bir saniye"
-,"5 sekundoj": "5 saniye"
-,"10 sekundoj": "10 saniye"
-,"30 sekundoj": "30 saniye"
-,"minuto": "Bir dakika"
-,"5 minutoj": "5 dakika"
-,"10 minutoj": "10 dakika"
-,"30 minutoj": "30 dakika"
-,"horo": "saat"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seçilen iki görüntü arasındaki zaman aralığını seçin."
-,"Filmo framfrekvenco": "Film kare hızı"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Sıkıştırılmış videonun ne kadar hızlı olmasını istediğinizi seçin."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Çok sayıda görsel göz önüne alındığında, videonuzu oluşturmak biraz zaman alabilir!"
-,"Krei akselita video": "Animasyonlu bir video oluşturun"
-,"Filmo kreanta en progreso...": "Film yapımı sürüyor…"
-,"Zipitaj": "sıkıştırılmış"
-,"Akselita video": "Hızlandırılmış video"
-,"Forigi ĉiujn": "Hepsini sil"
-,"Bildoj prenitaj de ": "Resimler şuradan alınmıştır: "
-,"Filmoj registritaj de ": "tarafından kaydedilen filmler, "
-,"montru ĉi tiun fotilon plenekranan": "bu kamerayı tam ekran göster"
-,"montri ĉiujn fotilojn": "tüm kameraları göster"
-,"montru nur ĉi tiun fotilon": "yalnızca bu kamerayı göster"
-,"malfermaj bildoj retumilo": "resim tarayıcısını aç"
-,"malferma videoj retumilo": "video tarayıcısını aç"
-,"agordi ĉi tiun kameraon": "bu kamerayı yapılandır"
-,"preni instantaron": "örnek al"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Henüz herhangi bir kamerayı yapılandırmadınız. Eklemek için buraya tıklayın..."
-,"enigu pozitivan nombron": "pozitif bir sayı girin"
-,"enigu pozitivan entjeran nombron": "pozitif bir tam sayı girin"
-,"enigu nombron": "bir sayı girin"
-,"enigu entjeran nombron": "bir tam sayı girin"
-," inter ": " arasında "
-," kaj ": " ve "
-," pli ol ": " bundan fazla "
-," malpli ol ": " daha az "
-,"enigu validan tempon en la sekva formato: HH:MM": "şu formatta geçerli bir zaman girin: SS:DD"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "geçerli bir URL girin (ör. http://ornek.com:8080/cams/)"
-,"fermi": "kapat"
-,"Ne": "Hayır"
-,"Jes": "Evet"
-,"Bone": "Tamam."
-,"Auto Exposure": "Otomatik Pozlama"
-,"Backlight Compensation": "Arka Işık Telafisi"
-,"Brightness": "Parlaklık"
-,"Contrast": "Kontrast"
-,"Exposure Absolute": "Mutlak Pozlama"
-,"Exposure Auto": "Otomatik-Pozlama"
-,"Exposure Auto Priority": "Pozlama Otomatik Önceliği"
-,"Exposure Time Absolute": "Mutlak Maruz Kalma Süresi"
-,"Focus Absolute": "Odak Kesinliği"
-,"Focus Auto": "Oto Fokus"
-,"Gain": "Kazanç"
-,"Gamma": "Gama"
-,"Hue": "Hue."
-,"Led1 Mode": "Led1 Modu"
-,"Led1 Frequency": "Led1 Frekansı"
-,"Pan Absolute": "Mutlak Pan"
-,"Power Line Frequency": "Güç Hattı Frekansı"
-,"Saturation": "Doyum"
-,"Sharpness": "Keskinlik"
-,"Tilt Absolute": "Kesinlik Eğilimi"
-,"White Balance Temperature": "Beyaz Dengesi Sıcaklığı"
-,"White Balance Temperature Auto": "Otomatik Beyaz Dengesi Sıcaklığı"
-,"Zoom Absolute": "Yakınlaştırma Eğilimi"
+{
+  "": {
+    "language": "tr",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "şifrede özel karakterlere izin verilmez",
+  "Ĉi tiu kampo estas deviga": "Bu alan zorunludur",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "kamera adı için özel karakterlere izin verilmez",
+  "valoro devas esti multoblo de 8": "değer 8'in katı olmalıdır",
+  "specialaj signoj ne rajtas en radika voja nomo": "kök yol adına özel işaretlere izin verilmez",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "dosyalar doğrudan sisteminizin kök dizininde oluşturulamaz",
+  "enigu validan retpoŝtadreson": "geçerli bir e-posta adresi girin",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "koma'nın ayrı geçerli e-posta adreslerinin bir listesini girin",
+  "specialaj signoj ne rajtas en dosiernomo": "dosya adında özel karakterlere izin verilmez",
+  "enigu validan valoron": "geçerli değeri girin",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Bu, bulut klasöründe bulunan tüm dosyaları yinelemeli olarak silecektir",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", sadece motionEye tarafından yüklenenler değil!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Bu, klasördeki tüm eski medya dosyalarını yinelemeli olarak silecektir \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", sadece motionEye tarafından yaratılanlar değil!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Geçerli bir kamera görüntüsü olmadan maskeyi düzenlemek mümkün değildir!",
+  "Propra": "Özel",
+  "Propra dosierindiko": "Özel dosya göstergesi",
+  "Retan kunlokon": "Ağ ortak konumu",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Tarayıcınız bu işlevi uygulamıyor!",
+  "Apliki": "Uygula",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Tüm yapılandırma seçeneklerinin geçerli olduğundan emin olun!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Bu, sistemi yeniden başlatır. Devam mı?",
+  "Vere fermiti sistemon?": "Gerçekten sistemi kapansın mı?",
+  "Malŝaltita": "Engelli",
+  "Ĉu vere restartigi ?": "Gerçekten bir yeniden başlatılsın mı?",
+  "La sistemo rekomencis!": "Sistem yeniden başlatıldı!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Lütfen önce değiştirilen ayarları uygulayın!",
+  "Neniu fotilo por forigi!": "Silinecek kamera yok!",
+  "Ĉu forigi kameraon ": "Kamerayı sil ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye güncellendi (güncel sürüm: ",
+  "Nova versio havebla: ": "Yeni sürüm mevcut: ",
+  ". Ĝisdatigi?": ". Güncelleme ?",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye başarıyla güncellendi!",
+  "Ĝisdatigo malsukcesis!": "Güncelleme başarısız oldu!",
+  "La ĝisdatiga procezo malsukcesis!": "Güncelleme işlemi başarısız oldu!",
+  "Rezerva dosiero": "Yedek dosya",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Daha önce indirdiğiniz yedekleme dosyası.",
+  "Restaŭrigi Agordon": "Yapılandırmayı Geri Yükle",
+  "Restaŭriganta agordon ...": "Yapılandırma geri yükleniyor...",
+  "La agordo restaŭrigis!": "Ayar geri yüklendi!",
+  "Malsukcesis restaŭri la agordon!": "Yapılandırma geri yüklenemedi!",
+  "Aliri la alŝutan servon malsukcesis: ": "Yükleme hizmetine erişim başarısız oldu: ",
+  "Aliri la alŝutan servon sukcesis!": "Yükleme hizmetine erişim başarılı oldu!",
+  "Sciiga retpoŝto fiaskis:": "Bildirim e-postası başarısız oldu:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Tüm yapılandırma seçeneklerinin, geçerli olduğundan emin olun!",
+  "Sciiga Telegramo fiaskis:": "Telegram Bildirimi başarısız oldu:",
+  "Sciiga Telegramo sukcesis!": "Telegram Bildirimi başarılı oldu!",
+  "Aliro al retdividado fiaskis: ": "Ağ paylaşımına erişim başarısız oldu: ",
+  "Aliro al retdividado sukcesis!": "Ağ paylaşımına erişim başarılı!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Bu dosyayı gerçekten silmek istiyor musunuz?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "\"%(group)s\" grubundaki tüm görseller gerçekten silinsin mi?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "\"%(group)s\" grubundaki tüm filmler gerçekten silinsin mi?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Gruplandırılmamış tüm görseller gerçekten silinsin mi?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Gruplandırılmamış tüm filmler gerçekten silinsin mi?",
+  "aldonadi kameraon...": "Kamera Ekle...",
+  "Uzantnomo": "Kullanıcı Adı",
+  "Pasvorto": "Şifre",
+  "Memoru min": "Beni hatırla",
+  "Ensaluti": "Giriş",
+  "Nuligi": "İptal",
+  "Vi abortis la filmeton.": "Videoyu iptal ettiniz.",
+  "Reto eraro okazis.": "Bir ağ hatası oluştu.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Kod çözme hatası veya eksik işlev.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Format desteklenmiyor veya kullanılamıyor/oynatmak için uygun değil.",
+  "Nekonata eraro okazis.": "Bilinmeyen bir hata oluştu.",
+  "Eraro : ": "Hata : ",
+  "antaŭa bildo": "önceki resim",
+  "ludi": "oynat",
+  "ludi * 5 kaj enĉenigi": "*5 oyna ve zincir çek",
+  "sekva bildo": "sonraki resim",
+  "Fermi": "Kapat",
+  "Elŝuti": "İndir",
+  "Forigi": "Kaldır",
+  "Kamerao tipo": "Kamera Tipi",
+  "Loka V4L2-kamerao": "Yerel V4L2 kamera",
+  "Loka MMAL-kamerao": "Yerel MMAL kamera",
+  "Reta kamerao": "Web kamerası",
+  "Fora motionEye kamerao": "Uzaktan motionEye kamerası",
+  "Simpla MJPEG-kamerao": "Basit bir MJPEG kamera",
+  "la speco de kamerao, kiun vi volas aldoni": "eklemek istediğiniz kamera türü",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://ornek.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "kamera URL'si (örneğin, http://ornek.com:8080/cam/)",
+  "uzantnomo...": "Kullanıcı adı...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "gerekli, URL'nin kullanıcı adı (örn. admin)",
+  "pasvorto...": "şifre...",
+  "la pasvorto por la URL, se bezonata": "gerekli, URL'nin şifresi",
+  "Kamerao": "Kamera",
+  "la kameraon, kiun vi volas aldoni": "eklemek istediğiniz kamera",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Remote motionEye kameraları, başka bir MotionEye sunucusunun arkasına kurulan kameralardır. Bunları buraya eklemek, onları uzaktan görüntülemenize ve yönetmenize olanak tanır.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Ağ kameraları (veya IP kameraları), RTSP/RTMP veya MJPEG videolarını veya düz JPEG görüntülerini yerel olarak yayınlayan cihazlardır. Doğru RTSP, RTMP, MJPEG veya JPEG URL'sini bulmak için cihazınızın kılavuzuna bakın.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Yerel MMAL kameralar doğrudan motionEye sisteminize bağlı cihazlardır. Bunlar genellikle karta özel kameralardır.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Cihazınızı web kamerası yerine basit bir MJPEG kamera olarak eklemek, fotoğrafçılığı iyileştirecektir ancak hareket algılama, görüntü yakalama veya film kaydı mümkün olmayacaktır. Kameranın sunucunuz ve tarayıcınız tarafından erişilebilir olması gerekir. Bu kamera türü Internet Explorer ile uyumlu değildir.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Yerel V4L2 kameralar, genellikle USB aracılığıyla motionEye sisteminize doğrudan bağlanan kamera cihazlarıdır.",
+  "Aldonadi kameraon...": "Bir kamera ekleyin...",
+  "Grupo": "Grup",
+  "Inkluzivi foton prenitan ĉiun": "Her birinin çekilmiş bir fotoğrafını ekleyin",
+  "sekundo": "bir saniye",
+  "5 sekundoj": "5 saniye",
+  "10 sekundoj": "10 saniye",
+  "30 sekundoj": "30 saniye",
+  "minuto": "Bir dakika",
+  "5 minutoj": "5 dakika",
+  "10 minutoj": "10 dakika",
+  "30 minutoj": "30 dakika",
+  "horo": "saat",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Seçilen iki görüntü arasındaki zaman aralığını seçin.",
+  "Filmo framfrekvenco": "Film kare hızı",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Sıkıştırılmış videonun ne kadar hızlı olmasını istediğinizi seçin.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Çok sayıda görsel göz önüne alındığında, videonuzu oluşturmak biraz zaman alabilir!",
+  "Krei akselita video": "Animasyonlu bir video oluşturun",
+  "Filmo kreanta en progreso...": "Film yapımı sürüyor…",
+  "Zipitaj": "sıkıştırılmış",
+  "Akselita video": "Hızlandırılmış video",
+  "Forigi ĉiujn": "Hepsini sil",
+  "Bildoj prenitaj de ": "Resimler şuradan alınmıştır: ",
+  "Filmoj registritaj de ": "tarafından kaydedilen filmler, ",
+  "montru ĉi tiun fotilon plenekranan": "bu kamerayı tam ekran göster",
+  "montri ĉiujn fotilojn": "tüm kameraları göster",
+  "montru nur ĉi tiun fotilon": "yalnızca bu kamerayı göster",
+  "malfermaj bildoj retumilo": "resim tarayıcısını aç",
+  "malferma videoj retumilo": "video tarayıcısını aç",
+  "agordi ĉi tiun kameraon": "bu kamerayı yapılandır",
+  "preni instantaron": "örnek al",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Henüz herhangi bir kamerayı yapılandırmadınız. Eklemek için buraya tıklayın...",
+  "enigu pozitivan nombron": "pozitif bir sayı girin",
+  "enigu pozitivan entjeran nombron": "pozitif bir tam sayı girin",
+  "enigu nombron": "bir sayı girin",
+  "enigu entjeran nombron": "bir tam sayı girin",
+  " inter ": " arasında ",
+  " kaj ": " ve ",
+  " pli ol ": " bundan fazla ",
+  " malpli ol ": " daha az ",
+  "enigu validan tempon en la sekva formato: HH:MM": "şu formatta geçerli bir zaman girin: SS:DD",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "geçerli bir URL girin (ör. http://ornek.com:8080/cams/)",
+  "fermi": "kapat",
+  "Ne": "Hayır",
+  "Jes": "Evet",
+  "Bone": "Tamam.",
+  "Auto Exposure": "Otomatik Pozlama",
+  "Backlight Compensation": "Arka Işık Telafisi",
+  "Brightness": "Parlaklık",
+  "Contrast": "Kontrast",
+  "Exposure Absolute": "Mutlak Pozlama",
+  "Exposure Auto": "Otomatik-Pozlama",
+  "Exposure Auto Priority": "Pozlama Otomatik Önceliği",
+  "Exposure Time Absolute": "Mutlak Maruz Kalma Süresi",
+  "Focus Absolute": "Odak Kesinliği",
+  "Focus Auto": "Oto Fokus",
+  "Gain": "Kazanç",
+  "Gamma": "Gama",
+  "Hue": "Hue.",
+  "Led1 Mode": "Led1 Modu",
+  "Led1 Frequency": "Led1 Frekansı",
+  "Pan Absolute": "Mutlak Pan",
+  "Power Line Frequency": "Güç Hattı Frekansı",
+  "Saturation": "Doyum",
+  "Sharpness": "Keskinlik",
+  "Tilt Absolute": "Kesinlik Eğilimi",
+  "White Balance Temperature": "Beyaz Dengesi Sıcaklığı",
+  "White Balance Temperature Auto": "Otomatik Beyaz Dengesi Sıcaklığı",
+  "Zoom Absolute": "Yakınlaştırma Eğilimi",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.uk.json
+++ b/motioneye/static/js/motioneye.uk.json
@@ -1,164 +1,176 @@
-{"":{"language":"uk","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "Спеціальні символи заборонені у паролі"
-,"Ĉi tiu kampo estas deviga": "Це поле є обов'язковим"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "Спеціальні символи заборонені від імені камери"
-,"valoro devas esti multoblo de 8": "Значення повинно бути кратним 8"
-,"specialaj signoj ne rajtas en radika voja nomo": "Спеціальні символи заборонені в назві Root Road"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Файли не можуть бути створені безпосередньо в корені вашої системи"
-,"enigu validan retpoŝtadreson": "Введіть дійсну електронну адресу"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "Введіть список окремих дійсних адрес електронної пошти"
-,"specialaj signoj ne rajtas en dosiernomo": "Спеціальні персонажі заборонені в імені файлу"
-,"enigu validan valoron": "Введіть дійсне значення"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Це буде рекурсивно видалити всі файли, присутні у хмарній папці »"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "\", не лише тих, хто завантажив Motioneye!"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ця рекурсія видаляє всі старі медіа -файли в каталозі \""
-,"\", ne nur tiuj kreitaj de motionEye!": "\", не тільки ті, створені Motioneye!"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "Не в змозі редагувати маску без дійсного зображення камери!"
-,"Propra": "Власний"
-,"Propra dosierindiko": "Власна індикація файлів"
-,"Retan kunlokon": "Онлайн -розташування"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "Ваш браузер не виконує цю функцію!"
-,"Apliki": "застосувати"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "Переконайтесь, що всі параметри конфігурації дійсні!"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "Це відновить систему. Продовжувати?"
-,"Vere fermiti sistemon?": "Справді закрили систему?"
-,"Malŝaltita": "Вимкнений"
-,"Ĉu vere restartigi ?": "Дійсно перезапустити?"
-,"La sistemo rekomencis!": "Система відновилася!"
-,"Bonvolu apliki unue la modifitajn agordojn!": "Будь ласка, спочатку застосуйте модифіковані налаштування!"
-,"Neniu fotilo por forigi!": "Ніякої камери для видалення!"
-,"Ĉu forigi kameraon ": "Чи зняти камеру "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "Motioneye оновлюється (Поточна версія: "
-,"Nova versio havebla: ": "Доступна нова версія: "
-,". Ĝisdatigi?": ". Оновлення?"
-,"motionEye estis sukcese ĝisdatigita!": "Motioneye успішно оновлюється!"
-,"Ĝisdatigo malsukcesis!": "Оновлення не вдалося!"
-,"La ĝisdatiga procezo malsukcesis!": "Процес оновлення не вдалося!"
-,"Rezerva dosiero": "Файл резервного копіювання"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "Файл резервного копіювання, який ви раніше завантажували."
-,"Restaŭrigi Agordon": "Відновити конфігурацію"
-,"Restaŭriganta agordon ...": "Налаштування відновлення ..."
-,"La agordo restaŭrigis!": "Конфігурація була відновлена!"
-,"Malsukcesis restaŭri la agordon!": "Не вдалося відновити конфігурацію!"
-,"Aliri la alŝutan servon malsukcesis: ": "Для доступу до служби завантаження не вдалося: "
-,"Aliri la alŝutan servon sukcesis!": "Доступ до послуги завантаження був успішним!"
-,"Sciiga retpoŝto fiaskis:": "Не вдалося повідомити електронну пошту:"
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Переконайтесь, що всі параметри конфігурації дійсні!"
-,"Sciiga Telegramo fiaskis:": "Новини Telegram не вдалося:"
-,"Sciiga Telegramo sukcesis!": "Новини Телеграма була успішною!"
-,"Aliro al retdividado fiaskis: ": "Доступ до веб -підрозділу не вдався: "
-,"Aliro al retdividado sukcesis!": "Доступ до веб -підрозділу був успішним!"
-,"Ĉu vere forigi ĉi tiun dosieron?": "Дійсно видалити цей файл?"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Дійсно видалить усі зображення з \"%(групи) S\"?"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Дійсно видалити всі фільми з \"%(групи) S\"?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Дійсно видалити всі не згруповані зображення?"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Дійсно видалити всі не згруповані фільми?"
-,"aldonadi kameraon...": "Додайте камеру ..."
-,"Uzantnomo": "Ім'я користувача"
-,"Pasvorto": "Пароль"
-,"Memoru min": "Пам'ятай мене"
-,"Ensaluti": "Увійти"
-,"Nuligi": "Скасувати"
-,"Vi abortis la filmeton.": "Ви перервали відео."
-,"Reto eraro okazis.": "Сталася помилка мережі."
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "Помилка декодування або непрогресивна функція."
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Формат, не підтримується або недоступний/невідповідний для гри."
-,"Nekonata eraro okazis.": "Сталася невідома помилка."
-,"Eraro : ": "Помилка: "
-,"antaŭa bildo": "Попереднє зображення"
-,"ludi": "грати"
-,"ludi * 5 kaj enĉenigi": "грати * 5 і потрапити"
-,"sekva bildo": "Наступна картина"
-,"Fermi": "Закрити"
-,"Elŝuti": "Завантажувати"
-,"Forigi": "Видалити"
-,"Kamerao tipo": "Тип камери"
-,"Loka V4L2-kamerao": "Місцева камера V4L2"
-,"Loka MMAL-kamerao": "Місцева камера ммаль"
-,"Reta kamerao": "Інтернет -камера"
-,"Fora motionEye kamerao": "Камера далекого руху"
-,"Simpla MJPEG-kamerao": "Проста камера MJPEG"
-,"la speco de kamerao, kiun vi volas aldoni": "Тип камери, який ви хочете додати"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http: //ekzemplo.com: 8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL -адреса камери (наприклад, http://ekzemplo.com:8080/cam/)"
-,"uzantnomo...": "Ім'я користувача ..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "Ім'я користувача для URL -адреси, якщо потрібно (наприклад, адміністратор)"
-,"pasvorto...": "Пароль ..."
-,"la pasvorto por la URL, se bezonata": "Пароль для URL -адреси, якщо потрібно"
-,"Kamerao": "Камера"
-,"la kameraon, kiun vi volas aldoni": "камера, яку ви хочете додати"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Камера Fora Motioney - це камери, встановлені за іншим сервером Motioneye. Додавання їх тут дозволить вам шукати та керувати ними здалеку."
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Веб -камери (або IP -камери) - це пристрої, які означають відео RTSP/RTMP або MJPEG або прості зображення JPEG. Зверніться до посібника свого пристрою, щоб дізнатися правильну URL -адресу RTSP, RTMP, MJPEG або JPEG."
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Місцеві камери MMAL - це пристрої, підключені безпосередньо до вашої системи Motioneye. Зазвичай це камери, що стосуються карт."
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Додавання вашого пристрою як просту камеру MJPEG замість того, як онлайн -камера покращить фотографію, але для неї не буде доступне виявлення руху, зйомки зображень чи запису фільмів. Камера повинна бути доступною для вашого сервера та вашого браузера. Цей тип камери не відповідає Internet Explorer."
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Місцеві камери V4L2 - це пристрої камери, підключені безпосередньо до вашої системи Motioneye, як правило, через USB."
-,"Aldonadi kameraon...": "Додайте камеру ..."
-,"Grupo": "Група"
-,"Inkluzivi foton prenitan ĉiun": "Включіть фотографію, зроблене кожним"
-,"sekundo": "секунда"
-,"5 sekundoj": "5 секунд"
-,"10 sekundoj": "10 секунд"
-,"30 sekundoj": "30 секунд"
-,"minuto": "хвилина"
-,"5 minutoj": "5 хвилин"
-,"10 minutoj": "10 хвилин"
-,"30 minutoj": "30 хвилин"
-,"horo": "година"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "Виберіть діапазон часу між двома вибраними зображеннями."
-,"Filmo framfrekvenco": "Швидкість кадру фільму"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "Виберіть, наскільки швидко ви хочете, щоб озброєне відео було."
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Враховуючи велику кількість фотографій, створення вашого відео може зайняти деякий час!"
-,"Krei akselita video": "Створіть озброєне відео"
-,"Filmo kreanta en progreso...": "Фільми, що створює в процесі ..."
-,"Zipitaj": "Застеблений"
-,"Akselita video": "Закріплене відео"
-,"Forigi ĉiujn": "Видалити все"
-,"Bildoj prenitaj de ": "Зображення, зроблені "
-,"Filmoj registritaj de ": "Фільми, записані "
-,"montru ĉi tiun fotilon plenekranan": "Покажіть цю камеру на повний екран"
-,"montri ĉiujn fotilojn": "Показати всі камери"
-,"montru nur ĉi tiun fotilon": "Покажіть лише цю камеру"
-,"malfermaj bildoj retumilo": "Відкриті картинки браузер"
-,"malferma videoj retumilo": "Відкрийте веб -переглядач"
-,"agordi ĉi tiun kameraon": "Встановіть цю камеру"
-,"preni instantaron": "прийняти миттєво"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ви ще не встановили жодної камери. Клацніть тут, щоб додати один ..."
-,"enigu pozitivan nombron": "Введіть додатковий номер"
-,"enigu pozitivan entjeran nombron": "Введіть позитивне ціле число"
-,"enigu nombron": "Введіть номер"
-,"enigu entjeran nombron": "Введіть цілий номер"
-," inter ": " між "
-," kaj ": " і "
-," pli ol ": " більше ніж "
-," malpli ol ": " менше ніж "
-,"enigu validan tempon en la sekva formato: HH:MM": "Введіть дійсний час у такому форматі: HH: MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Введіть дійсну URL -адресу (наприклад, http://ekzemplo.com:8080/cams/)"
-,"fermi": "закрити"
-,"Ne": "Ні"
-,"Jes": "Так"
-,"Bone": "В порядку"
-,"Auto Exposure": "Автоматичне опромінення"
-,"Backlight Compensation": "Компенсація підсвічування"
-,"Brightness": "Яскравість"
-,"Contrast": "Протиставляти"
-,"Exposure Absolute": "Експозиція абсолютно"
-,"Exposure Auto": "Експозиція автоматично"
-,"Exposure Auto Priority": "Експозиція Авто -пріоритет"
-,"Exposure Time Absolute": "Час експозиції абсолютно"
-,"Focus Absolute": "Зосередитись абсолютно"
-,"Focus Auto": "Фокус автоматично"
-,"Gain": "Виграш"
-,"Gamma": "Гамма"
-,"Hue": "Відтінок"
-,"Led1 Mode": "Режим LED1"
-,"Led1 Frequency": "Частота LED1"
-,"Pan Absolute": "Пан абсолютно"
-,"Power Line Frequency": "Частота лінії електропередач"
-,"Saturation": "Насичення"
-,"Sharpness": "Різкість"
-,"Tilt Absolute": "Нахил абсолютно"
-,"White Balance Temperature": "Температура балансу білого"
-,"White Balance Temperature Auto": "Температура балансу білого автоматично"
-,"Zoom Absolute": "Збільшити абсолютно"
+{
+  "": {
+    "language": "uk",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "Спеціальні символи заборонені у паролі",
+  "Ĉi tiu kampo estas deviga": "Це поле є обов'язковим",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "Спеціальні символи заборонені від імені камери",
+  "valoro devas esti multoblo de 8": "Значення повинно бути кратним 8",
+  "specialaj signoj ne rajtas en radika voja nomo": "Спеціальні символи заборонені в назві Root Road",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "Файли не можуть бути створені безпосередньо в корені вашої системи",
+  "enigu validan retpoŝtadreson": "Введіть дійсну електронну адресу",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "Введіть список окремих дійсних адрес електронної пошти",
+  "specialaj signoj ne rajtas en dosiernomo": "Спеціальні персонажі заборонені в імені файлу",
+  "enigu validan valoron": "Введіть дійсне значення",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "Це буде рекурсивно видалити всі файли, присутні у хмарній папці »",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "\", не лише тих, хто завантажив Motioneye!",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "Ця рекурсія видаляє всі старі медіа -файли в каталозі \"",
+  "\", ne nur tiuj kreitaj de motionEye!": "\", не тільки ті, створені Motioneye!",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "Не в змозі редагувати маску без дійсного зображення камери!",
+  "Propra": "Власний",
+  "Propra dosierindiko": "Власна індикація файлів",
+  "Retan kunlokon": "Онлайн -розташування",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "Ваш браузер не виконує цю функцію!",
+  "Apliki": "застосувати",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "Переконайтесь, що всі параметри конфігурації дійсні!",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "Це відновить систему. Продовжувати?",
+  "Vere fermiti sistemon?": "Справді закрили систему?",
+  "Malŝaltita": "Вимкнений",
+  "Ĉu vere restartigi ?": "Дійсно перезапустити?",
+  "La sistemo rekomencis!": "Система відновилася!",
+  "Bonvolu apliki unue la modifitajn agordojn!": "Будь ласка, спочатку застосуйте модифіковані налаштування!",
+  "Neniu fotilo por forigi!": "Ніякої камери для видалення!",
+  "Ĉu forigi kameraon ": "Чи зняти камеру ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "Motioneye оновлюється (Поточна версія: ",
+  "Nova versio havebla: ": "Доступна нова версія: ",
+  ". Ĝisdatigi?": ". Оновлення?",
+  "motionEye estis sukcese ĝisdatigita!": "Motioneye успішно оновлюється!",
+  "Ĝisdatigo malsukcesis!": "Оновлення не вдалося!",
+  "La ĝisdatiga procezo malsukcesis!": "Процес оновлення не вдалося!",
+  "Rezerva dosiero": "Файл резервного копіювання",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "Файл резервного копіювання, який ви раніше завантажували.",
+  "Restaŭrigi Agordon": "Відновити конфігурацію",
+  "Restaŭriganta agordon ...": "Налаштування відновлення ...",
+  "La agordo restaŭrigis!": "Конфігурація була відновлена!",
+  "Malsukcesis restaŭri la agordon!": "Не вдалося відновити конфігурацію!",
+  "Aliri la alŝutan servon malsukcesis: ": "Для доступу до служби завантаження не вдалося: ",
+  "Aliri la alŝutan servon sukcesis!": "Доступ до послуги завантаження був успішним!",
+  "Sciiga retpoŝto fiaskis:": "Не вдалося повідомити електронну пошту:",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "Переконайтесь, що всі параметри конфігурації дійсні!",
+  "Sciiga Telegramo fiaskis:": "Новини Telegram не вдалося:",
+  "Sciiga Telegramo sukcesis!": "Новини Телеграма була успішною!",
+  "Aliro al retdividado fiaskis: ": "Доступ до веб -підрозділу не вдався: ",
+  "Aliro al retdividado sukcesis!": "Доступ до веб -підрозділу був успішним!",
+  "Ĉu vere forigi ĉi tiun dosieron?": "Дійсно видалити цей файл?",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "Дійсно видалить усі зображення з \"%(групи) S\"?",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "Дійсно видалити всі фільми з \"%(групи) S\"?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "Дійсно видалити всі не згруповані зображення?",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "Дійсно видалити всі не згруповані фільми?",
+  "aldonadi kameraon...": "Додайте камеру ...",
+  "Uzantnomo": "Ім'я користувача",
+  "Pasvorto": "Пароль",
+  "Memoru min": "Пам'ятай мене",
+  "Ensaluti": "Увійти",
+  "Nuligi": "Скасувати",
+  "Vi abortis la filmeton.": "Ви перервали відео.",
+  "Reto eraro okazis.": "Сталася помилка мережі.",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "Помилка декодування або непрогресивна функція.",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "Формат, не підтримується або недоступний/невідповідний для гри.",
+  "Nekonata eraro okazis.": "Сталася невідома помилка.",
+  "Eraro : ": "Помилка: ",
+  "antaŭa bildo": "Попереднє зображення",
+  "ludi": "грати",
+  "ludi * 5 kaj enĉenigi": "грати * 5 і потрапити",
+  "sekva bildo": "Наступна картина",
+  "Fermi": "Закрити",
+  "Elŝuti": "Завантажувати",
+  "Forigi": "Видалити",
+  "Kamerao tipo": "Тип камери",
+  "Loka V4L2-kamerao": "Місцева камера V4L2",
+  "Loka MMAL-kamerao": "Місцева камера ммаль",
+  "Reta kamerao": "Інтернет -камера",
+  "Fora motionEye kamerao": "Камера далекого руху",
+  "Simpla MJPEG-kamerao": "Проста камера MJPEG",
+  "la speco de kamerao, kiun vi volas aldoni": "Тип камери, який ви хочете додати",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http: //ekzemplo.com: 8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "URL -адреса камери (наприклад, http://ekzemplo.com:8080/cam/)",
+  "uzantnomo...": "Ім'я користувача ...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "Ім'я користувача для URL -адреси, якщо потрібно (наприклад, адміністратор)",
+  "pasvorto...": "Пароль ...",
+  "la pasvorto por la URL, se bezonata": "Пароль для URL -адреси, якщо потрібно",
+  "Kamerao": "Камера",
+  "la kameraon, kiun vi volas aldoni": "камера, яку ви хочете додати",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "Камера Fora Motioney - це камери, встановлені за іншим сервером Motioneye. Додавання їх тут дозволить вам шукати та керувати ними здалеку.",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "Веб -камери (або IP -камери) - це пристрої, які означають відео RTSP/RTMP або MJPEG або прості зображення JPEG. Зверніться до посібника свого пристрою, щоб дізнатися правильну URL -адресу RTSP, RTMP, MJPEG або JPEG.",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "Місцеві камери MMAL - це пристрої, підключені безпосередньо до вашої системи Motioneye. Зазвичай це камери, що стосуються карт.",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "Додавання вашого пристрою як просту камеру MJPEG замість того, як онлайн -камера покращить фотографію, але для неї не буде доступне виявлення руху, зйомки зображень чи запису фільмів. Камера повинна бути доступною для вашого сервера та вашого браузера. Цей тип камери не відповідає Internet Explorer.",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "Місцеві камери V4L2 - це пристрої камери, підключені безпосередньо до вашої системи Motioneye, як правило, через USB.",
+  "Aldonadi kameraon...": "Додайте камеру ...",
+  "Grupo": "Група",
+  "Inkluzivi foton prenitan ĉiun": "Включіть фотографію, зроблене кожним",
+  "sekundo": "секунда",
+  "5 sekundoj": "5 секунд",
+  "10 sekundoj": "10 секунд",
+  "30 sekundoj": "30 секунд",
+  "minuto": "хвилина",
+  "5 minutoj": "5 хвилин",
+  "10 minutoj": "10 хвилин",
+  "30 minutoj": "30 хвилин",
+  "horo": "година",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "Виберіть діапазон часу між двома вибраними зображеннями.",
+  "Filmo framfrekvenco": "Швидкість кадру фільму",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "Виберіть, наскільки швидко ви хочете, щоб озброєне відео було.",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "Враховуючи велику кількість фотографій, створення вашого відео може зайняти деякий час!",
+  "Krei akselita video": "Створіть озброєне відео",
+  "Filmo kreanta en progreso...": "Фільми, що створює в процесі ...",
+  "Zipitaj": "Застеблений",
+  "Akselita video": "Закріплене відео",
+  "Forigi ĉiujn": "Видалити все",
+  "Bildoj prenitaj de ": "Зображення, зроблені ",
+  "Filmoj registritaj de ": "Фільми, записані ",
+  "montru ĉi tiun fotilon plenekranan": "Покажіть цю камеру на повний екран",
+  "montri ĉiujn fotilojn": "Показати всі камери",
+  "montru nur ĉi tiun fotilon": "Покажіть лише цю камеру",
+  "malfermaj bildoj retumilo": "Відкриті картинки браузер",
+  "malferma videoj retumilo": "Відкрийте веб -переглядач",
+  "agordi ĉi tiun kameraon": "Встановіть цю камеру",
+  "preni instantaron": "прийняти миттєво",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "Ви ще не встановили жодної камери. Клацніть тут, щоб додати один ...",
+  "enigu pozitivan nombron": "Введіть додатковий номер",
+  "enigu pozitivan entjeran nombron": "Введіть позитивне ціле число",
+  "enigu nombron": "Введіть номер",
+  "enigu entjeran nombron": "Введіть цілий номер",
+  " inter ": " між ",
+  " kaj ": " і ",
+  " pli ol ": " більше ніж ",
+  " malpli ol ": " менше ніж ",
+  "enigu validan tempon en la sekva formato: HH:MM": "Введіть дійсний час у такому форматі: HH: MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "Введіть дійсну URL -адресу (наприклад, http://ekzemplo.com:8080/cams/)",
+  "fermi": "закрити",
+  "Ne": "Ні",
+  "Jes": "Так",
+  "Bone": "В порядку",
+  "Auto Exposure": "Автоматичне опромінення",
+  "Backlight Compensation": "Компенсація підсвічування",
+  "Brightness": "Яскравість",
+  "Contrast": "Протиставляти",
+  "Exposure Absolute": "Експозиція абсолютно",
+  "Exposure Auto": "Експозиція автоматично",
+  "Exposure Auto Priority": "Експозиція Авто -пріоритет",
+  "Exposure Time Absolute": "Час експозиції абсолютно",
+  "Focus Absolute": "Зосередитись абсолютно",
+  "Focus Auto": "Фокус автоматично",
+  "Gain": "Виграш",
+  "Gamma": "Гамма",
+  "Hue": "Відтінок",
+  "Led1 Mode": "Режим LED1",
+  "Led1 Frequency": "Частота LED1",
+  "Pan Absolute": "Пан абсолютно",
+  "Power Line Frequency": "Частота лінії електропередач",
+  "Saturation": "Насичення",
+  "Sharpness": "Різкість",
+  "Tilt Absolute": "Нахил абсолютно",
+  "White Balance Temperature": "Температура балансу білого",
+  "White Balance Temperature Auto": "Температура балансу білого автоматично",
+  "Zoom Absolute": "Збільшити абсолютно",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.vi.json
+++ b/motioneye/static/js/motioneye.vi.json
@@ -1,164 +1,176 @@
-{"":{"language":"vi","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": ""
-,"Ĉi tiu kampo estas deviga": ""
-,"specialaj signoj ne rajtas en la nomo de kamerao": ""
-,"valoro devas esti multoblo de 8": ""
-,"specialaj signoj ne rajtas en radika voja nomo": ""
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": ""
-,"enigu validan retpoŝtadreson": ""
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": ""
-,"specialaj signoj ne rajtas en dosiernomo": ""
-,"enigu validan valoron": ""
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": ""
-,"\", ne nur tiuj alŝutitaj de motionEye!": ""
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": ""
-,"\", ne nur tiuj kreitaj de motionEye!": ""
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": ""
-,"Propra": ""
-,"Propra dosierindiko": ""
-,"Retan kunlokon": ""
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": ""
-,"Apliki": ""
-,"Certigu, ke ĉiuj agordaj opcioj validas!": ""
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": ""
-,"Vere fermiti sistemon?": ""
-,"Malŝaltita": ""
-,"Ĉu vere restartigi ?": ""
-,"La sistemo rekomencis!": ""
-,"Bonvolu apliki unue la modifitajn agordojn!": ""
-,"Neniu fotilo por forigi!": ""
-,"Ĉu forigi kameraon ": ""
-,"motionEye estas ĝisdatigita (aktuala versio: ": ""
-,"Nova versio havebla: ": ""
-,". Ĝisdatigi?": ""
-,"motionEye estis sukcese ĝisdatigita!": ""
-,"Ĝisdatigo malsukcesis!": ""
-,"La ĝisdatiga procezo malsukcesis!": ""
-,"Rezerva dosiero": ""
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": ""
-,"Restaŭrigi Agordon": ""
-,"Restaŭriganta agordon ...": ""
-,"La agordo restaŭrigis!": ""
-,"Malsukcesis restaŭri la agordon!": ""
-,"Aliri la alŝutan servon malsukcesis: ": ""
-,"Aliri la alŝutan servon sukcesis!": ""
-,"Sciiga retpoŝto fiaskis:": ""
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": ""
-,"Sciiga Telegramo fiaskis:": ""
-,"Sciiga Telegramo sukcesis!": ""
-,"Aliro al retdividado fiaskis: ": ""
-,"Aliro al retdividado sukcesis!": ""
-,"Ĉu vere forigi ĉi tiun dosieron?": ""
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": ""
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": ""
-,"aldonadi kameraon...": ""
-,"Uzantnomo": ""
-,"Pasvorto": ""
-,"Memoru min": ""
-,"Ensaluti": ""
-,"Nuligi": ""
-,"Vi abortis la filmeton.": ""
-,"Reto eraro okazis.": ""
-,"Malkodado-eraro aŭ neprogresinta funkcio.": ""
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": ""
-,"Nekonata eraro okazis.": ""
-,"Eraro : ": ""
-,"antaŭa bildo": ""
-,"ludi": ""
-,"ludi * 5 kaj enĉenigi": ""
-,"sekva bildo": ""
-,"Fermi": ""
-,"Elŝuti": ""
-,"Forigi": ""
-,"Kamerao tipo": ""
-,"Loka V4L2-kamerao": ""
-,"Loka MMAL-kamerao": ""
-,"Reta kamerao": ""
-,"Fora motionEye kamerao": ""
-,"Simpla MJPEG-kamerao": ""
-,"la speco de kamerao, kiun vi volas aldoni": ""
-,"URL": ""
-,"http://ekzemplo.com:8765/cams/...": ""
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": ""
-,"uzantnomo...": ""
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": ""
-,"pasvorto...": ""
-,"la pasvorto por la URL, se bezonata": ""
-,"Kamerao": ""
-,"la kameraon, kiun vi volas aldoni": ""
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": ""
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": ""
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": ""
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": ""
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": ""
-,"Aldonadi kameraon...": ""
-,"Grupo": ""
-,"Inkluzivi foton prenitan ĉiun": ""
-,"sekundo": ""
-,"5 sekundoj": ""
-,"10 sekundoj": ""
-,"30 sekundoj": ""
-,"minuto": ""
-,"5 minutoj": ""
-,"10 minutoj": ""
-,"30 minutoj": ""
-,"horo": ""
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": ""
-,"Filmo framfrekvenco": ""
-,"Elektu kiom rapide vi volas ke la akselita video estu.": ""
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": ""
-,"Krei akselita video": ""
-,"Filmo kreanta en progreso...": ""
-,"Zipitaj": ""
-,"Akselita video": ""
-,"Forigi ĉiujn": ""
-,"Bildoj prenitaj de ": ""
-,"Filmoj registritaj de ": ""
-,"montru ĉi tiun fotilon plenekranan": ""
-,"montri ĉiujn fotilojn": ""
-,"montru nur ĉi tiun fotilon": ""
-,"malfermaj bildoj retumilo": ""
-,"malferma videoj retumilo": ""
-,"agordi ĉi tiun kameraon": ""
-,"preni instantaron": ""
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": ""
-,"enigu pozitivan nombron": ""
-,"enigu pozitivan entjeran nombron": ""
-,"enigu nombron": ""
-,"enigu entjeran nombron": ""
-," inter ": ""
-," kaj ": ""
-," pli ol ": ""
-," malpli ol ": ""
-,"enigu validan tempon en la sekva formato: HH:MM": ""
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": ""
-,"fermi": ""
-,"Ne": ""
-,"Jes": ""
-,"Bone": ""
-,"Auto Exposure": ""
-,"Backlight Compensation": ""
-,"Brightness": ""
-,"Contrast": ""
-,"Exposure Absolute": ""
-,"Exposure Auto": ""
-,"Exposure Auto Priority": ""
-,"Exposure Time Absolute": ""
-,"Focus Absolute": ""
-,"Focus Auto": ""
-,"Gain": ""
-,"Gamma": ""
-,"Hue": ""
-,"Led1 Mode": ""
-,"Led1 Frequency": ""
-,"Pan Absolute": ""
-,"Power Line Frequency": ""
-,"Saturation": ""
-,"Sharpness": ""
-,"Tilt Absolute": ""
-,"White Balance Temperature": ""
-,"White Balance Temperature Auto": ""
-,"Zoom Absolute": ""
+{
+  "": {
+    "language": "vi",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "",
+  "Ĉi tiu kampo estas deviga": "",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "",
+  "valoro devas esti multoblo de 8": "",
+  "specialaj signoj ne rajtas en radika voja nomo": "",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "",
+  "enigu validan retpoŝtadreson": "",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "",
+  "specialaj signoj ne rajtas en dosiernomo": "",
+  "enigu validan valoron": "",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "",
+  "\", ne nur tiuj kreitaj de motionEye!": "",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "",
+  "Propra": "",
+  "Propra dosierindiko": "",
+  "Retan kunlokon": "",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "",
+  "Apliki": "",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "",
+  "Vere fermiti sistemon?": "",
+  "Malŝaltita": "",
+  "Ĉu vere restartigi ?": "",
+  "La sistemo rekomencis!": "",
+  "Bonvolu apliki unue la modifitajn agordojn!": "",
+  "Neniu fotilo por forigi!": "",
+  "Ĉu forigi kameraon ": "",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "",
+  "Nova versio havebla: ": "",
+  ". Ĝisdatigi?": "",
+  "motionEye estis sukcese ĝisdatigita!": "",
+  "Ĝisdatigo malsukcesis!": "",
+  "La ĝisdatiga procezo malsukcesis!": "",
+  "Rezerva dosiero": "",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "",
+  "Restaŭrigi Agordon": "",
+  "Restaŭriganta agordon ...": "",
+  "La agordo restaŭrigis!": "",
+  "Malsukcesis restaŭri la agordon!": "",
+  "Aliri la alŝutan servon malsukcesis: ": "",
+  "Aliri la alŝutan servon sukcesis!": "",
+  "Sciiga retpoŝto fiaskis:": "",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "",
+  "Sciiga Telegramo fiaskis:": "",
+  "Sciiga Telegramo sukcesis!": "",
+  "Aliro al retdividado fiaskis: ": "",
+  "Aliro al retdividado sukcesis!": "",
+  "Ĉu vere forigi ĉi tiun dosieron?": "",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "",
+  "aldonadi kameraon...": "",
+  "Uzantnomo": "",
+  "Pasvorto": "",
+  "Memoru min": "",
+  "Ensaluti": "",
+  "Nuligi": "",
+  "Vi abortis la filmeton.": "",
+  "Reto eraro okazis.": "",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "",
+  "Nekonata eraro okazis.": "",
+  "Eraro : ": "",
+  "antaŭa bildo": "",
+  "ludi": "",
+  "ludi * 5 kaj enĉenigi": "",
+  "sekva bildo": "",
+  "Fermi": "",
+  "Elŝuti": "",
+  "Forigi": "",
+  "Kamerao tipo": "",
+  "Loka V4L2-kamerao": "",
+  "Loka MMAL-kamerao": "",
+  "Reta kamerao": "",
+  "Fora motionEye kamerao": "",
+  "Simpla MJPEG-kamerao": "",
+  "la speco de kamerao, kiun vi volas aldoni": "",
+  "URL": "",
+  "http://ekzemplo.com:8765/cams/...": "",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "",
+  "uzantnomo...": "",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "",
+  "pasvorto...": "",
+  "la pasvorto por la URL, se bezonata": "",
+  "Kamerao": "",
+  "la kameraon, kiun vi volas aldoni": "",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "",
+  "Aldonadi kameraon...": "",
+  "Grupo": "",
+  "Inkluzivi foton prenitan ĉiun": "",
+  "sekundo": "",
+  "5 sekundoj": "",
+  "10 sekundoj": "",
+  "30 sekundoj": "",
+  "minuto": "",
+  "5 minutoj": "",
+  "10 minutoj": "",
+  "30 minutoj": "",
+  "horo": "",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "",
+  "Filmo framfrekvenco": "",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "",
+  "Krei akselita video": "",
+  "Filmo kreanta en progreso...": "",
+  "Zipitaj": "",
+  "Akselita video": "",
+  "Forigi ĉiujn": "",
+  "Bildoj prenitaj de ": "",
+  "Filmoj registritaj de ": "",
+  "montru ĉi tiun fotilon plenekranan": "",
+  "montri ĉiujn fotilojn": "",
+  "montru nur ĉi tiun fotilon": "",
+  "malfermaj bildoj retumilo": "",
+  "malferma videoj retumilo": "",
+  "agordi ĉi tiun kameraon": "",
+  "preni instantaron": "",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "",
+  "enigu pozitivan nombron": "",
+  "enigu pozitivan entjeran nombron": "",
+  "enigu nombron": "",
+  "enigu entjeran nombron": "",
+  " inter ": "",
+  " kaj ": "",
+  " pli ol ": "",
+  " malpli ol ": "",
+  "enigu validan tempon en la sekva formato: HH:MM": "",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "",
+  "fermi": "",
+  "Ne": "",
+  "Jes": "",
+  "Bone": "",
+  "Auto Exposure": "",
+  "Backlight Compensation": "",
+  "Brightness": "",
+  "Contrast": "",
+  "Exposure Absolute": "",
+  "Exposure Auto": "",
+  "Exposure Auto Priority": "",
+  "Exposure Time Absolute": "",
+  "Focus Absolute": "",
+  "Focus Auto": "",
+  "Gain": "",
+  "Gamma": "",
+  "Hue": "",
+  "Led1 Mode": "",
+  "Led1 Frequency": "",
+  "Pan Absolute": "",
+  "Power Line Frequency": "",
+  "Saturation": "",
+  "Sharpness": "",
+  "Tilt Absolute": "",
+  "White Balance Temperature": "",
+  "White Balance Temperature Auto": "",
+  "Zoom Absolute": "",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/static/js/motioneye.zh.json
+++ b/motioneye/static/js/motioneye.zh.json
@@ -1,164 +1,176 @@
-{"":{"language":"zh","plural-forms":"nplurals=2; plural=(n > 1);"}
-,"specialaj signoj ne rajtas en pasvorto": "密码中不允许使用特殊字符"
-,"Ĉi tiu kampo estas deviga": "必填项"
-,"specialaj signoj ne rajtas en la nomo de kamerao": "摄像头名称中不允许使用特殊字符"
-,"valoro devas esti multoblo de 8": "值必须是8的倍数"
-,"specialaj signoj ne rajtas en radika voja nomo": "根路径名中不允许使用特殊字符"
-,"dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "不能在系统根目录中创建文件"
-,"enigu validan retpoŝtadreson": "输入有效的电子邮箱"
-,"enigu liston de koma apartaj validaj retpoŝtadresoj": "输入以逗号分隔的有效电子邮件地址列表"
-,"specialaj signoj ne rajtas en dosiernomo": "文件名中不允许使用特殊字符"
-,"enigu validan valoron": "输入一个有效值"
-,"Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "将递归删除云文件夹中的所有文件”"
-,"\", ne nur tiuj alŝutitaj de motionEye!": "”，不只是由motionEye上传的！"
-,"Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "将递归删除文件夹中所有过期的媒体文件”"
-,"\", ne nur tiuj kreitaj de motionEye!": "”，不只是由motionEye创建的！"
-,"Ne eblas redakti la maskon sen valida kameraa bildo!": "无法在摄像头无效的情况下编辑蒙版！"
-,"Propra": "自定义"
-,"Propra dosierindiko": "自定义路径"
-,"Retan kunlokon": "在线连接"
-,"Via retumilo ne efektivigas ĉi tiun funkcion!": "您的浏览器不支持此功能！"
-,"Apliki": "应用修改"
-,"Certigu, ke ĉiuj agordaj opcioj validas!": "请检查所有配置项是否有效！"
-,"Ĉi tio rekomencos la sistemon. Daŭrigi?": "是否重新启动系统？"
-,"Vere fermiti sistemon?": "确认关机？"
-,"Malŝaltita": "关机"
-,"Ĉu vere restartigi ?": "是否重启？"
-,"La sistemo rekomencis!": "系统已重启！"
-,"Bonvolu apliki unue la modifitajn agordojn!": "请先应用设置更改！"
-,"Neniu fotilo por forigi!": "无摄像头可移除！"
-,"Ĉu forigi kameraon ": "移除摄像头 "
-,"motionEye estas ĝisdatigita (aktuala versio: ": "motionEye已最新（当前版本： "
-,"Nova versio havebla: ": "新版本可用： "
-,". Ĝisdatigi?": "，立即更新？"
-,"motionEye estis sukcese ĝisdatigita!": "motionEye已成功更新！"
-,"Ĝisdatigo malsukcesis!": "更新失败！"
-,"La ĝisdatiga procezo malsukcesis!": "升级失败！"
-,"Rezerva dosiero": "备份文件"
-,"La rezervan dosieron, kiun vi antaŭe elŝutis.": "您先前下载的备份文件。"
-,"Restaŭrigi Agordon": "配置加载"
-,"Restaŭriganta agordon ...": "配置加载中..."
-,"La agordo restaŭrigis!": "配置已加载！"
-,"Malsukcesis restaŭri la agordon!": "配置加载失败！"
-,"Aliri la alŝutan servon malsukcesis: ": "连接上传服务失败： "
-,"Aliri la alŝutan servon sukcesis!": "连接上传服务成功！"
-,"Sciiga retpoŝto fiaskis:": "通知邮件失败："
-,"Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "请确认所有配置项都有效！"
-,"Sciiga Telegramo fiaskis:": "通知Telegram失败："
-,"Sciiga Telegramo sukcesis!": "通知Telegram成功！"
-,"Aliro al retdividado fiaskis: ": "访问网络共享失败： "
-,"Aliro al retdividado sukcesis!": "访问网络共享成功！"
-,"Ĉu vere forigi ĉi tiun dosieron?": "是否删除此文件？"
-,"Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "是否删除\"%(group)s\"组中的所有图片？"
-,"Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "是否删除\"%(group)s\"中的所有录像？"
-,"Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "是否删除所有未分组的图像？"
-,"Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "是否删除所有未分组的录像？"
-,"aldonadi kameraon...": "添加摄像头..."
-,"Uzantnomo": "用户名"
-,"Pasvorto": "密码"
-,"Memoru min": "记住我"
-,"Ensaluti": "登入"
-,"Nuligi": "取消"
-,"Vi abortis la filmeton.": "您中止了视频。"
-,"Reto eraro okazis.": "发生网络错误。"
-,"Malkodado-eraro aŭ neprogresinta funkcio.": "解码错误或不支持的媒体特性。"
-,"Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "格式不支持或无权限回放/回放不可用。"
-,"Nekonata eraro okazis.": "发生未知错误。"
-,"Eraro : ": "错误： "
-,"antaŭa bildo": "上一张图像"
-,"ludi": "播放"
-,"ludi * 5 kaj enĉenigi": "顺序5倍速播放"
-,"sekva bildo": "下一张图像"
-,"Fermi": "关闭"
-,"Elŝuti": "下载"
-,"Forigi": "删除"
-,"Kamerao tipo": "摄像头类型"
-,"Loka V4L2-kamerao": "本地V4L2摄像头"
-,"Loka MMAL-kamerao": "本地MMAL摄像头"
-,"Reta kamerao": "网路摄影头"
-,"Fora motionEye kamerao": "远程motionEye摄像头"
-,"Simpla MJPEG-kamerao": "普通MJPEG摄像头"
-,"la speco de kamerao, kiun vi volas aldoni": "您要添加的摄像头类型"
-,"URL": "URL"
-,"http://ekzemplo.com:8765/cams/...": "http://ekzemplo.com:8765/cams/..."
-,"la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "摄像头网址（例如：http://example.com:8080/cam/）"
-,"uzantnomo...": "用户名..."
-,"la uzantnomo por la URL, se bezonata (ekz. administranto)": "URL的用户名（选填，例如：admin）"
-,"pasvorto...": "密码..."
-,"la pasvorto por la URL, se bezonata": "URL的密码（选填）"
-,"Kamerao": "摄像头"
-,"la kameraon, kiun vi volas aldoni": "您要添加的摄像头"
-,"Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "远程MotionEye摄像头是安装在另一台MotionEye服务器下摄像头。在此处添加将使您可以远程查看和管理它们。"
-,"Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "网络摄像头（或IP摄像头）是指传输原生RTSP / RTMP流或MJPEG视频流或普通MJPEG图像流的设备。请查阅您的设备手册，以找到正确的RTSP，RTMP，MJPEG或JPEG的URL地址。"
-,"Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "本地MMAL摄像头是指直接连接到motionEye系统的设备。这些通常是硬件提供接口兼容的摄像头。"
-,"Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "将设备添加为简单的MJPEG摄像头而不是网络摄像头可以改善摄影效果，但是无法进行运动检测，图像捕获或动画录制。您的服务器和浏览器必须可以访问该相机。这类相机与Internet Explorer不匹配。"
-,"Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "本地V4L2摄像头通常通过USB直接连接到motionEye系统。"
-,"Aldonadi kameraon...": "添加摄像头..."
-,"Grupo": "分组"
-,"Inkluzivi foton prenitan ĉiun": "包括每张图像"
-,"sekundo": "第二"
-,"5 sekundoj": "5秒"
-,"10 sekundoj": "10秒"
-,"30 sekundoj": "30秒"
-,"minuto": "分钟"
-,"5 minutoj": "5分钟"
-,"10 minutoj": "10分钟"
-,"30 minutoj": "30分钟"
-,"horo": "小时"
-,"Elektu la intervalon de tempo inter du elektitaj bildoj.": "选择两个选定图像之间的时间间隔。"
-,"Filmo framfrekvenco": "视频帧率"
-,"Elektu kiom rapide vi volas ke la akselita video estu.": "选择您想要视频减缓的速度。"
-,"Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "图片太多会导致创建视频需要一些时间！"
-,"Krei akselita video": "创建延时视频"
-,"Filmo kreanta en progreso...": "延时视频创建中..."
-,"Zipitaj": "链式"
-,"Akselita video": "回看"
-,"Forigi ĉiujn": "全部删除"
-,"Bildoj prenitaj de ": "图像拍摄自 "
-,"Filmoj registritaj de ": "视频录像自 "
-,"montru ĉi tiun fotilon plenekranan": "全屏展示此摄像头"
-,"montri ĉiujn fotilojn": "显示所有摄像头"
-,"montru nur ĉi tiun fotilon": "只显示此摄像头"
-,"malfermaj bildoj retumilo": "打开图像浏览器"
-,"malferma videoj retumilo": "打开视频浏览器"
-,"agordi ĉi tiun kameraon": "配置此摄像头"
-,"preni instantaron": "快照"
-,"Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "您尚未配置任何摄像头。点击这里添加一个..."
-,"enigu pozitivan nombron": "输入一个正数"
-,"enigu pozitivan entjeran nombron": "输入一个正整数"
-,"enigu nombron": "输入一个数字"
-,"enigu entjeran nombron": "输入一个整数"
-," inter ": " 之间 "
-," kaj ": " 和 "
-," pli ol ": " 超过 "
-," malpli ol ": " 少于 "
-,"enigu validan tempon en la sekva formato: HH:MM": "按以下格式输入时间：HH:MM"
-,"enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "输入有效的网址（例如：http://example.com:8080/cams/）"
-,"fermi": "关闭"
-,"Ne": "否"
-,"Jes": "是"
-,"Bone": "确定"
-,"Auto Exposure": "自动曝光"
-,"Backlight Compensation": "背光补偿"
-,"Brightness": "亮度"
-,"Contrast": "对比度"
-,"Exposure Absolute": "绝对曝光度"
-,"Exposure Auto": "曝光自动"
-,"Exposure Auto Priority": "曝光自动优先级"
-,"Exposure Time Absolute": "曝光绝对时间"
-,"Focus Absolute": "绝对焦距"
-,"Focus Auto": "聚焦自动"
-,"Gain": "增益值"
-,"Gamma": "伽玛值"
-,"Hue": "色调值"
-,"Led1 Mode": "LED1模式"
-,"Led1 Frequency": "LED1频率"
-,"Pan Absolute": "绝对混响"
-,"Power Line Frequency": "电源线频率"
-,"Saturation": "饱和度"
-,"Sharpness": "清晰度"
-,"Tilt Absolute": "绝对倾斜"
-,"White Balance Temperature": "白平衡温度"
-,"White Balance Temperature Auto": "白平衡自动"
-,"Zoom Absolute": "绝对缩放"
+{
+  "": {
+    "language": "zh",
+    "plural-forms": "nplurals=2; plural=(n > 1);"
+  },
+  "specialaj signoj ne rajtas en pasvorto": "密码中不允许使用特殊字符",
+  "Ĉi tiu kampo estas deviga": "必填项",
+  "specialaj signoj ne rajtas en la nomo de kamerao": "摄像头名称中不允许使用特殊字符",
+  "valoro devas esti multoblo de 8": "值必须是8的倍数",
+  "specialaj signoj ne rajtas en radika voja nomo": "根路径名中不允许使用特殊字符",
+  "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo": "不能在系统根目录中创建文件",
+  "enigu validan retpoŝtadreson": "输入有效的电子邮箱",
+  "enigu liston de koma apartaj validaj retpoŝtadresoj": "输入以逗号分隔的有效电子邮件地址列表",
+  "specialaj signoj ne rajtas en dosiernomo": "文件名中不允许使用特殊字符",
+  "enigu validan valoron": "输入一个有效值",
+  "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \"": "将递归删除云文件夹中的所有文件”",
+  "\", ne nur tiuj alŝutitaj de motionEye!": "”，不只是由motionEye上传的！",
+  "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \"": "将递归删除文件夹中所有过期的媒体文件”",
+  "\", ne nur tiuj kreitaj de motionEye!": "”，不只是由motionEye创建的！",
+  "Ne eblas redakti la maskon sen valida kameraa bildo!": "无法在摄像头无效的情况下编辑蒙版！",
+  "Propra": "自定义",
+  "Propra dosierindiko": "自定义路径",
+  "Retan kunlokon": "在线连接",
+  "Via retumilo ne efektivigas ĉi tiun funkcion!": "您的浏览器不支持此功能！",
+  "Apliki": "应用修改",
+  "Certigu, ke ĉiuj agordaj opcioj validas!": "请检查所有配置项是否有效！",
+  "Ĉi tio rekomencos la sistemon. Daŭrigi?": "是否重新启动系统？",
+  "Vere fermiti sistemon?": "确认关机？",
+  "Malŝaltita": "关机",
+  "Ĉu vere restartigi ?": "是否重启？",
+  "La sistemo rekomencis!": "系统已重启！",
+  "Bonvolu apliki unue la modifitajn agordojn!": "请先应用设置更改！",
+  "Neniu fotilo por forigi!": "无摄像头可移除！",
+  "Ĉu forigi kameraon ": "移除摄像头 ",
+  "motionEye estas ĝisdatigita (aktuala versio: ": "motionEye已最新（当前版本： ",
+  "Nova versio havebla: ": "新版本可用： ",
+  ". Ĝisdatigi?": "，立即更新？",
+  "motionEye estis sukcese ĝisdatigita!": "motionEye已成功更新！",
+  "Ĝisdatigo malsukcesis!": "更新失败！",
+  "La ĝisdatiga procezo malsukcesis!": "升级失败！",
+  "Rezerva dosiero": "备份文件",
+  "La rezervan dosieron, kiun vi antaŭe elŝutis.": "您先前下载的备份文件。",
+  "Restaŭrigi Agordon": "配置加载",
+  "Restaŭriganta agordon ...": "配置加载中...",
+  "La agordo restaŭrigis!": "配置已加载！",
+  "Malsukcesis restaŭri la agordon!": "配置加载失败！",
+  "Aliri la alŝutan servon malsukcesis: ": "连接上传服务失败： ",
+  "Aliri la alŝutan servon sukcesis!": "连接上传服务成功！",
+  "Sciiga retpoŝto fiaskis:": "通知邮件失败：",
+  "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!": "请确认所有配置项都有效！",
+  "Sciiga Telegramo fiaskis:": "通知Telegram失败：",
+  "Sciiga Telegramo sukcesis!": "通知Telegram成功！",
+  "Aliro al retdividado fiaskis: ": "访问网络共享失败： ",
+  "Aliro al retdividado sukcesis!": "访问网络共享成功！",
+  "Ĉu vere forigi ĉi tiun dosieron?": "是否删除此文件？",
+  "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?": "是否删除\"%(group)s\"组中的所有图片？",
+  "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?": "是否删除\"%(group)s\"中的所有录像？",
+  "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?": "是否删除所有未分组的图像？",
+  "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?": "是否删除所有未分组的录像？",
+  "aldonadi kameraon...": "添加摄像头...",
+  "Uzantnomo": "用户名",
+  "Pasvorto": "密码",
+  "Memoru min": "记住我",
+  "Ensaluti": "登入",
+  "Nuligi": "取消",
+  "Vi abortis la filmeton.": "您中止了视频。",
+  "Reto eraro okazis.": "发生网络错误。",
+  "Malkodado-eraro aŭ neprogresinta funkcio.": "解码错误或不支持的媒体特性。",
+  "Formato ne subtenata aŭ neatingebla/netaŭga por ludado.": "格式不支持或无权限回放/回放不可用。",
+  "Nekonata eraro okazis.": "发生未知错误。",
+  "Eraro : ": "错误： ",
+  "antaŭa bildo": "上一张图像",
+  "ludi": "播放",
+  "ludi * 5 kaj enĉenigi": "顺序5倍速播放",
+  "sekva bildo": "下一张图像",
+  "Fermi": "关闭",
+  "Elŝuti": "下载",
+  "Forigi": "删除",
+  "Kamerao tipo": "摄像头类型",
+  "Loka V4L2-kamerao": "本地V4L2摄像头",
+  "Loka MMAL-kamerao": "本地MMAL摄像头",
+  "Reta kamerao": "网路摄影头",
+  "Fora motionEye kamerao": "远程motionEye摄像头",
+  "Simpla MJPEG-kamerao": "普通MJPEG摄像头",
+  "la speco de kamerao, kiun vi volas aldoni": "您要添加的摄像头类型",
+  "URL": "URL",
+  "http://ekzemplo.com:8765/cams/...": "http://ekzemplo.com:8765/cams/...",
+  "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)": "摄像头网址（例如：http://example.com:8080/cam/）",
+  "uzantnomo...": "用户名...",
+  "la uzantnomo por la URL, se bezonata (ekz. administranto)": "URL的用户名（选填，例如：admin）",
+  "pasvorto...": "密码...",
+  "la pasvorto por la URL, se bezonata": "URL的密码（选填）",
+  "Kamerao": "摄像头",
+  "la kameraon, kiun vi volas aldoni": "您要添加的摄像头",
+  "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime.": "远程MotionEye摄像头是安装在另一台MotionEye服务器下摄像头。在此处添加将使您可以远程查看和管理它们。",
+  "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG.": "网络摄像头（或IP摄像头）是指传输原生RTSP / RTMP流或MJPEG视频流或普通MJPEG图像流的设备。请查阅您的设备手册，以找到正确的RTSP，RTMP，MJPEG或JPEG的URL地址。",
+  "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj.": "本地MMAL摄像头是指直接连接到motionEye系统的设备。这些通常是硬件提供接口兼容的摄像头。",
+  "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer.": "将设备添加为简单的MJPEG摄像头而不是网络摄像头可以改善摄影效果，但是无法进行运动检测，图像捕获或动画录制。您的服务器和浏览器必须可以访问该相机。这类相机与Internet Explorer不匹配。",
+  "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB.": "本地V4L2摄像头通常通过USB直接连接到motionEye系统。",
+  "Aldonadi kameraon...": "添加摄像头...",
+  "Grupo": "分组",
+  "Inkluzivi foton prenitan ĉiun": "包括每张图像",
+  "sekundo": "第二",
+  "5 sekundoj": "5秒",
+  "10 sekundoj": "10秒",
+  "30 sekundoj": "30秒",
+  "minuto": "分钟",
+  "5 minutoj": "5分钟",
+  "10 minutoj": "10分钟",
+  "30 minutoj": "30分钟",
+  "horo": "小时",
+  "Elektu la intervalon de tempo inter du elektitaj bildoj.": "选择两个选定图像之间的时间间隔。",
+  "Filmo framfrekvenco": "视频帧率",
+  "Elektu kiom rapide vi volas ke la akselita video estu.": "选择您想要视频减缓的速度。",
+  "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!": "图片太多会导致创建视频需要一些时间！",
+  "Krei akselita video": "创建延时视频",
+  "Filmo kreanta en progreso...": "延时视频创建中...",
+  "Zipitaj": "链式",
+  "Akselita video": "回看",
+  "Forigi ĉiujn": "全部删除",
+  "Bildoj prenitaj de ": "图像拍摄自 ",
+  "Filmoj registritaj de ": "视频录像自 ",
+  "montru ĉi tiun fotilon plenekranan": "全屏展示此摄像头",
+  "montri ĉiujn fotilojn": "显示所有摄像头",
+  "montru nur ĉi tiun fotilon": "只显示此摄像头",
+  "malfermaj bildoj retumilo": "打开图像浏览器",
+  "malferma videoj retumilo": "打开视频浏览器",
+  "agordi ĉi tiun kameraon": "配置此摄像头",
+  "preni instantaron": "快照",
+  "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ...": "您尚未配置任何摄像头。点击这里添加一个...",
+  "enigu pozitivan nombron": "输入一个正数",
+  "enigu pozitivan entjeran nombron": "输入一个正整数",
+  "enigu nombron": "输入一个数字",
+  "enigu entjeran nombron": "输入一个整数",
+  " inter ": " 之间 ",
+  " kaj ": " 和 ",
+  " pli ol ": " 超过 ",
+  " malpli ol ": " 少于 ",
+  "enigu validan tempon en la sekva formato: HH:MM": "按以下格式输入时间：HH:MM",
+  "enigu validan URL (ekz. http://ekzemplo.com:8080/cams/)": "输入有效的网址（例如：http://example.com:8080/cams/）",
+  "fermi": "关闭",
+  "Ne": "否",
+  "Jes": "是",
+  "Bone": "确定",
+  "Auto Exposure": "自动曝光",
+  "Backlight Compensation": "背光补偿",
+  "Brightness": "亮度",
+  "Contrast": "对比度",
+  "Exposure Absolute": "绝对曝光度",
+  "Exposure Auto": "曝光自动",
+  "Exposure Auto Priority": "曝光自动优先级",
+  "Exposure Time Absolute": "曝光绝对时间",
+  "Focus Absolute": "绝对焦距",
+  "Focus Auto": "聚焦自动",
+  "Gain": "增益值",
+  "Gamma": "伽玛值",
+  "Hue": "色调值",
+  "Led1 Mode": "LED1模式",
+  "Led1 Frequency": "LED1频率",
+  "Pan Absolute": "绝对混响",
+  "Power Line Frequency": "电源线频率",
+  "Saturation": "饱和度",
+  "Sharpness": "清晰度",
+  "Tilt Absolute": "绝对倾斜",
+  "White Balance Temperature": "白平衡温度",
+  "White Balance Temperature Auto": "白平衡自动",
+  "Zoom Absolute": "绝对缩放",
+  "Aŭdio Aktivigita": "Audio Enabled",
+  "Aŭdio Aparato": "Audio Device",
+  "Aŭdio Kodeko": "Audio Codec",
+  "Aŭdio Bitrapideco": "Audio Bitrate",
+  "ebligas aŭdion por ĉi tiu kamerao": "enable audio for this camera",
+  "elektu la aŭdkaptan aparaton": "select the audio capture device",
+  "elektu la audiokodekon": "select the audio codec",
+  "bitrapideco por kodita aŭdio en kbps": "bitrate for encoded audio in kbps"
 }

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+<!-- version: 2025-08-26 -->
 
 {% macro config_item(config, depends="") -%}
     <tr class="settings-item additional-config"
@@ -294,6 +295,36 @@
                             <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="autoBrightnessSwitch"></td>
                             <td><span class="help-mark" title="{{ _("ebligas aŭtomatan brilon de programaro (rekomendita nur por kameraoj sen aŭtomata brilo)") }}">?</span></td>
                         </tr>
+                        {% if has_audio_support %}
+                        <tr class="settings-item">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Aŭdio Aktivigita") }}</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="audioDeviceEnabledSwitch"></td>
+                            <td><span class="help-mark" title="{{ _("ebligas aŭdion por ĉi tiu kamerao") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="audioDeviceEnabled">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Aŭdio Aparato") }}</span></td>
+                            <td class="settings-item-value">
+                                <select class="styled device camera-config" id="audioDeviceSelect"></select>
+                            </td>
+                            <td><span class="help-mark" title="{{ _("elektu la aŭdkaptan aparaton") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="audioDeviceEnabled">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Aŭdio Kodeko") }}</span></td>
+                            <td class="settings-item-value">
+                                <select class="styled device camera-config" id="audioCodecSelect">
+                                    <option value="aac">AAC</option>
+                                    <option value="mp3">MP3</option>
+                                    <option value="pcm_s16le">PCM</option>
+                                </select>
+                            </td>
+                            <td><span class="help-mark" title="{{ _("elektu la audiokodekon") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" min="8" max="512" depends="audioDeviceEnabled">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Aŭdio Bitrapideco") }}</span></td>
+                            <td class="settings-item-value"><input type="text" class="styled number device camera-config" id="audioBitrateEntry"></td>
+                            <td><span class="help-mark" title="{{ _("bitrapideco por kodita aŭdio en kbps") }}">?</span></td>
+                        </tr>
+                        {% endif %}
                         <tr class="settings-item">
                             <td colspan="100"><div class="settings-item-separator"></div></td>
                         </tr>

--- a/user_manual.md
+++ b/user_manual.md
@@ -8,6 +8,7 @@ motionEye supports audio options per camera:
 - **Audio Enabled** – maps to `sound_enabled`.
 - **Audio Codec** – maps to `ffmpeg_audio_codec`.
 - **Audio Bitrate** – maps to `ffmpeg_audio_bitrate`.
+- UI now provides a checkbox to enable audio and selectors for device, codec and bitrate.
 
 Global defaults reside in `settings.py` (`AUDIO_DEVICE`, `AUDIO_ENABLED`, `AUDIO_CODEC`, `AUDIO_BITRATE`).
 Configuration and preference APIs accept these options via `audio_*` fields in GET or POST requests.


### PR DESCRIPTION
## Résumé
- possibilité d'activer l'audio et de choisir périphérique, codec et débit pour chaque caméra
- gestion JS de `audio_device`, `audio_codec` et `audio_bitrate`
- nouvelles entrées i18n pour les libellés et aides audio

## Tests
- `pre-commit run --files $FILES` *(échoué : pre-commit non installé et installation impossible)*

------
https://chatgpt.com/codex/tasks/task_e_68acfbdeb3d4832ca788cde10ec2f8c1