### PR TITLE
Add audio dependencies and document ALSA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- version: 2025-08-26.1 -->
 # What is motionEye?
 
 **motionEye** is an online interface for the software [_motion_](https://motion-project.github.io/), a video surveillance program with motion detection.
@@ -23,11 +24,19 @@ You can contribute to translations on [__Weblate__](https://hosted.weblate.org/p
     sudo apt --no-install-recommends install ca-certificates curl python3
     ```
 
+    For audio capture support, install ALSA utilities and ffmpeg:
+
+    ```sh
+    sudo apt --no-install-recommends install alsa-utils ffmpeg
+    ```
+
     On **ARMv6 and ARMv7 (32-bit), RISC-V and other rare CPU architectures** additional build dependencies may be required to compile the [Pillow](https://pypi.org/project/pillow/) and [PycURL](https://pypi.org/project/pycurl/) modules:
     ```sh
     sudo apt update
     sudo apt --no-install-recommends install ca-certificates curl python3 python3-dev gcc libjpeg62-turbo-dev libcurl4-openssl-dev libssl-dev
     ```
+
+The Python package pulls in **PyAudio** and **ffmpeg-python** modules to handle audio.
 
 2. Install the Python package manager `pip`
     ```sh

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-<!-- version: 2025-08-26.7 -->
+<!-- version: 2025-08-26.8 -->
 
 2025-08-26
 - Added FFMPEG audio codec mapping and optional audio stream inclusion during conversions.
@@ -18,6 +18,8 @@
 - Updated PO headers with `Project-Id-Version: motionEye 0.43.1b9` and current revision dates.
 - Recompiled JavaScript translation JSON files including new audio messages.
 - Documented translation update workflow in the user manual.
+- Added PyAudio and ffmpeg-python dependencies and documented audio prerequisites.
+- Docker image installs `alsa-utils` and `ffmpeg` and lists ALSA devices at startup.
 
 2025-08-25
 - Added audio configuration support (sound_device, sound_enabled, ffmpeg_audio_codec, ffmpeg_audio_bitrate).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# version: 2025-08-26.1
 FROM debian:trixie-slim
 LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
@@ -17,7 +18,7 @@ RUN printf '%b' '[global]\nbreak-system-packages=true\n' > /etc/pip.conf && \
     esac && \
     apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -qq --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-      ca-certificates curl python3 fdisk $PACKAGES && \
+      ca-certificates curl python3 fdisk alsa-utils ffmpeg $PACKAGES && \
     curl -sSfO 'https://bootstrap.pypa.io/get-pip.py' && \
     python3 get-pip.py && \
     python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
+# version: 2025-08-26.1
+# Map host /dev/snd to access ALSA audio devices.
+if command -v arecord >/dev/null 2>&1; then
+    echo "Available ALSA capture devices:"
+    arecord -l || true
+fi
 # We need to chown at startup time since volumes are mounted as root. This is fugly.
 mkdir -p /run/motioneye
 chown motion:motion /run/motioneye

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-# version: 2025-08-26.1
+# version: 2025-08-26.2
 name = motioneye
 version = 0.43.1b9
 author = Calin Crisan, Jean Michault, ...
@@ -23,12 +23,14 @@ packages = motioneye
 include_package_data = False
 python_requires = >=3.7
 install_requires =
-	tornado
-	jinja2
-	pillow
-	pycurl
-	babel
-	boto3
+        tornado
+        jinja2
+        pillow
+        pycurl
+        babel
+        boto3
+        pyaudio
+        ffmpeg-python
 
 [options.package_data]
 motioneye = extra/*, static/*.*, static/*/*, templates/*, scripts/*, controls/*, handlers/*, utils/*, locale/*/LC_MESSAGES/*.mo

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,6 +1,9 @@
-<!-- version: 2025-08-26.2 -->
+<!-- version: 2025-08-26.3 -->
 
 # User Manual
+
+## Audio Prerequisites
+motionEye relies on **PyAudio** and **ffmpeg-python** for sound features. Install `alsa-utils` and `ffmpeg` on the host and expose `/dev/snd` to containers to access audio hardware.
 
 ## Audio Configuration
 motionEye supports audio options per camera:


### PR DESCRIPTION
## Summary
- add PyAudio and ffmpeg-python to install requirements
- include ALSA utilities and ffmpeg in Docker image and list ALSA devices on startup
- document new audio prerequisites in README and user manual

## Testing
- `pip install -e .` *(failed: Could not fetch setuptools: 403 Forbidden)*
- `pytest` *(failed: fixture 'data' not found; 14 passed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae455aaeec832c8d58193c4e16d926