### PR TITLE
Add JSON export option to translation script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
-<!-- version: 2025-08-27.1 -->
+<!-- version: 2025-08-27.2 -->
 
 2025-08-27
 - Removed compiled translation binaries from package data; `.po` files ship for on-install compilation.
 - `l10n/make_mo.sh --install` now invokes `msgfmt` to build `.mo` files during installation.
+- Added early checks for `msgfmt` and `po2json` in `l10n/make_mo.sh` with a new `--json` option to generate JSON files.
 
 2025-08-26
 - Added FFMPEG audio codec mapping and optional audio stream inclusion during conversions.

--- a/l10n/make_mo.sh
+++ b/l10n/make_mo.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
-# version: 2025-08-27.1
+# version: 2025-08-27.2
 # date: 2025-08-27
-VERSION="2025-08-27"
+VERSION="2025-08-27.2"
 
 set -e
 
 usage() {
     cat <<USAGE
-Usage: $0 [--install [path]] [--remove [path]] [-h|--help]
+Usage: $0 [--install [path]] [--remove [path]] [--json] [-h|--help]
 Without options, compiles .po files in motioneye/locale/*/LC_MESSAGES/ to .mo files.
   --install [path]  Copy this script to /usr/local/bin/make_mo or provided path.
   --remove  [path]  Remove script from /usr/local/bin/make_mo or provided path.
+  --json            Also generate .json files using po2json.
   -h, --help        Show this help message.
 USAGE
 }
 
 install_path="/usr/local/bin/make_mo"
+run_json=0
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -41,6 +44,9 @@ while [[ $# -gt 0 ]]; do
             echo "Removed $target"
             exit 0
             ;;
+        --json)
+            run_json=1
+            ;;
         -h|--help)
             usage
             exit 0
@@ -54,11 +60,31 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+if ! command -v msgfmt >/dev/null 2>&1; then
+    echo "Error: msgfmt command not found. Please install gettext." >&2
+    exit 1
+fi
+
+if (( run_json )); then
+    if command -v po2json >/dev/null 2>&1; then
+        PO2JSON="$(command -v po2json)"
+    elif [[ -x "$script_dir/po2json" ]]; then
+        PO2JSON="$script_dir/po2json"
+    else
+        echo "Error: po2json command not found." >&2
+        exit 1
+    fi
+fi
+
 for dir in motioneye/locale/*/LC_MESSAGES; do
     [ -d "$dir" ] || continue
     for po in "$dir"/motioneye.po "$dir"/motioneye.js.po; do
         [ -f "$po" ] || continue
         mo="${po%.po}.mo"
         msgfmt "$po" -o "$mo"
+        if (( run_json )); then
+            json="${po%.po}.json"
+            "$PO2JSON" "$po" "$json"
+        fi
     done
 done

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-<!-- version: 2025-08-27.1 -->
+<!-- version: 2025-08-27.2 -->
 
 # User Manual
 
@@ -27,6 +27,7 @@ use the correct extension (e.g., `.mp4`) when video and audio are present.
 
 ## Translation Compilation
 The `l10n/make_mo.sh` script builds binary `.mo` files from each `motioneye.po` or `motioneye.js.po` found under `motioneye/locale/*/LC_MESSAGES/`.
+It requires `msgfmt` and optionally `po2json` when generating JSON files. The script exits early with a clear message if a required tool is missing.
 
 Run the script without arguments to compile every locale:
 
@@ -44,6 +45,12 @@ Remove an installed copy:
 
 ```
 l10n/make_mo.sh --remove [/path/to/make_mo]
+```
+
+Generate JSON translations alongside `.mo` files:
+
+```
+l10n/make_mo.sh --json
 ```
 
 ## JavaScript Translation Update


### PR DESCRIPTION
## Summary
- check for `msgfmt` and `po2json` at startup in `make_mo.sh`
- add `--json` option to generate translation JSON files
- document the new option in user manual and changelog

## Testing
- `pre-commit run --files l10n/make_mo.sh user_manual.md changelog.md` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5124350c832c9708b9a111e82407