### PR TITLE
Add translation compilation script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-<!-- version: 2025-08-26.3 -->
+<!-- version: 2025-08-26.4 -->
 
 2025-08-26
 - Added FFMPEG audio codec mapping and optional audio stream inclusion during conversions.
@@ -11,6 +11,7 @@
 - Synchronized all locale PO files with the latest template and incremented `Project-Id-Version`.
 - Filled audio msgstr entries for all locales and updated revision dates; bumped Project-Id-Version to 0.43.1b9.
 - Restored original .mo translation binaries to avoid binary diffs.
+- Added make_mo.sh script to compile translation files with install/remove options.
 
 2025-08-25
 - Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).

--- a/l10n/make_mo.sh
+++ b/l10n/make_mo.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# version: 2025-08-26
+# date: 2025-08-26
+VERSION="2025-08-26"
+
+set -e
+
+usage() {
+    cat <<USAGE
+Usage: $0 [--install [path]] [--remove [path]] [-h|--help]
+Without options, compiles .po files in motioneye/locale/*/LC_MESSAGES/ to .mo files.
+  --install [path]  Copy this script to /usr/local/bin/make_mo or provided path.
+  --remove  [path]  Remove script from /usr/local/bin/make_mo or provided path.
+  -h, --help        Show this help message.
+USAGE
+}
+
+install_path="/usr/local/bin/make_mo"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install)
+            target="$install_path"
+            if [[ -n "$2" && "$2" != -* ]]; then
+                target="$2"
+                shift
+            fi
+            cp "$0" "$target"
+            chmod +x "$target"
+            echo "Installed to $target"
+            exit 0
+            ;;
+        --remove)
+            target="$install_path"
+            if [[ -n "$2" && "$2" != -* ]]; then
+                target="$2"
+                shift
+            fi
+            rm -f "$target"
+            echo "Removed $target"
+            exit 0
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+for dir in motioneye/locale/*/LC_MESSAGES; do
+    [ -d "$dir" ] || continue
+    for po in "$dir"/motioneye.po "$dir"/motioneye.js.po; do
+        [ -f "$po" ] || continue
+        mo="${po%.po}.mo"
+        msgfmt "$po" -o "$mo"
+    done
+done

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-<!-- version: 2025-08-26 -->
+<!-- version: 2025-08-26.1 -->
 
 # User Manual
 
@@ -21,3 +21,24 @@ Use `list_audio_devices()` to enumerate capture hardware. Templates can check
 During video conversion, motionEye now maps existing audio streams with `-map 0:a` and
 encodes them using a codec from `FFMPEG_AUDIO_CODEC_MAPPING`. Output files automatically
 use the correct extension (e.g., `.mp4`) when video and audio are present.
+
+## Translation Compilation
+The `l10n/make_mo.sh` script builds binary `.mo` files from each `motioneye.po` or `motioneye.js.po` found under `motioneye/locale/*/LC_MESSAGES/`.
+
+Run the script without arguments to compile every locale:
+
+```
+l10n/make_mo.sh
+```
+
+Install the script system-wide:
+
+```
+l10n/make_mo.sh --install [/path/to/make_mo]
+```
+
+Remove an installed copy:
+
+```
+l10n/make_mo.sh --remove [/path/to/make_mo]
+```


### PR DESCRIPTION
## Summary
- add l10n/make_mo.sh to compile translation files with optional install/remove
- document translation compilation script usage
- record script creation in changelog

## Testing
- `pre-commit run --files l10n/make_mo.sh changelog.md user_manual.md` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae22a4d93c832cb0d362ac1a018642