### PR TITLE
Update POT template and bump version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Enabled GET/POST handling for `audio_*` parameters in config and preference APIs.
 - Validated and persisted audio configuration values.
 - Added camera UI fields for enabling audio, selecting devices, codec and bitrate.
+- Updated translation template and bumped version to 0.43.1b8.
 
 2025-08-25
 - Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.43.1b7"  # version: 2025-08-26
+VERSION = "0.43.1b8"  # version: 2025-08-26

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
+"Project-Id-Version: motionEye 0.43.1b8\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-04-28 19:42+0000\n"
+"POT-Creation-Date: 2025-08-26 17:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,616 +81,648 @@ msgstr ""
 msgid "adiaŭ!"
 msgstr ""
 
-#: motioneye/templates/main.html:104
+#: motioneye/templates/main.html:105
 msgid "agordojn"
 msgstr ""
 
-#: motioneye/templates/main.html:105
+#: motioneye/templates/main.html:106
 msgid "ŝanĝi uzanton"
 msgstr ""
 
-#: motioneye/templates/main.html:107
+#: motioneye/templates/main.html:108
 msgid "forigi kameraon"
 msgstr ""
 
-#: motioneye/templates/main.html:108
+#: motioneye/templates/main.html:109
 msgid "Apliki"
 msgstr ""
 
-#: motioneye/templates/main.html:127
+#: motioneye/templates/main.html:128
 msgid "preferoj de uzanto"
 msgstr ""
 
-#: motioneye/templates/main.html:128
+#: motioneye/templates/main.html:129
 msgid "Preferoj"
 msgstr ""
 
-#: motioneye/templates/main.html:133
+#: motioneye/templates/main.html:134
 msgid "Aranĝo Kolumnoj"
 msgstr ""
 
-#: motioneye/templates/main.html:135
+#: motioneye/templates/main.html:136
 msgid "agordas la nombron da kolumnoj uzataj por aranĝi la fotilojn"
 msgstr ""
 
-#: motioneye/templates/main.html:138
+#: motioneye/templates/main.html:139
 msgid "Fiksi Kadrojn Vertikale"
 msgstr ""
 
-#: motioneye/templates/main.html:140
+#: motioneye/templates/main.html:141
 msgid ""
 "kontrolas ĉu framfojoj povas esti reduktitaj por vertikale konveni al la "
 "fenestro aŭ ne"
 msgstr ""
 
-#: motioneye/templates/main.html:143
+#: motioneye/templates/main.html:144
 msgid "Aranĝo linioj"
 msgstr ""
 
-#: motioneye/templates/main.html:145
+#: motioneye/templates/main.html:146
 msgid "agordas la nombron da linioj uzataj por aranĝi la fotilojn"
 msgstr ""
 
-#: motioneye/templates/main.html:148
+#: motioneye/templates/main.html:149
 msgid "kadro-variatoro"
 msgstr ""
 
-#: motioneye/templates/main.html:150
+#: motioneye/templates/main.html:151
 msgid ""
 "reduktas framfrekvencon por ŝpari retan larĝan bandon kaj trafikon (ne "
 "funkcias kun simplaj MJPEG-fotiloj)"
 msgstr ""
 
-#: motioneye/templates/main.html:153
+#: motioneye/templates/main.html:154
 msgid "Rezolucio-variatoro"
 msgstr ""
 
-#: motioneye/templates/main.html:155
+#: motioneye/templates/main.html:156
 msgid ""
 "reduktas la efektivan rezolucion de ĉiuj fotiloj por ŝpari retan larĝan "
 "bandon kaj trafikon (ne funkcias en simplaj MJPEG-fotiloj)"
 msgstr ""
 
-#: motioneye/templates/main.html:161
+#: motioneye/templates/main.html:162
 msgid "ĝeneralaj parametroj, komunaj al ĉiuj fotiloj"
 msgstr ""
 
-#: motioneye/templates/main.html:162
+#: motioneye/templates/main.html:163
 msgid "Ĝeneralaj Agordoj"
 msgstr ""
 
-#: motioneye/templates/main.html:167
+#: motioneye/templates/main.html:168
 msgid "Lingvo"
 msgstr ""
 
-#: motioneye/templates/main.html:173
+#: motioneye/templates/main.html:174
 msgid "la lingvo de la interfaco (du literoj)"
 msgstr ""
 
-#: motioneye/templates/main.html:176
+#: motioneye/templates/main.html:177
 msgid "Administranto"
 msgstr ""
 
-#: motioneye/templates/main.html:178
+#: motioneye/templates/main.html:179
 msgid "la uzantnomo uzata por agordi la sistemon"
 msgstr ""
 
-#: motioneye/templates/main.html:181 motioneye/templates/main.html:191
-#: motioneye/templates/main.html:521
+#: motioneye/templates/main.html:182 motioneye/templates/main.html:192
+#: motioneye/templates/main.html:552
 msgid "Pasvorto"
 msgstr ""
 
-#: motioneye/templates/main.html:183
+#: motioneye/templates/main.html:184
 msgid "pasvorto de administranto"
 msgstr ""
 
-#: motioneye/templates/main.html:186
+#: motioneye/templates/main.html:187
 msgid "Observanto"
 msgstr ""
 
-#: motioneye/templates/main.html:188
+#: motioneye/templates/main.html:189
 msgid "la uzantnomo por uzi por la monitorado"
 msgstr ""
 
-#: motioneye/templates/main.html:193
+#: motioneye/templates/main.html:194
 msgid ""
 "la pasvorto de la uzanto de monitorado (lasu blankan por monitorado sen "
 "pasvorto)"
 msgstr ""
 
-#: motioneye/templates/main.html:202
+#: motioneye/templates/main.html:203
 msgid "motionEye Versio"
 msgstr ""
 
-#: motioneye/templates/main.html:206
+#: motioneye/templates/main.html:207
 msgid "Motion Versio"
 msgstr ""
 
-#: motioneye/templates/main.html:210
+#: motioneye/templates/main.html:211
 msgid "Operaciumo Versio"
 msgstr ""
 
-#: motioneye/templates/main.html:215
+#: motioneye/templates/main.html:216
 msgid "Programara Ĝisdatigo"
 msgstr ""
 
-#: motioneye/templates/main.html:217
+#: motioneye/templates/main.html:218
 msgid "kontrolas novajn versiojn kaj plenumas ĝisdatigojn"
 msgstr ""
 
-#: motioneye/templates/main.html:221
+#: motioneye/templates/main.html:222
 msgid "Nutro"
 msgstr ""
 
-#: motioneye/templates/main.html:222
+#: motioneye/templates/main.html:223
 msgid "Fermu"
 msgstr ""
 
-#: motioneye/templates/main.html:223
+#: motioneye/templates/main.html:224
 msgid "malŝaltas la sistemon"
 msgstr ""
 
-#: motioneye/templates/main.html:227
+#: motioneye/templates/main.html:228
 msgid "Rekomencu"
 msgstr ""
 
-#: motioneye/templates/main.html:228
+#: motioneye/templates/main.html:229
 msgid "rekomencas la sistemon"
 msgstr ""
 
-#: motioneye/templates/main.html:234
+#: motioneye/templates/main.html:235
 msgid "Agordo"
 msgstr ""
 
-#: motioneye/templates/main.html:235
+#: motioneye/templates/main.html:236
 msgid "Sekurkopio"
 msgstr ""
 
-#: motioneye/templates/main.html:236
+#: motioneye/templates/main.html:237
 msgid "kreas dosieron kun la nuna agordo por ke vi konservu ĝin surloke"
 msgstr ""
 
-#: motioneye/templates/main.html:240
+#: motioneye/templates/main.html:241
 msgid "Restaŭri"
 msgstr ""
 
-#: motioneye/templates/main.html:241
+#: motioneye/templates/main.html:242
 msgid "restarigas la agordon el antaŭe konservita rezerva dosiero"
 msgstr ""
 
-#: motioneye/templates/main.html:265
+#: motioneye/templates/main.html:266
 msgid "aktivigu ĉi tion, se vi volas uzi ĉi tiun kameraon"
 msgstr ""
 
-#: motioneye/templates/main.html:266
+#: motioneye/templates/main.html:267
 msgid "Video-Aparato"
 msgstr ""
 
-#: motioneye/templates/main.html:271 motioneye/templates/main.html:614
-#: motioneye/templates/main.html:631
+#: motioneye/templates/main.html:272 motioneye/templates/main.html:645
+#: motioneye/templates/main.html:662
 msgid "Kamerao Nomo"
 msgstr ""
 
-#: motioneye/templates/main.html:272
+#: motioneye/templates/main.html:273
 msgid "kameraa nomo…"
 msgstr ""
 
-#: motioneye/templates/main.html:273
+#: motioneye/templates/main.html:274
 msgid "alias pri ĉi tiu kamera aparato"
 msgstr ""
 
-#: motioneye/templates/main.html:276
+#: motioneye/templates/main.html:277
 msgid "Kamerao ID"
 msgstr ""
 
-#: motioneye/templates/main.html:278
+#: motioneye/templates/main.html:279
 msgid "la kamerao identiga numero"
 msgstr ""
 
-#: motioneye/templates/main.html:281
+#: motioneye/templates/main.html:282
 msgid "Kamerao aparato"
 msgstr ""
 
-#: motioneye/templates/main.html:283
+#: motioneye/templates/main.html:284
 msgid ""
 "Eniga aparato (ekz. : /dev/video) or URL (ekz. : "
 "rtsp://192.168.1.1/stream)"
 msgstr ""
 
-#: motioneye/templates/main.html:286
+#: motioneye/templates/main.html:287
 msgid "Kamerao Tipo"
 msgstr ""
 
-#: motioneye/templates/main.html:293
+#: motioneye/templates/main.html:294
 msgid "Aŭtomata Brilo"
 msgstr ""
 
-#: motioneye/templates/main.html:295
+#: motioneye/templates/main.html:296
 msgid ""
 "ebligas aŭtomatan brilon de programaro (rekomendita nur por kameraoj sen "
 "aŭtomata brilo)"
 msgstr ""
 
-#: motioneye/templates/main.html:301
+#: motioneye/templates/main.html:300
+msgid "Aŭdio Aktivigita"
+msgstr ""
+
+#: motioneye/templates/main.html:302
+msgid "ebligas aŭdion por ĉi tiu kamerao"
+msgstr ""
+
+#: motioneye/templates/main.html:305
+msgid "Aŭdio Aparato"
+msgstr ""
+
+#: motioneye/templates/main.html:309
+msgid "elektu la aŭdkaptan aparaton"
+msgstr ""
+
+#: motioneye/templates/main.html:312
+msgid "Aŭdio Kodeko"
+msgstr ""
+
+#: motioneye/templates/main.html:320
+msgid "elektu la audiokodekon"
+msgstr ""
+
+#: motioneye/templates/main.html:323
+msgid "Aŭdio Bitrapideco"
+msgstr ""
+
+#: motioneye/templates/main.html:325
+msgid "bitrapideco por kodita aŭdio en kbps"
+msgstr ""
+
+#: motioneye/templates/main.html:332
 msgid "Video-rezolucio"
 msgstr ""
 
-#: motioneye/templates/main.html:306
+#: motioneye/templates/main.html:337
 msgid ""
 "la video-rezolucio (pli grandaj valoroj produktas pli bonan kvaliton, sed"
 " postulas pli da CPU-potenco, pli granda stokado kaj larĝa de bando)"
 msgstr ""
 
-#: motioneye/templates/main.html:309
+#: motioneye/templates/main.html:340
 msgid "Larĝeco"
 msgstr ""
 
-#: motioneye/templates/main.html:311
+#: motioneye/templates/main.html:342
 msgid "enigu kutiman rezolucian larĝon"
 msgstr ""
 
-#: motioneye/templates/main.html:314
+#: motioneye/templates/main.html:345
 msgid "Alteco"
 msgstr ""
 
-#: motioneye/templates/main.html:316
+#: motioneye/templates/main.html:347
 msgid "enigu kutiman rezolucian altecon"
 msgstr ""
 
-#: motioneye/templates/main.html:319
+#: motioneye/templates/main.html:350
 msgid "Video-Rotacio"
 msgstr ""
 
-#: motioneye/templates/main.html:328
+#: motioneye/templates/main.html:359
 msgid ""
 "uzu ĉi tion por turni la kaptitan bildon, se via kamerao ne estas "
 "poziciigita ĝuste"
 msgstr ""
 
-#: motioneye/templates/main.html:331
+#: motioneye/templates/main.html:362
 msgid "Kadrofrekvenco"
 msgstr ""
 
-#: motioneye/templates/main.html:333
+#: motioneye/templates/main.html:364
 msgid ""
 "agordas la nombron de kadroj kaptitaj de la kamerao ĉiun sekundon (pli "
 "altaj valoroj produktas pli mildajn filmetojn sed postulas pli da CPU-"
 "potenco, pli grandan stokadon kaj larĝan bandon)"
 msgstr ""
 
-#: motioneye/templates/main.html:339
+#: motioneye/templates/main.html:370
 msgid "Privateca masko"
 msgstr ""
 
-#: motioneye/templates/main.html:341
+#: motioneye/templates/main.html:372
 msgid ""
 "ebligas maskeradon de bildoj por eviti registradon de iuj bildaj areoj "
 "por protekti privatecon"
 msgstr ""
 
-#: motioneye/templates/main.html:346 motioneye/templates/main.html:1007
+#: motioneye/templates/main.html:377 motioneye/templates/main.html:1038
 msgid "Redakti maskon"
 msgstr ""
 
-#: motioneye/templates/main.html:347 motioneye/templates/main.html:1008
+#: motioneye/templates/main.html:378 motioneye/templates/main.html:1039
 msgid "Konservi maskon"
 msgstr ""
 
-#: motioneye/templates/main.html:350
+#: motioneye/templates/main.html:381
 msgid "alklaku ĉi tiun butonon por ebligi/malebligi la maskan redaktilon"
 msgstr ""
 
-#: motioneye/templates/main.html:361
+#: motioneye/templates/main.html:392
 msgid "Ekstraj Elektoj"
 msgstr ""
 
-#: motioneye/templates/main.html:363
+#: motioneye/templates/main.html:394
 msgid ""
 "vi povas aldoni iujn ajn pliajn opciojn ĉi tie por la «motion» demono "
 "(uzu la «nomo valoro» formaton, unu opcion por linio)"
 msgstr ""
 
-#: motioneye/templates/main.html:372
+#: motioneye/templates/main.html:403
 msgid "elektu kie kaj kiel viaj amaskomunikiloj estas konservitaj"
 msgstr ""
 
-#: motioneye/templates/main.html:373
+#: motioneye/templates/main.html:404
 msgid "Stokado de dosieroj"
 msgstr ""
 
-#: motioneye/templates/main.html:378
+#: motioneye/templates/main.html:409
 msgid "Stokada Aparato"
 msgstr ""
 
-#: motioneye/templates/main.html:383
+#: motioneye/templates/main.html:414
 msgid ""
 "indikas la stokan aparaton, kie la bildo kaj video-dosieroj estos "
 "konservitaj"
 msgstr ""
 
-#: motioneye/templates/main.html:386
+#: motioneye/templates/main.html:417
 msgid "Retservilo"
 msgstr ""
 
-#: motioneye/templates/main.html:388
+#: motioneye/templates/main.html:419
 msgid "la adreso de la retservilo (IP-adreso aŭ nomo)"
 msgstr ""
 
-#: motioneye/templates/main.html:391
+#: motioneye/templates/main.html:422
 msgid "SMB Protokolo-Versio"
 msgstr ""
 
-#: motioneye/templates/main.html:401
+#: motioneye/templates/main.html:432
 msgid ""
 "elektu la SMB-version, kiun vi povas uzi (testu la malsamajn eblojn kaj "
 "vidu, kiu funkcias plej bone kun via NAS)"
 msgstr ""
 
-#: motioneye/templates/main.html:404
+#: motioneye/templates/main.html:435
 msgid "Kunhava nomo"
 msgstr ""
 
-#: motioneye/templates/main.html:406
+#: motioneye/templates/main.html:437
 msgid "la nomo de la interŝanĝa reto"
 msgstr ""
 
-#: motioneye/templates/main.html:409 motioneye/templates/main.html:516
+#: motioneye/templates/main.html:440 motioneye/templates/main.html:547
 msgid "Uzantnomo"
 msgstr ""
 
-#: motioneye/templates/main.html:411
+#: motioneye/templates/main.html:442
 msgid ""
 "la uzantnomo kiu estu provizita kiam vi aliras la reton dosierujon (lasu "
 "malplena se neniu uzantnomo estas bezonata)"
 msgstr ""
 
-#: motioneye/templates/main.html:414
+#: motioneye/templates/main.html:445
 msgid "Pasvorton"
 msgstr ""
 
-#: motioneye/templates/main.html:416
+#: motioneye/templates/main.html:447
 msgid ""
 "la pasvorto bezonata de la reto dosierujo (lasi malplena se neniu "
 "pasvorto estas bezonata)"
 msgstr ""
 
-#: motioneye/templates/main.html:419
+#: motioneye/templates/main.html:450
 msgid "Radika dosierujo"
 msgstr ""
 
-#: motioneye/templates/main.html:421
+#: motioneye/templates/main.html:452
 msgid ""
 "la radika vojo (sur la elektita stokada aparato), kie la dosieroj estos "
 "konservitaj"
 msgstr ""
 
-#: motioneye/templates/main.html:425
+#: motioneye/templates/main.html:456
 msgid "Testi la reton dosierujon"
 msgstr ""
 
-#: motioneye/templates/main.html:426
+#: motioneye/templates/main.html:457
 msgid ""
 "alklaku ĉi tiun butonon por testi la retan kunlokon post kiam vi plenigis"
 " la postulatajn detalojn"
 msgstr ""
 
-#: motioneye/templates/main.html:432
+#: motioneye/templates/main.html:463
 msgid "Uzado de Disko"
 msgstr ""
 
-#: motioneye/templates/main.html:436
+#: motioneye/templates/main.html:467
 msgid "la uzata/tuta grandeco de la disko, kie loĝas la radika dosierujo"
 msgstr ""
 
-#: motioneye/templates/main.html:442
+#: motioneye/templates/main.html:473
 msgid "Alŝutu Mediajn Dosierojn"
 msgstr ""
 
-#: motioneye/templates/main.html:444
+#: motioneye/templates/main.html:475
 msgid ""
 "aktivigu ĉi tiun opcion, se vi volas, ke viaj amaskomunikiloj estu "
 "alŝutitaj al ekstera servo"
 msgstr ""
 
-#: motioneye/templates/main.html:447
+#: motioneye/templates/main.html:478
 msgid "Alŝutu Bildojn"
 msgstr ""
 
-#: motioneye/templates/main.html:449
+#: motioneye/templates/main.html:480
 msgid ""
 "aktivigu ĉi tiun opcion, se vi volas, ke la bildoj elŝutiĝu al ekstera "
 "servo"
 msgstr ""
 
-#: motioneye/templates/main.html:452
+#: motioneye/templates/main.html:483
 msgid "Alŝutu Filmojn"
 msgstr ""
 
-#: motioneye/templates/main.html:454
+#: motioneye/templates/main.html:485
 msgid "ebligu ĉi tion, se vi volas, ke filmetoj estu alŝutitaj al ekstera servo"
 msgstr ""
 
-#: motioneye/templates/main.html:457
+#: motioneye/templates/main.html:488
 msgid "Alŝuta Servo"
 msgstr ""
 
-#: motioneye/templates/main.html:460
+#: motioneye/templates/main.html:491
 msgid "Servilo FTP"
 msgstr ""
 
-#: motioneye/templates/main.html:461
+#: motioneye/templates/main.html:492
 msgid "Servilo SFTP"
 msgstr ""
 
-#: motioneye/templates/main.html:462
+#: motioneye/templates/main.html:493
 msgid "Servilo HTTP"
 msgstr ""
 
-#: motioneye/templates/main.html:463
+#: motioneye/templates/main.html:494
 msgid "Servilo HTTPS"
 msgstr ""
 
-#: motioneye/templates/main.html:471
+#: motioneye/templates/main.html:502
 msgid "elektu servon, al kiu la mediadosieroj estu alŝutitaj"
 msgstr ""
 
-#: motioneye/templates/main.html:474
+#: motioneye/templates/main.html:505
 msgid "Servila Adreso"
 msgstr ""
 
-#: motioneye/templates/main.html:476
+#: motioneye/templates/main.html:507
 msgid ""
 "la domajna nomo aŭ IP-adreso de la servilo (ekz. ftp.example.com aŭ "
 "192.168.1.3)"
 msgstr ""
 
-#: motioneye/templates/main.html:479
+#: motioneye/templates/main.html:510
 msgid "Servila haveno"
 msgstr ""
 
-#: motioneye/templates/main.html:481
+#: motioneye/templates/main.html:512
 msgid ""
 "la haveno por uzi konekti al la servo (lasu ĉi tiun kampon malplena por "
 "uzi la defaŭltan valoron)"
 msgstr ""
 
-#: motioneye/templates/main.html:484
+#: motioneye/templates/main.html:515
 msgid "Metodo"
 msgstr ""
 
-#: motioneye/templates/main.html:491
+#: motioneye/templates/main.html:522
 msgid "la HTTP-metodo uzi por alŝuti dosierojn"
 msgstr ""
 
-#: motioneye/templates/main.html:494
+#: motioneye/templates/main.html:525
 msgid "Finpunkto URL"
 msgstr ""
 
-#: motioneye/templates/main.html:496
+#: motioneye/templates/main.html:527
 msgid "La kompleta URL al la alŝuta servila finpunkto:"
 msgstr ""
 
-#: motioneye/templates/main.html:497
+#: motioneye/templates/main.html:528
 msgid "Por S3: ekz. http://my.minio:9000. Lasu ĝin malplena por AWS!"
 msgstr ""
 
-#: motioneye/templates/main.html:498
+#: motioneye/templates/main.html:529
 msgid "Por WebDAV: ekz. https://my.cloud/remote.php/dav/files/Me/"
 msgstr ""
 
-#: motioneye/templates/main.html:501
+#: motioneye/templates/main.html:532
 msgid "Loko"
 msgstr ""
 
-#: motioneye/templates/main.html:503
+#: motioneye/templates/main.html:534
 msgid ""
 "la loko (radika vojo) kie amaskomunikiloj devas esti alŝutitaj (ekz. "
 "/files/cam1/)"
 msgstr ""
 
-#: motioneye/templates/main.html:506
+#: motioneye/templates/main.html:537
 msgid "Inkluzivi Subdosierujojn"
 msgstr ""
 
-#: motioneye/templates/main.html:508
+#: motioneye/templates/main.html:539
 msgid ""
 "Aktivigu tion por elŝuti plurmediajn dosierojn kun siaj subdosierujoj, "
 "anstataŭ meti ilin rekte en la radikan lokon"
 msgstr ""
 
-#: motioneye/templates/main.html:511
+#: motioneye/templates/main.html:542
 msgid "Purigi la nubon"
 msgstr ""
 
-#: motioneye/templates/main.html:513
+#: motioneye/templates/main.html:544
 msgid ""
 "ebligu ĉi tion forigi amaskomunikilaĵojn dosierojn alŝutitajn al la nubo "
 "ankaŭ kiam loka amaskomunikilaro estas forigita konforme al la agordo de "
 "persistemo de dosieroj. Nuntempe ĉi tiu opcio nur haveblas por gdrivo."
 msgstr ""
 
-#: motioneye/templates/main.html:518
+#: motioneye/templates/main.html:549
 msgid "la uzantnomo por la alŝuta servo-konto"
 msgstr ""
 
-#: motioneye/templates/main.html:523
+#: motioneye/templates/main.html:554
 msgid "la pasvorto por la alŝuta servo-konto"
 msgstr ""
 
-#: motioneye/templates/main.html:526
+#: motioneye/templates/main.html:557
 msgid "Rajtiga ŝlosilo"
 msgstr ""
 
-#: motioneye/templates/main.html:528
+#: motioneye/templates/main.html:559
 msgid ""
 "la ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo (kutime bezonata nur "
 "dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:534
+#: motioneye/templates/main.html:565
 msgid "Akiri ŝlosilon"
 msgstr ""
 
-#: motioneye/templates/main.html:537
+#: motioneye/templates/main.html:568
 msgid "alklaku ĉi tie por akiri la ŝlosilan rajtigan servon"
 msgstr ""
 
-#: motioneye/templates/main.html:540
+#: motioneye/templates/main.html:571
 msgid "Access Key"
 msgstr ""
 
-#: motioneye/templates/main.html:542
+#: motioneye/templates/main.html:573
 msgid "The AWS access key used to authenticate with the upload service"
 msgstr ""
 
-#: motioneye/templates/main.html:545
+#: motioneye/templates/main.html:576
 msgid "Sekreta Alira Ŝlosilo"
 msgstr ""
 
-#: motioneye/templates/main.html:547
+#: motioneye/templates/main.html:578
 msgid ""
 "la AWS-sekreta alira ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo "
 "(kutime bezonata nur dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:550
+#: motioneye/templates/main.html:581
 msgid "Sitelo"
 msgstr ""
 
-#: motioneye/templates/main.html:552
+#: motioneye/templates/main.html:583
 msgid "la nomo S3-sitelo por la alŝuta servo (kutime bezonata nur dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:556
+#: motioneye/templates/main.html:587
 msgid "Testi la servon"
 msgstr ""
 
-#: motioneye/templates/main.html:557
+#: motioneye/templates/main.html:588
 msgid ""
 "alklaku ĉi tiun butonon por provi la alŝutan servon post kiam vi plenigis"
 " la postulatajn detalojn"
 msgstr ""
 
-#: motioneye/templates/main.html:563
+#: motioneye/templates/main.html:594
 msgid "alvoki URL"
 msgstr ""
 
-#: motioneye/templates/main.html:565
+#: motioneye/templates/main.html:596
 msgid ""
 "ebligu ĉi tion, se vi volas, ke URL estu petata post kreado de "
 "amaskomunikila dosiero"
 msgstr ""
 
-#: motioneye/templates/main.html:568 motioneye/templates/main.html:1136
-#: motioneye/templates/main.html:1181
+#: motioneye/templates/main.html:599 motioneye/templates/main.html:1167
+#: motioneye/templates/main.html:1212
 msgid "Reteja URL"
 msgstr ""
 
-#: motioneye/templates/main.html:569
+#: motioneye/templates/main.html:600
 msgid "ekz. http://example.com/notify/"
 msgstr ""
 
-#: motioneye/templates/main.html:570
+#: motioneye/templates/main.html:601
 #, python-format
 msgid ""
 "URL por transdoni kiam moviĝo estas detektita; la sekvaj specialaj "
@@ -699,36 +731,36 @@ msgid ""
 "numero,%%f = dosiera vojo"
 msgstr ""
 
-#: motioneye/templates/main.html:573 motioneye/templates/main.html:1141
-#: motioneye/templates/main.html:1186
+#: motioneye/templates/main.html:604 motioneye/templates/main.html:1172
+#: motioneye/templates/main.html:1217
 msgid "Metodo HTTP"
 msgstr ""
 
-#: motioneye/templates/main.html:582
+#: motioneye/templates/main.html:613
 msgid ""
 "la HTTP-metodo por uzi kiam vi petas retan hoko-URL (la donitaj URL-"
 "koditaj parametroj fakte estos transdonitaj kiel indikite ĉi tie)"
 msgstr ""
 
-#: motioneye/templates/main.html:588
+#: motioneye/templates/main.html:619
 msgid "Kuri Komando"
 msgstr ""
 
-#: motioneye/templates/main.html:590
+#: motioneye/templates/main.html:621
 msgid ""
 "ebligu ĉi tion, se vi volas ekzekuti komandon post kiam media dosiero "
 "estas kreita"
 msgstr ""
 
-#: motioneye/templates/main.html:593
+#: motioneye/templates/main.html:624
 msgid "Ordono"
 msgstr ""
 
-#: motioneye/templates/main.html:594
+#: motioneye/templates/main.html:625
 msgid "ordono…"
 msgstr ""
 
-#: motioneye/templates/main.html:595
+#: motioneye/templates/main.html:626
 #, python-format
 msgid ""
 "Komando por esti plenumita post la kreo de plurmedia dosiero. Pluraj "
@@ -738,42 +770,42 @@ msgid ""
 "kadra numero , %%v = okaza numero, %%f = dosiera vojo"
 msgstr ""
 
-#: motioneye/templates/main.html:605
+#: motioneye/templates/main.html:636
 msgid "elektu kiajn informojn montras sur la kaptitaj kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:606
+#: motioneye/templates/main.html:637
 msgid "Teksto Superkovrita"
 msgstr ""
 
-#: motioneye/templates/main.html:611
+#: motioneye/templates/main.html:642
 msgid "Maldekstra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:615 motioneye/templates/main.html:632
+#: motioneye/templates/main.html:646 motioneye/templates/main.html:663
 msgid "Tempostampo"
 msgstr ""
 
-#: motioneye/templates/main.html:616 motioneye/templates/main.html:633
+#: motioneye/templates/main.html:647 motioneye/templates/main.html:664
 msgid "Propra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:617 motioneye/templates/main.html:634
-#: motioneye/templates/main.html:691
+#: motioneye/templates/main.html:648 motioneye/templates/main.html:665
+#: motioneye/templates/main.html:722
 msgid "Malebligita"
 msgstr ""
 
-#: motioneye/templates/main.html:620
+#: motioneye/templates/main.html:651
 msgid ""
 "Fiksas la tekston montritan sur la filmoj kaj bildoj, sur la malsupra "
 "maldekstra angulo"
 msgstr ""
 
-#: motioneye/templates/main.html:624 motioneye/templates/main.html:641
+#: motioneye/templates/main.html:655 motioneye/templates/main.html:672
 msgid "propra teksto…"
 msgstr ""
 
-#: motioneye/templates/main.html:625
+#: motioneye/templates/main.html:656
 #, python-format
 msgid ""
 "Difinas kutimon maldekstran tekston; la sekvaj specialaj tokensoj estas "
@@ -782,17 +814,17 @@ msgid ""
 "nova linio"
 msgstr ""
 
-#: motioneye/templates/main.html:628
+#: motioneye/templates/main.html:659
 msgid "Dekstra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:637
+#: motioneye/templates/main.html:668
 msgid ""
 "Fiksas la tekston montritan sur la filmoj kaj bildoj, sur la malsupra "
 "dekstra angulo"
 msgstr ""
 
-#: motioneye/templates/main.html:642
+#: motioneye/templates/main.html:673
 #, python-format
 msgid ""
 "Difinas kutimon dekstran tekston; la sekvaj specialaj tokensoj estas "
@@ -801,138 +833,138 @@ msgid ""
 "nova linio"
 msgstr ""
 
-#: motioneye/templates/main.html:645
+#: motioneye/templates/main.html:676
 msgid "Teksta Skalo"
 msgstr ""
 
-#: motioneye/templates/main.html:647
+#: motioneye/templates/main.html:678
 msgid "Difinas la grandecon de la superkovrita teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:657
+#: motioneye/templates/main.html:688
 msgid "Ebligu ĉi tion, se vi volas videofluon por ĉi tiu fotilo"
 msgstr ""
 
-#: motioneye/templates/main.html:658
+#: motioneye/templates/main.html:689
 msgid "Videofluo"
 msgstr ""
 
-#: motioneye/templates/main.html:663
+#: motioneye/templates/main.html:694
 msgid "Framo frekvencon"
 msgstr ""
 
-#: motioneye/templates/main.html:665
+#: motioneye/templates/main.html:696
 msgid "Fiksas la nombron de kadroj transdonitaj ĉiun sekundon en la viva fluo."
 msgstr ""
 
-#: motioneye/templates/main.html:668
+#: motioneye/templates/main.html:699
 msgid "Flua Kvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:670
+#: motioneye/templates/main.html:701
 msgid ""
 "Agordas la vivan fluan kvaliton (pli altaj valoroj produktas pli bonan "
 "videokvaliton sed postulas pli da larĝa bando)."
 msgstr ""
 
-#: motioneye/templates/main.html:673
+#: motioneye/templates/main.html:704
 msgid "Bilda Redimensionado"
 msgstr ""
 
-#: motioneye/templates/main.html:675
+#: motioneye/templates/main.html:706
 msgid ""
 "Kiam ĉi tio estas enŝaltita, la bildoj estas regrandigitaj antaŭ ol ili "
 "estas senditaj al la retumilo (malebligu dum funkciado sur malrapida "
 "CPU)."
 msgstr ""
 
-#: motioneye/templates/main.html:678
+#: motioneye/templates/main.html:709
 msgid "Flua rezolucio"
 msgstr ""
 
-#: motioneye/templates/main.html:680
+#: motioneye/templates/main.html:711
 msgid ""
 "la rezolucio donita kiel procento de la rezolucio de la video-aparato "
 "(pli altaj valoroj produktas pli bonan videan kvaliton sed postulas pli "
 "da larĝa de bando)"
 msgstr ""
 
-#: motioneye/templates/main.html:683
+#: motioneye/templates/main.html:714
 msgid "Flua haveno"
 msgstr ""
 
-#: motioneye/templates/main.html:685
+#: motioneye/templates/main.html:716
 msgid "starigas la TCP-havenon, sur kiu aŭskultas la ret-servila ret-servo"
 msgstr ""
 
-#: motioneye/templates/main.html:688
+#: motioneye/templates/main.html:719
 msgid "Aŭtentiga reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:696
+#: motioneye/templates/main.html:727
 msgid ""
 "la aŭtentiga metodo uzata de la rivereto (elektu 'Bazic' anstataŭ "
 "'Digest' se vi renkontas problemojn kun triaj programoj); akreditoj "
 "kontroloj estos uzataj"
 msgstr ""
 
-#: motioneye/templates/main.html:699
+#: motioneye/templates/main.html:730
 msgid "Movado-Optimigo"
 msgstr ""
 
-#: motioneye/templates/main.html:701
+#: motioneye/templates/main.html:732
 msgid ""
 "ebligu ĉi tion, se vi volas pli malaltan kadran indicon por la livera "
 "fluo kiam neniu movo estas detektita"
 msgstr ""
 
-#: motioneye/templates/main.html:707
+#: motioneye/templates/main.html:738
 msgid "Utilaj URLoj"
 msgstr ""
 
-#: motioneye/templates/main.html:710
+#: motioneye/templates/main.html:741
 msgid "Instantara URL"
 msgstr ""
 
-#: motioneye/templates/main.html:713
+#: motioneye/templates/main.html:744
 msgid "URL kiu provizas JPEG-bildon kun la plej freŝa kaptaĵo de la kamerao"
 msgstr ""
 
-#: motioneye/templates/main.html:719
+#: motioneye/templates/main.html:750
 msgid "Flua URL"
 msgstr ""
 
-#: motioneye/templates/main.html:722
+#: motioneye/templates/main.html:753
 msgid "URL kiu provizas MJPEG-fluon de la kamerao"
 msgstr ""
 
-#: motioneye/templates/main.html:728
+#: motioneye/templates/main.html:759
 msgid "Enigita URL"
 msgstr ""
 
-#: motioneye/templates/main.html:731
+#: motioneye/templates/main.html:762
 msgid ""
 "URL kiu provizas minimuman HTML-dokumenton enhavantan la kameraan kadron,"
 " preta por esti enigita"
 msgstr ""
 
-#: motioneye/templates/main.html:741
+#: motioneye/templates/main.html:772
 msgid "Ebligu ĉi tion, se vi volas kapti statika bildojn."
 msgstr ""
 
-#: motioneye/templates/main.html:742
+#: motioneye/templates/main.html:773
 msgid "Kaptitaj Bildoj"
 msgstr ""
 
-#: motioneye/templates/main.html:747
+#: motioneye/templates/main.html:778
 msgid "Nomo Bildo-Dosiero"
 msgstr ""
 
-#: motioneye/templates/main.html:748 motioneye/templates/main.html:817
+#: motioneye/templates/main.html:779 motioneye/templates/main.html:848
 msgid "dosiernomo ŝablono…"
 msgstr ""
 
-#: motioneye/templates/main.html:749
+#: motioneye/templates/main.html:780
 #, python-format
 msgid ""
 "Difinas la nomon ŝablonon por bilddosieroj (JPEG); la sekvaj specialaj "
@@ -941,139 +973,139 @@ msgid ""
 " = subdosierujo."
 msgstr ""
 
-#: motioneye/templates/main.html:752
+#: motioneye/templates/main.html:783
 msgid "Bildkvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:754
+#: motioneye/templates/main.html:785
 msgid ""
 "agordas la JPEG-bildkvaliton (pli altaj valoroj produktas pli bonan "
 "bildan kvaliton sed postulas pli da stokado)"
 msgstr ""
 
-#: motioneye/templates/main.html:757
+#: motioneye/templates/main.html:788
 msgid "Kaptila reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:760 motioneye/templates/main.html:880
+#: motioneye/templates/main.html:791 motioneye/templates/main.html:911
 msgid "Moviĝa deĉenigo"
 msgstr ""
 
-#: motioneye/templates/main.html:761
+#: motioneye/templates/main.html:792
 msgid "Moviĝa deĉenigo (Unu bildo)"
 msgstr ""
 
-#: motioneye/templates/main.html:762
+#: motioneye/templates/main.html:793
 msgid "Intertempe"
 msgstr ""
 
-#: motioneye/templates/main.html:763
+#: motioneye/templates/main.html:794
 msgid "Ĉiuj bildoj"
 msgstr ""
 
-#: motioneye/templates/main.html:764
+#: motioneye/templates/main.html:795
 msgid "Mane"
 msgstr ""
 
-#: motioneye/templates/main.html:767
+#: motioneye/templates/main.html:798
 msgid "Difinas la kapta reĝimon:"
 msgstr ""
 
-#: motioneye/templates/main.html:768
+#: motioneye/templates/main.html:799
 msgid "Moviĝa deĉenigo = bildo kaptita ĉiufoje kiam moviĝo estas detektita,"
 msgstr ""
 
-#: motioneye/templates/main.html:769
+#: motioneye/templates/main.html:800
 msgid "Intertempe = bildo kaptita ĉiun x sekundojn,"
 msgstr ""
 
-#: motioneye/templates/main.html:770
+#: motioneye/templates/main.html:801
 msgid "Ĉiuj bildoj = konservas ĉiun kadron en bildodosiero,"
 msgstr ""
 
-#: motioneye/templates/main.html:771
+#: motioneye/templates/main.html:802
 msgid "Mane = mana kapto kun dediĉita butono."
 msgstr ""
 
-#: motioneye/templates/main.html:774
+#: motioneye/templates/main.html:805
 msgid "Interkapto-Intervalo"
 msgstr ""
 
-#: motioneye/templates/main.html:775 motioneye/templates/main.html:888
-#: motioneye/templates/main.html:963 motioneye/templates/main.html:1092
+#: motioneye/templates/main.html:806 motioneye/templates/main.html:919
+#: motioneye/templates/main.html:994 motioneye/templates/main.html:1123
 #: motioneye/utils/dtconv.py:146 motioneye/utils/dtconv.py:149
 msgid "sekundoj"
 msgstr ""
 
-#: motioneye/templates/main.html:776
+#: motioneye/templates/main.html:807
 msgid "agordas la intervalon (en sekundoj) por la kaptiloj"
 msgstr ""
 
-#: motioneye/templates/main.html:779
+#: motioneye/templates/main.html:810
 msgid "Konservi bildojn"
 msgstr ""
 
-#: motioneye/templates/main.html:782 motioneye/templates/main.html:895
+#: motioneye/templates/main.html:813 motioneye/templates/main.html:926
 msgid "Dum unu tago"
 msgstr ""
 
-#: motioneye/templates/main.html:783 motioneye/templates/main.html:896
+#: motioneye/templates/main.html:814 motioneye/templates/main.html:927
 msgid "Dum unu semajno"
 msgstr ""
 
-#: motioneye/templates/main.html:784 motioneye/templates/main.html:897
+#: motioneye/templates/main.html:815 motioneye/templates/main.html:928
 msgid "Dum unu monato"
 msgstr ""
 
-#: motioneye/templates/main.html:785 motioneye/templates/main.html:898
+#: motioneye/templates/main.html:816 motioneye/templates/main.html:929
 msgid "Dum unu jaro"
 msgstr ""
 
-#: motioneye/templates/main.html:786 motioneye/templates/main.html:899
+#: motioneye/templates/main.html:817 motioneye/templates/main.html:930
 msgid "Porĉiame"
 msgstr ""
 
-#: motioneye/templates/main.html:787 motioneye/templates/main.html:900
+#: motioneye/templates/main.html:818 motioneye/templates/main.html:931
 msgid "Propra"
 msgstr ""
 
-#: motioneye/templates/main.html:790
+#: motioneye/templates/main.html:821
 msgid ""
 "Bildoj pli aĝaj ol la difinita daŭro estas aŭtomate forigitaj por "
 "liberigi stokadan spacon."
 msgstr ""
 
-#: motioneye/templates/main.html:793
+#: motioneye/templates/main.html:824
 msgid "Bildaj Vivdaŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:795
+#: motioneye/templates/main.html:826
 msgid "Difinas la nombron da tagoj post kiuj la bildoj estos forigitaj aŭtomate."
 msgstr ""
 
-#: motioneye/templates/main.html:798
+#: motioneye/templates/main.html:829
 msgid "Ebligu manaj kaptoj"
 msgstr ""
 
-#: motioneye/templates/main.html:800
+#: motioneye/templates/main.html:831
 msgid ""
 "Kiam ĉi tio estas enŝaltita, butono sur la kameraa kadro permesos al vi "
 "permane preni kaptojn."
 msgstr ""
 
-#: motioneye/templates/main.html:810
+#: motioneye/templates/main.html:841
 msgid "ebligu ĉi tion, se vi volas registri filmojn"
 msgstr ""
 
-#: motioneye/templates/main.html:811
+#: motioneye/templates/main.html:842
 msgid "Filmoj"
 msgstr ""
 
-#: motioneye/templates/main.html:816
+#: motioneye/templates/main.html:847
 msgid "Filma Dosiernomo"
 msgstr ""
 
-#: motioneye/templates/main.html:818
+#: motioneye/templates/main.html:849
 #, python-format
 msgid ""
 "Difinas la nomon ŝablonon por por la filmdosieroj; la sekvaj specialaj "
@@ -1082,11 +1114,11 @@ msgid ""
 " = subdosierujo."
 msgstr ""
 
-#: motioneye/templates/main.html:821
+#: motioneye/templates/main.html:852
 msgid "Rekta kopia filmeto"
 msgstr ""
 
-#: motioneye/templates/main.html:823
+#: motioneye/templates/main.html:854
 msgid ""
 "Kreu filmojn rekte de la kamerao. Ĉi tiu opcio devus redukti CPU-uzadon "
 "sed pliigi memorpostulojn. Neniu bilda prilaborado estas farita, do "
@@ -1094,131 +1126,131 @@ msgid ""
 "video."
 msgstr ""
 
-#: motioneye/templates/main.html:826
+#: motioneye/templates/main.html:857
 msgid "Filmformato"
 msgstr ""
 
-#: motioneye/templates/main.html:869
+#: motioneye/templates/main.html:900
 msgid ""
 "Agordas la filmdosieron; ne ĉiuj formatoj garantias funkcii en ĉiuj "
 "sistemoj; se vi dubas, testu ĉiun formaton kaj elektu tiun, kiu plej bone"
 " funkcias per via filmetilo."
 msgstr ""
 
-#: motioneye/templates/main.html:872
+#: motioneye/templates/main.html:903
 msgid "Filma Kvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:874
+#: motioneye/templates/main.html:905
 msgid ""
 "Agordas la MPEG-video-kvaliton (pli altaj valoroj produktas pli bonan "
 "videokvaliton sed postulas pli da stokado)."
 msgstr ""
 
-#: motioneye/templates/main.html:877
+#: motioneye/templates/main.html:908
 msgid "Rekorda reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:881
+#: motioneye/templates/main.html:912
 msgid "Kontinua registrado"
 msgstr ""
 
-#: motioneye/templates/main.html:884
+#: motioneye/templates/main.html:915
 msgid ""
 "Agordas la registradreĝimon: Moviĝa deĉenigo = nova filmo kreita kiam ajn"
 " moviĝo estas detektita, Kontinua Registrado = unu granda filma dosiero."
 msgstr ""
 
-#: motioneye/templates/main.html:887
+#: motioneye/templates/main.html:918
 msgid "Maksimuma filma daŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:889
+#: motioneye/templates/main.html:920
 msgid ""
 "Agordas la maksimuman longon de filmoj en sekundoj; se la movada evento "
 "daŭras pli longe, nova filmdosiero estas kreita; uzu 0 por senlima longo."
 msgstr ""
 
-#: motioneye/templates/main.html:892
+#: motioneye/templates/main.html:923
 msgid "Konservi filmojn"
 msgstr ""
 
-#: motioneye/templates/main.html:903
+#: motioneye/templates/main.html:934
 msgid ""
 "Filmoj pli aĝaj ol la difinita daŭro estas aŭtomate forigitaj por "
 "liberigi stokadon."
 msgstr ""
 
-#: motioneye/templates/main.html:906
+#: motioneye/templates/main.html:937
 msgid "Filmoj Vivdaŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:907 motioneye/utils/dtconv.py:125
+#: motioneye/templates/main.html:938 motioneye/utils/dtconv.py:125
 msgid "tagoj"
 msgstr ""
 
-#: motioneye/templates/main.html:908
+#: motioneye/templates/main.html:939
 msgid "Agordas la nombron da tagoj post kiuj la filmoj estos forigitaj aŭtomate."
 msgstr ""
 
-#: motioneye/templates/main.html:918
+#: motioneye/templates/main.html:949
 msgid "Aktivigu ĉi tion, por uzi kaj agordi la mekanismon por detekti movadon."
 msgstr ""
 
-#: motioneye/templates/main.html:919
+#: motioneye/templates/main.html:950
 msgid "Movado-Detekto"
 msgstr ""
 
-#: motioneye/templates/main.html:924
+#: motioneye/templates/main.html:955
 msgid "Kadra ŝanĝo sojlo"
 msgstr ""
 
-#: motioneye/templates/main.html:926
+#: motioneye/templates/main.html:957
 msgid ""
 "Indikas la minimuman procenton de la bildo, kiu devas ŝanĝi inter du "
 "pluaj kadroj por detekti movadon (pli malgrandaj valoroj donas pli "
 "sentivan detekton, sed inklinas al falsaj pozitivoj)."
 msgstr ""
 
-#: motioneye/templates/main.html:929
+#: motioneye/templates/main.html:960
 msgid "Maksimuma ŝanĝo sojlo"
 msgstr ""
 
-#: motioneye/templates/main.html:931
+#: motioneye/templates/main.html:962
 msgid ""
 "Starigas la nombron da rastrumeroj ŝanĝitaj inter kadroj super kiuj movo "
 "ne plu ekigas (0 malŝaltas la limon)."
 msgstr ""
 
-#: motioneye/templates/main.html:934
+#: motioneye/templates/main.html:965
 msgid "Aŭtomata sojla agordo"
 msgstr ""
 
-#: motioneye/templates/main.html:936
+#: motioneye/templates/main.html:967
 msgid "Ebligu tion aŭtomate ĝustigi la sojlon."
 msgstr ""
 
-#: motioneye/templates/main.html:939
+#: motioneye/templates/main.html:970
 msgid "Aŭtomata bruo-detekto"
 msgstr ""
 
-#: motioneye/templates/main.html:941
+#: motioneye/templates/main.html:972
 msgid "Ebligu tion por aŭtomate ĝustigi la nivelon de bruo."
 msgstr ""
 
-#: motioneye/templates/main.html:944
+#: motioneye/templates/main.html:975
 msgid "Bruo-nivelo"
 msgstr ""
 
-#: motioneye/templates/main.html:946
+#: motioneye/templates/main.html:977
 msgid "Permane agordas la bruan nivelon al fiksita valoro."
 msgstr ""
 
-#: motioneye/templates/main.html:949
+#: motioneye/templates/main.html:980
 msgid "Detekto de lumaj ŝanĝoj"
 msgstr ""
 
-#: motioneye/templates/main.html:951
+#: motioneye/templates/main.html:982
 #, python-format
 msgid ""
 "Difinas la procenton de la bildo, kiu bezonas ŝanĝi, por ke la evento "
@@ -1226,240 +1258,240 @@ msgid ""
 "funkcion)."
 msgstr ""
 
-#: motioneye/templates/main.html:954
+#: motioneye/templates/main.html:985
 msgid "Makula filtrilo"
 msgstr ""
 
-#: motioneye/templates/main.html:956
+#: motioneye/templates/main.html:987
 msgid "Ebligu tion apliki makulan filtrilon al kadroj antaŭ ol detekti movadon."
 msgstr ""
 
-#: motioneye/templates/main.html:962
+#: motioneye/templates/main.html:993
 msgid "Senmovada daŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:964
+#: motioneye/templates/main.html:995
 msgid ""
 "Agordas la nombron da sekundoj da silento (t.e. neniu moviĝo), kiuj "
 "markas la finon de movada okazaĵo."
 msgstr ""
 
-#: motioneye/templates/main.html:967
+#: motioneye/templates/main.html:998
 msgid "Kaptita Antaŭe"
 msgstr ""
 
-#: motioneye/templates/main.html:968 motioneye/templates/main.html:973
-#: motioneye/templates/main.html:978
+#: motioneye/templates/main.html:999 motioneye/templates/main.html:1004
+#: motioneye/templates/main.html:1009
 msgid "kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:969
+#: motioneye/templates/main.html:1000
 msgid ""
 "Starigas la nombron de kadroj kaptitaj (kaj inkluzivitaj en la filmo) "
 "antaŭ ol moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:972
+#: motioneye/templates/main.html:1003
 msgid "Kaptita Post"
 msgstr ""
 
-#: motioneye/templates/main.html:974
+#: motioneye/templates/main.html:1005
 msgid ""
 "Starigas la nombron de kadroj kaptotaj (kaj inkluzivitaj en la filmo) "
 "post la fino de movada evento."
 msgstr ""
 
-#: motioneye/templates/main.html:977
+#: motioneye/templates/main.html:1008
 msgid "Minimumaj movaj kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:979
+#: motioneye/templates/main.html:1010
 msgid ""
 "Fiksas la minimuman nombron da pluaj movaj kadroj necesaj por komenci "
 "moviĝan eventon."
 msgstr ""
 
-#: motioneye/templates/main.html:985
+#: motioneye/templates/main.html:1016
 msgid "Masko"
 msgstr ""
 
-#: motioneye/templates/main.html:987
+#: motioneye/templates/main.html:1018
 msgid "Ebligas bildigan maskeradon por pli selektema kaj preciza moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:990
+#: motioneye/templates/main.html:1021
 msgid "Tipo de masko"
 msgstr ""
 
-#: motioneye/templates/main.html:993
+#: motioneye/templates/main.html:1024
 msgid "Inteligenta"
 msgstr ""
 
-#: motioneye/templates/main.html:994
+#: motioneye/templates/main.html:1025
 msgid "Redaktebla"
 msgstr ""
 
-#: motioneye/templates/main.html:997
+#: motioneye/templates/main.html:1028
 msgid ""
 "La Inteligenta opcio aŭtomate detektas regionojn per regula movado kaj "
 "dinamike kreas internan maskon, dum la Redaktebla opcio permesas permane "
 "konstrui ĝin mem."
 msgstr ""
 
-#: motioneye/templates/main.html:1000
+#: motioneye/templates/main.html:1031
 msgid "Inteligenta-maska Malrapideco"
 msgstr ""
 
-#: motioneye/templates/main.html:1002
+#: motioneye/templates/main.html:1033
 msgid ""
 "Pli altaj valoroj donas pli daŭran maskon kun pli malrapida "
 "konstruprocezo."
 msgstr ""
 
-#: motioneye/templates/main.html:1011
+#: motioneye/templates/main.html:1042
 msgid "Alklaku ĉi tiun butonon por ebligi/malebligi la maskan redaktilon."
 msgstr ""
 
-#: motioneye/templates/main.html:1015
+#: motioneye/templates/main.html:1046
 msgid "Purigi maskon"
 msgstr ""
 
-#: motioneye/templates/main.html:1016
+#: motioneye/templates/main.html:1047
 msgid "Alklaku ĉi tiun butonon por malplenigi la nunan maskon."
 msgstr ""
 
-#: motioneye/templates/main.html:1022
+#: motioneye/templates/main.html:1053
 msgid "Montri Kadro-Ŝanĝojn"
 msgstr ""
 
-#: motioneye/templates/main.html:1024
+#: motioneye/templates/main.html:1055
 msgid ""
 "Se ĉi tio estas aktiva, la bilda ŝanĝojn (nombro de pikseloj kaj la "
 "modifita areo) estas montritaj en la video; provizore ebligigu ĉi tion "
 "por ĝustigi agordojn de moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:1027
+#: motioneye/templates/main.html:1058
 msgid "Krei debug media files"
 msgstr ""
 
-#: motioneye/templates/main.html:1029
+#: motioneye/templates/main.html:1060
 msgid ""
 "Kiam ebligite, kreas specialajn filmojn kaj bildojn, kiuj helpas elpurigi"
 " problemojn de moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:1038
+#: motioneye/templates/main.html:1069
 msgid "Ebligu tion se vi volas esti sciigita kiam moviĝo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1039
+#: motioneye/templates/main.html:1070
 msgid "Moviĝaj sciigoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1051
+#: motioneye/templates/main.html:1082
 msgid "Sendi retpoŝton"
 msgstr ""
 
-#: motioneye/templates/main.html:1053
+#: motioneye/templates/main.html:1084
 msgid ""
 "Aktivigu ĉi tiun opcion, se vi volas ricevi retpoŝton ĉiufoje kiam "
 "moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1056
+#: motioneye/templates/main.html:1087
 msgid "Retpoŝtadresoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1057
+#: motioneye/templates/main.html:1088
 msgid "retpoŝtadresoj…"
 msgstr ""
 
-#: motioneye/templates/main.html:1058
+#: motioneye/templates/main.html:1089
 msgid ""
 "Retpoŝtadresoj (apartigitaj per komo) aldonitaj ĉi tie ricevos sciigojn "
 "kiam ajn moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1061
+#: motioneye/templates/main.html:1092
 msgid "Servilo SMTP"
 msgstr ""
 
-#: motioneye/templates/main.html:1062
+#: motioneye/templates/main.html:1093
 msgid "ekz. smtp.gmail.com"
 msgstr ""
 
-#: motioneye/templates/main.html:1063
+#: motioneye/templates/main.html:1094
 msgid ""
 "Enigu la hostname aŭ IP-adreson de via SMTP-servilo (por uzado de Gmail "
 "smtp.gmail.com)."
 msgstr ""
 
-#: motioneye/templates/main.html:1066
+#: motioneye/templates/main.html:1097
 msgid "SMTP Haveno"
 msgstr ""
 
-#: motioneye/templates/main.html:1067
+#: motioneye/templates/main.html:1098
 msgid "ekz. 587"
 msgstr ""
 
-#: motioneye/templates/main.html:1068
+#: motioneye/templates/main.html:1099
 msgid ""
 "Eniru la havenon uzatan de via SMTP-servilo (kutime 465 por ne-TLS-ligoj "
 "kaj 587 por TLS-ligoj)."
 msgstr ""
 
-#: motioneye/templates/main.html:1071
+#: motioneye/templates/main.html:1102
 msgid "SMTP-Konto"
 msgstr ""
 
-#: motioneye/templates/main.html:1072
+#: motioneye/templates/main.html:1103
 msgid "konto@gmail.com…"
 msgstr ""
 
-#: motioneye/templates/main.html:1073
+#: motioneye/templates/main.html:1104
 msgid "Enigu vian SMTPan konton (kutime via retpoŝta adreso)."
 msgstr ""
 
-#: motioneye/templates/main.html:1076
+#: motioneye/templates/main.html:1107
 msgid "SMTP Pasvorto"
 msgstr ""
 
-#: motioneye/templates/main.html:1078
+#: motioneye/templates/main.html:1109
 msgid ""
 "Enigu vian SMTPan pasvorton (por Gmail uzu vian Google-pasvorton aŭ app-"
 "specifan generitan pasvorton)."
 msgstr ""
 
-#: motioneye/templates/main.html:1081
+#: motioneye/templates/main.html:1112
 msgid "De adreso"
 msgstr ""
 
-#: motioneye/templates/main.html:1082
+#: motioneye/templates/main.html:1113
 msgid "retpoŝta adreso…"
 msgstr ""
 
-#: motioneye/templates/main.html:1083
+#: motioneye/templates/main.html:1114
 msgid ""
 "Agordi kutimon De adreso, se via SMTP-servo postulas unu (la unua destina"
 " retpoŝta adreso estos uzata se lasita malplena)."
 msgstr ""
 
-#: motioneye/templates/main.html:1086
+#: motioneye/templates/main.html:1117
 msgid "Uzi TLS"
 msgstr ""
 
-#: motioneye/templates/main.html:1088
+#: motioneye/templates/main.html:1119
 msgid ""
 "Ebligu tion, se via SMTP-servilo postulas TLS (Gmail bezonas ĉi tion por "
 "ebligi)."
 msgstr ""
 
-#: motioneye/templates/main.html:1091
+#: motioneye/templates/main.html:1122
 msgid "Aldonitaj bildoj tempo-intervalo"
 msgstr ""
 
-#: motioneye/templates/main.html:1093
+#: motioneye/templates/main.html:1124
 msgid ""
 "Difinas la tempo-serĉan intervalon por uzi dum kreado de retpoŝtaj "
 "ligiloj (pli altaj valoroj generas retpoŝtojn kun pli da bildoj koste de "
@@ -1467,35 +1499,35 @@ msgid ""
 " ankaŭ devas rajtigi «Kaptitaj bildoj» por ke ĉi tio funkciu."
 msgstr ""
 
-#: motioneye/templates/main.html:1097
+#: motioneye/templates/main.html:1128
 msgid "Testi retpoŝto"
 msgstr ""
 
-#: motioneye/templates/main.html:1098
+#: motioneye/templates/main.html:1129
 msgid ""
 "Alklaku ĉi tiun butonon por testi retpoŝtajn sciigojn post kiam vi "
 "plenigis la postulatajn detalojn."
 msgstr ""
 
-#: motioneye/templates/main.html:1104
+#: motioneye/templates/main.html:1135
 msgid "Sendu Telegraman Sciigon"
 msgstr ""
 
-#: motioneye/templates/main.html:1106
+#: motioneye/templates/main.html:1137
 msgid ""
 "ebligu tion se vi volas ricevi telegraman mesaĝon kiam ajn moviĝa evento "
 "estas detektita"
 msgstr ""
 
-#: motioneye/templates/main.html:1109
+#: motioneye/templates/main.html:1140
 msgid "HTTP API ĵetono"
 msgstr ""
 
-#: motioneye/templates/main.html:1110
+#: motioneye/templates/main.html:1141
 msgid "Ekzemplo: 93847672:AACdSn843hsjJsh32bSmdN3sHsh2bsh0xRs_32dbcr1W"
 msgstr ""
 
-#: motioneye/templates/main.html:1111
+#: motioneye/templates/main.html:1142
 msgid ""
 "Kreante la telegram-bot-babilejon, vi ricevos API-ĵetonon, kiun vi devas "
 "enigi ĉi tie. Alklaku la API-butonon sube por paŝo-post-paŝa gvidilo pri "
@@ -1504,25 +1536,25 @@ msgid ""
 "mesaĝojn."
 msgstr ""
 
-#: motioneye/templates/main.html:1114
+#: motioneye/templates/main.html:1145
 msgid "Babileja ID"
 msgstr ""
 
-#: motioneye/templates/main.html:1115
+#: motioneye/templates/main.html:1146
 msgid "Ekzemplo: 938272312"
 msgstr ""
 
-#: motioneye/templates/main.html:1116
+#: motioneye/templates/main.html:1147
 msgid ""
 "Kreu novan babilejon al id_chatbot (@id_chatbot) kaj elektu starti. La "
 "babilejo redonos la necesan numeron por ĉi tiu kampo."
 msgstr ""
 
-#: motioneye/templates/main.html:1119
+#: motioneye/templates/main.html:1150
 msgid "Alkroĉitaj Bildoj Tempo"
 msgstr ""
 
-#: motioneye/templates/main.html:1121
+#: motioneye/templates/main.html:1152
 msgid ""
 "difinas la bildan serĉtempan intervalon por krei telegramajn aldonojn "
 "(pli altaj valoroj generas pli da bildoj koste de pliigita sciiga "
@@ -1533,29 +1565,29 @@ msgid ""
 "ekigita, starigu ĉi tion multe pli malalte."
 msgstr ""
 
-#: motioneye/templates/main.html:1124
+#: motioneye/templates/main.html:1155
 msgid "API-Informoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1125
+#: motioneye/templates/main.html:1156
 msgid "Testo"
 msgstr ""
 
-#: motioneye/templates/main.html:1131 motioneye/templates/main.html:1176
+#: motioneye/templates/main.html:1162 motioneye/templates/main.html:1207
 msgid "Alvoki URL"
 msgstr ""
 
-#: motioneye/templates/main.html:1133
+#: motioneye/templates/main.html:1164
 msgid ""
 "Ebligu ĉi tion, se vi volas, ke URL estu petata kiam ajn moviĝokazaĵo "
 "estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1137
+#: motioneye/templates/main.html:1168
 msgid "ekz. http://ekzemplo.com/sciigi/"
 msgstr ""
 
-#: motioneye/templates/main.html:1138
+#: motioneye/templates/main.html:1169
 #, python-format
 msgid ""
 "URL por esti petita kiam moviĝo estas detektita; la sekvaj specialaj "
@@ -1563,31 +1595,31 @@ msgid ""
 "horo, %%M = minuto, %%S = sekundo, %%q = kadro-numero, %%v = okaza numero"
 msgstr ""
 
-#: motioneye/templates/main.html:1150 motioneye/templates/main.html:1195
+#: motioneye/templates/main.html:1181 motioneye/templates/main.html:1226
 msgid ""
 "La HTTP-metodo por uzi kiam vi petas URL (la donitaj URL-parametroj estos"
 " transdonitaj kiel indikite ĉi tie)."
 msgstr ""
 
-#: motioneye/templates/main.html:1156 motioneye/templates/main.html:1201
+#: motioneye/templates/main.html:1187 motioneye/templates/main.html:1232
 msgid "Lanĉi komando"
 msgstr ""
 
-#: motioneye/templates/main.html:1158
+#: motioneye/templates/main.html:1189
 msgid ""
 "Ebligu ĉi tion, se vi volas lanĉi komandon ĉiufoje kiam moviĝokazaĵo "
 "estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1161 motioneye/templates/main.html:1206
+#: motioneye/templates/main.html:1192 motioneye/templates/main.html:1237
 msgid "Komando"
 msgstr ""
 
-#: motioneye/templates/main.html:1162 motioneye/templates/main.html:1207
+#: motioneye/templates/main.html:1193 motioneye/templates/main.html:1238
 msgid "komando…"
 msgstr ""
 
-#: motioneye/templates/main.html:1163
+#: motioneye/templates/main.html:1194
 #, python-format
 msgid ""
 "Komando por esti lanĉa kiam moviĝo estas detektita; multnombraj komandoj "
@@ -1597,13 +1629,13 @@ msgid ""
 "%%v = okaza numero"
 msgstr ""
 
-#: motioneye/templates/main.html:1203
+#: motioneye/templates/main.html:1234
 msgid ""
 "Ebligu ĉi tion, se vi volas lanĉi komandon ĉiufoje kiam movada evento "
 "finiĝos."
 msgstr ""
 
-#: motioneye/templates/main.html:1208
+#: motioneye/templates/main.html:1239
 #, python-format
 msgid ""
 "Komando por esti lanĉa kiam moviĝokazaĵo finiĝas; multnombraj komandoj "
@@ -1612,93 +1644,93 @@ msgid ""
 "%%d = dato, %%H = horo, %%M = minuto, %%S = sekundo, %%q = kadra nombro."
 msgstr ""
 
-#: motioneye/templates/main.html:1218
+#: motioneye/templates/main.html:1249
 msgid ""
 "Ebligu ĉi tion, se vi volas difini ĉiusemajnan horaron por detekto de "
 "moviĝo."
 msgstr ""
 
-#: motioneye/templates/main.html:1219
+#: motioneye/templates/main.html:1250
 msgid "Laboranta horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1224
+#: motioneye/templates/main.html:1255
 msgid "Lundo"
 msgstr ""
 
-#: motioneye/templates/main.html:1227
+#: motioneye/templates/main.html:1258
 msgid "de"
 msgstr ""
 
-#: motioneye/templates/main.html:1228
+#: motioneye/templates/main.html:1259
 msgid "ĝis"
 msgstr ""
 
-#: motioneye/templates/main.html:1230
+#: motioneye/templates/main.html:1261
 msgid "Fiksas la labortagan tempintervalon por lundoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1233
+#: motioneye/templates/main.html:1264
 msgid "Mardo"
 msgstr ""
 
-#: motioneye/templates/main.html:1239
+#: motioneye/templates/main.html:1270
 msgid "Fiksas la labortagan tempintervalon por mardoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1242
+#: motioneye/templates/main.html:1273
 msgid "Merkredo"
 msgstr ""
 
-#: motioneye/templates/main.html:1248
+#: motioneye/templates/main.html:1279
 msgid "Fiksas la labortagan tempintervalon por merkredoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1251
+#: motioneye/templates/main.html:1282
 msgid "Ĵaŭdo"
 msgstr ""
 
-#: motioneye/templates/main.html:1257
+#: motioneye/templates/main.html:1288
 msgid "Fiksas la labortagan tempintervalon por ĵaŭdoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1260
+#: motioneye/templates/main.html:1291
 msgid "Vendredo"
 msgstr ""
 
-#: motioneye/templates/main.html:1266
+#: motioneye/templates/main.html:1297
 msgid "Fiksas la labortagan tempintervalon por vendredoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1269
+#: motioneye/templates/main.html:1300
 msgid "Sabato"
 msgstr ""
 
-#: motioneye/templates/main.html:1275
+#: motioneye/templates/main.html:1306
 msgid "Fiksas la labortagan tempintervalon por sabatoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1278
+#: motioneye/templates/main.html:1309
 msgid "Dimanĉo"
 msgstr ""
 
-#: motioneye/templates/main.html:1284
+#: motioneye/templates/main.html:1315
 msgid "Fiksas la labortagan tempintervalon por dimanĉoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1287
+#: motioneye/templates/main.html:1318
 msgid "Detekti movadon"
 msgstr ""
 
-#: motioneye/templates/main.html:1290
+#: motioneye/templates/main.html:1321
 msgid "Dum laborista horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1291
+#: motioneye/templates/main.html:1322
 msgid "Ekster laborista horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1294
+#: motioneye/templates/main.html:1325
 msgid ""
 "Difinas, ĉu moviĝodetekto devas esti aktiva dum aŭ ekster la laborista "
 "horaro."
@@ -1747,3 +1779,4 @@ msgstr ""
 #: motioneye/utils/dtconv.py:153
 msgid "minus"
 msgstr ""
+


### PR DESCRIPTION
## Summary
- regenerate Python translation template and merge into motioneye.pot
- bump project and template version to 0.43.1b8

## Testing
- `pytest` *(fails: fixture 'data' not found in tests/test_utils/test_mjpeg.py::test_mjpeg_url and tests/test_utils/test_rtmp.py::test_rtmp_url)*

------
https://chatgpt.com/codex/tasks/task_e_68adef421bf0832c96f6974ca3f9159f